### PR TITLE
remove manual gsap install from workflow

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 10
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -160,14 +160,6 @@ jobs:
         with:
           version: 8
 
-      - name: Login GSAP
-        shell: bash
-        run: |
-          pnpm config set //npm.greensock.com/:_authToken ${{ secrets.GSAP_TOKEN }}
-          pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-          cd ./apps/web
-          pnpm install gsap@npm:@gsap/business
-
       - name: Install node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
* Tries to fix the moose cli deployment (missing executable) by removing the gsap manual install from the release workflow

```
Run ./apps/moose-cli-npm/scripts/release-cli.sh 0.3.45
v0.3.45
Progress: resolved 1, reused 0, downloaded 0, added 0
.                                        |  WARN  Package name mismatch found while reading {"integrity":"sha512-pra7mFBNFK8YkfBr2KFIjK3xGr38K8SIfzH+Dvf0j+dAO70dqZX1s8xEqzK3Y4mlfB21Sa[6](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:7)i5o[7](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:8)bnC5rZSfarg==","tarball":"https://npm.greensock.com/@gsap/business/-/business-3.12.4.tgz"} from the store. This means that the lockfile is broken. Expected package: gsap@3.12.4. Actual package in the store by the given integrity: @gsap/business@3.12.4.
 ERR_PNPM_ERR_PNPM_UNEXPECTED_PKG_CONTENT_IN_STORE  The lockfile is broken! A full installation will be performed in an attempt to fix it.
Progress: resolved [8](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:9)4, reused 50, downloaded 3, added 0
Progress: resolved 104, reused 50, downloaded 11, added 0
Progress: resolved 1[9](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:10)6, reused 119, downloaded 24, added 0
Progress: resolved 326, reused 228, downloaded 29, added 0
Progress: resolved 543, reused 416, downloaded 49, added 0
Progress: resolved 800, reused 633, downloaded 69, added 0
Progress: resolved [10](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:11)90, reused 906, downloaded 85, added 0
 WARN  2 deprecated subdependencies found: abab@2.0.6, domexception@4.0.0
.                                        | +108 -183 ++++++++++-----------------
/home/runner/work/moose/moose/apps/web:
 ERR_PNPM_UNEXPECTED_PKG_CONTENT_IN_STORE  Package name mismatch found while reading {"integrity":"sha5[12](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:13)-pra7mFBNFK8YkfBr2KFIjK3xGr38K8SIfzH+Dvf0j+dAO70dqZX1s8xEqzK3Y4mlfB21Sa6i5o7bnC5rZSfarg==","tarball":"https://npm.greensock.com/@gsap%2fbusiness/-/business-3.12.4.tgz"} from the store. This means that the lockfile is broken. Expected package: gsap@3.12.4. Actual package in the store by the given integrity: @gsap/business@3.12.4.
```

```
sh: 1: turbo: not found
 ELIFECYCLE  Command failed.
npm notice 
npm notice 📦  @514labs/moose-cli@0.3.45
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 3.2kB README.md   
npm notice 748B  package.json
npm notice === Tarball Details === 
npm notice name:          @514labs/moose-cli                      
npm notice version:       0.3.45                                  
npm notice filename:      514labs-moose-cli-0.3.45.tgz            
npm notice package size:  2.2 kB                                  
npm notice unpacked size: 5.0 kB                                  
npm notice shasum:        15fc34c2f0e59bfd8f29a642d68c2bb3e4[28](https://github.com/514-labs/moose/actions/runs/7434887029/job/20229698113#step:9:29)c748
npm notice integrity:     sha512-EdIxiuwNOZS8X[...]kI/3vCKZdTshQ==
npm notice total files:   3                                       
npm notice 
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
```

