### PR TITLE
Callicles/514 255 in dev mode hook up the console with route data from the cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ Cargo.lock
 *.pdb
 
 .igloo/
+
+console.db

--- a/apps/moose-console/package.json
+++ b/apps/moose-console/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.0",
     "cmdk": "^0.2.0",
     "gsap": "file:gsap-bonus.tgz",
+    "lowdb": "^7.0.1",
     "lucide-react": "^0.312.0",
     "next": "^14.0.4",
     "next-themes": "^0.2.1",

--- a/apps/moose-console/src/app/api/console/route.ts
+++ b/apps/moose-console/src/app/api/console/route.ts
@@ -1,0 +1,8 @@
+import * as PouchDB from "pouchdb-node";
+import { putCliData } from "../../db";
+
+export async function POST(request: Request) {
+  const json = await request.json();
+  await putCliData(json);
+  return new Response("OK");
+}

--- a/apps/moose-console/src/app/api/console/route.ts
+++ b/apps/moose-console/src/app/api/console/route.ts
@@ -1,4 +1,3 @@
-import * as PouchDB from "pouchdb-node";
 import { putCliData } from "../../db";
 
 export async function POST(request: Request) {

--- a/apps/moose-console/src/app/db.ts
+++ b/apps/moose-console/src/app/db.ts
@@ -1,0 +1,56 @@
+import { JSONFilePreset } from "lowdb/node";
+
+// We added a DB here because we don't know how next will handle
+// the request. We have found a hack where we could use modules to
+// have a singleton and handle shared state but we are not guaranteed
+// that it would work: https://stackoverflow.com/questions/13179109/singleton-pattern-in-nodejs-is-it-needed
+// In terms of Local db implementation, we looked at: Level, PouchDB, sqlite3, lowdb
+
+const DB_FILE = "./console.db";
+const CLI_DATA_ID = "cliData";
+
+const defaultData: {
+  [CLI_DATA_ID]: CliData;
+} = {
+  [CLI_DATA_ID]: {
+    routes: [],
+    tables: [],
+    topics: [],
+  },
+};
+
+const dbPromise = JSONFilePreset(DB_FILE, defaultData);
+
+export interface Route {
+  file_path: string;
+  route_path: string;
+  table_name: string;
+  view_name: string;
+}
+
+export interface Table {
+  database: string;
+  dependencies_table: string[];
+  engine: string;
+  name: string;
+  uuid: string;
+}
+
+export interface CliData {
+  routes: Route[];
+  tables: Table[];
+  topics: string[];
+}
+
+export async function putCliData(data: CliData): Promise<void> {
+  const db = await dbPromise;
+  return await db.update((dbData) => {
+    dbData[CLI_DATA_ID] = data;
+  });
+}
+
+export async function getCliData(): Promise<CliData> {
+  const db = await dbPromise;
+  await db.read();
+  return db.data[CLI_DATA_ID];
+}

--- a/apps/moose-console/src/app/layout.tsx
+++ b/apps/moose-console/src/app/layout.tsx
@@ -1,14 +1,13 @@
-import "styles/globals.css"
-import { ThemeProvider } from "components/theme-provider"
-import { cn } from "lib/utils"
-
+import "styles/globals.css";
+import { ThemeProvider } from "../components/theme-provider";
+import { cn } from "../lib/utils";
 
 import localFont from "next/font/local";
 
 import { Analytics } from "@vercel/analytics/react";
 import { ReactNode } from "react";
-import { ThemeToggle } from "components/ui/theme-toggle";
-import { LeftNav } from "components/left-nav";
+import { ThemeToggle } from "../components/ui/theme-toggle";
+import { LeftNav } from "../components/left-nav";
 
 // Font files can be colocated inside of `app`
 const monoFont = localFont({
@@ -29,10 +28,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }): ReactNode {
   return (
-    <html lang="en" suppressHydrationWarning className={cn(sansFont.variable, monoFont.variable)}>
-      <body className={cn(
-        "min-h-screen font-sans antialiased"
-      )}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={cn(sansFont.variable, monoFont.variable)}
+    >
+      <body className={cn("min-h-screen font-sans antialiased")}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"
@@ -42,17 +43,16 @@ export default function RootLayout({
           <header className="flex text-lg px-3">
             <span className="py-4">moosejs</span>
             <span className="flex-grow" />
-            <span className="py-3"><ThemeToggle /></span>
+            <span className="py-3">
+              <ThemeToggle />
+            </span>
           </header>
           <div className="flex">
             <nav>
               <LeftNav />
             </nav>
-            <section>
-              {children}
-            </section>
+            <section>{children}</section>
           </div>
-
         </ThemeProvider>
         <Analytics />
       </body>

--- a/apps/moose-console/src/app/page.tsx
+++ b/apps/moose-console/src/app/page.tsx
@@ -1,4 +1,7 @@
 import Metadata from "next";
+import { gsap } from "gsap";
+import { unstable_noStore as noStore } from "next/cache";
+import { getCliData, Route, Table } from "./db";
 
 export const metadata: Metadata = {
   title: "MooseJS | Build for the modern data stack",
@@ -6,27 +9,6 @@ export const metadata: Metadata = {
     images: "/open-graph/og_igloo_4x.webp",
   },
 };
-
-interface Route {
-  file_path: string;
-  route_path: string;
-  table_name: string;
-  view_name: string;
-}
-
-interface Table {
-  database: string;
-  dependencies_table: string[];
-  engine: string;
-  name: string;
-  uuid: string;
-}
-
-interface ConsoleResponse {
-  routes: Route[];
-  tables: Table[];
-  topics: string[];
-}
 
 interface RoutesListProps {
   routes: Route[];
@@ -38,21 +20,6 @@ interface TablesListProps {
 
 interface TopicsListProps {
   topics: string[];
-}
-
-async function getData(): Promise<ConsoleResponse> {
-  const res = await fetch("http://localhost:4000/console", {
-    cache: "no-store",
-  });
-  // The return value is *not* serialized
-  // You can return Date, Map, Set, etc.
-
-  if (!res.ok) {
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error("Failed to fetch data");
-  }
-
-  return res.json();
 }
 
 const RoutesList = ({ routes }: RoutesListProps) => (
@@ -87,7 +54,10 @@ const TopicsList = ({ topics }) => (
 );
 
 export default async function Home(): Promise<JSX.Element> {
-  const data = await getData();
+  // This is to make sure the environment variables are read at runtime
+  // and not during build time
+  noStore();
+  const data = await getCliData();
 
   return (
     <>

--- a/apps/moose-console/tsconfig.json
+++ b/apps/moose-console/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "tsconfig/nextjs.json",
   "compilerOptions": {
     "baseUrl": "src/",
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "allowSyntheticDefaultImports": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
     dependencies:
       '@514labs/igloo-cli':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -59,7 +59,7 @@ importers:
     dependencies:
       '@514labs/moose-cli':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -154,16 +154,16 @@ importers:
     optionalDependencies:
       '@514labs/igloo-cli-darwin-arm64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
       '@514labs/igloo-cli-darwin-x64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
       '@514labs/igloo-cli-linux-arm64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
       '@514labs/igloo-cli-linux-x64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -188,16 +188,16 @@ importers:
     optionalDependencies:
       '@514labs/moose-cli-darwin-arm64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
       '@514labs/moose-cli-darwin-x64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
       '@514labs/moose-cli-linux-arm64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
       '@514labs/moose-cli-linux-x64':
         specifier: latest
-        version: 0.3.53
+        version: 0.3.54
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -464,88 +464,88 @@ importers:
 
 packages:
 
-  /@514labs/igloo-cli-darwin-arm64@0.3.53:
-    resolution: {integrity: sha512-JMHyW0LzuG9oJoYXro83lBGjGyeSnGDXirKthK3hRDST51cdkacUqZJ33F9rupMbt7tFssLQOnsLvVUW2v1t9w==}
+  /@514labs/igloo-cli-darwin-arm64@0.3.54:
+    resolution: {integrity: sha512-l5E1RDIDol5FG7zMhfoXXpcrX6DNp/zDw8INdndmHoU4j+me9COgaO3nwJpjUH3LLWgCS8BWEIGoEKMM9C46LQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli-darwin-x64@0.3.53:
-    resolution: {integrity: sha512-HJp4GJjP+fSOQdzfreHnCLqN2F/6mjR9nrqI+RsKRZfMljXCfwJhpkFkGjEQt69S/45b8tYHoENipP9Kd8rp3w==}
+  /@514labs/igloo-cli-darwin-x64@0.3.54:
+    resolution: {integrity: sha512-0S14X54VG5cL2PM5IkHkLXlJC5jHKc6mceH9v8srzoAhb8lzwcTJpffBKTmy041UYb83lNZwCSeujhFBYjPI+Q==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli-linux-arm64@0.3.53:
-    resolution: {integrity: sha512-1FaFW3MQFatIo05Zb9LoyQ/PNQlagqrXHo8Ug7GH/UDvGNS3lkwmm9gp/MfK3UhdP2rSoa8pVRSCGVIKjLrOkA==}
+  /@514labs/igloo-cli-linux-arm64@0.3.54:
+    resolution: {integrity: sha512-Zh+II8hOf+Y4pnA91NOwRRqlKEosKqC8itRGETjOQGvuz/HfqkIW0AaWmtorUlb/ZZRMIwS+562twVlo2kmF9w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli-linux-x64@0.3.53:
-    resolution: {integrity: sha512-eVrhyYIbAgJkEdAeKDk3P1b6/zHoQqWwMb05b2pKip4/V8ZdA4usAXEhUvZvM7BA+qHl+BMwpFz0A0WXXncT9Q==}
+  /@514labs/igloo-cli-linux-x64@0.3.54:
+    resolution: {integrity: sha512-yZCTmYKrAUUNjFXxKAf0ofW5aeM7A13vmy4JW6PEiQqK4ztOTKYxOhq5Py9I3LWIFDMIwEfHuw37CbS5X75V5A==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli@0.3.53:
-    resolution: {integrity: sha512-8JlXnjoWr99WvYfRD9m+gc3Et2KH+755P8lU4ZPrkgFDNiBbRceNKL53hN+g3QbNIRwPOgl7ZtksHfWsA8MckA==}
+  /@514labs/igloo-cli@0.3.54:
+    resolution: {integrity: sha512-mKCDBm3hPp4qI/VFfvGBVPTVMRylMUdyH3uUi/mYwRK3bu7de7QfueD0eTqcjALET7Bx6MWEokIHCDSNNasmDQ==}
     hasBin: true
     optionalDependencies:
-      '@514labs/igloo-cli-darwin-arm64': 0.3.53
-      '@514labs/igloo-cli-darwin-x64': 0.3.53
-      '@514labs/igloo-cli-linux-arm64': 0.3.53
-      '@514labs/igloo-cli-linux-x64': 0.3.53
+      '@514labs/igloo-cli-darwin-arm64': 0.3.54
+      '@514labs/igloo-cli-darwin-x64': 0.3.54
+      '@514labs/igloo-cli-linux-arm64': 0.3.54
+      '@514labs/igloo-cli-linux-x64': 0.3.54
     dev: false
 
-  /@514labs/moose-cli-darwin-arm64@0.3.53:
-    resolution: {integrity: sha512-N6ST6ie4QJ6iirvS1j3QDGYIYJTBq8/gMB2Vcrxf+SBvzlba6j7BecB70NY8FLi01rO5mrYqDv6WRlk1NQFjOg==}
+  /@514labs/moose-cli-darwin-arm64@0.3.54:
+    resolution: {integrity: sha512-iyaUSOGOXqogJgC+PcNlENYSY2wFI59G+wC0mV79mlFTWnFND2JH7sIyeHahvR+fDG1CSD9gzap7k9e6rD8l1w==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/moose-cli-darwin-x64@0.3.53:
-    resolution: {integrity: sha512-KkJE+o5JNQB4rKOucUPssUzjlj3xQPWEAwvzpsMgCjOgHKjbZ5RfNfz1+nxxZKoFB+x/xYgaCqf25nQ5YE/xFA==}
+  /@514labs/moose-cli-darwin-x64@0.3.54:
+    resolution: {integrity: sha512-IDWWjddsG/k2GdChSoNTxZSJuaxJvIdhumffhSxBi/h5LHWHt9V/XAKDQsrD/E6X+N2cfL4p6Y/NqOvI/OwWDg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/moose-cli-linux-arm64@0.3.53:
-    resolution: {integrity: sha512-HMH+iRghw+w/Al9ivc+nRXq8X2fZ4M5XmTGrb6Ng10Q4Iz3bYDNMiIvm8l4b9kmj2Sitz8izkpBN0KbRf68bmQ==}
+  /@514labs/moose-cli-linux-arm64@0.3.54:
+    resolution: {integrity: sha512-MeCWx7j4Z5YahWee7ms1rZJiE3CSq0IeRXdHZtCs3qdO9MPruX0/eJrkIen1ngzgcc0RvbyPHpAJ6+XocxOWfQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/moose-cli-linux-x64@0.3.53:
-    resolution: {integrity: sha512-kKyXwCOBzFy8yRnnaQxJvui6vg6hrSD6njydJ16tOUjGsX54IHdn2MeWpK6s2oZnQjvBCN/2yReTmcXK4Wptqg==}
+  /@514labs/moose-cli-linux-x64@0.3.54:
+    resolution: {integrity: sha512-PZYTo4Pz8po6LSIuwRyC05yroSAAetvBAYhkjeIhrxGA8Rl+qIuMdvz9qEALSKDqEhv56XP86P8BBvkfcfLljw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/moose-cli@0.3.53:
-    resolution: {integrity: sha512-MNxdeJExqAlCg02B1KUQK9EP4jYWZ44+emTsxijK5e1aKEvfs75pdkPJXrdil7eCMBACktY3no9hOK4a4YLKYQ==}
+  /@514labs/moose-cli@0.3.54:
+    resolution: {integrity: sha512-a61+SJDhGuHahQPt4wH7iVsb/htK+cQdcOaF3UQBK2fG9ssA+p6G2hlOcvbJTC0JG2D2sUzaxbnyXC2QnULQuQ==}
     hasBin: true
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.3.53
-      '@514labs/moose-cli-darwin-x64': 0.3.53
-      '@514labs/moose-cli-linux-arm64': 0.3.53
-      '@514labs/moose-cli-linux-x64': 0.3.53
+      '@514labs/moose-cli-darwin-arm64': 0.3.54
+      '@514labs/moose-cli-darwin-x64': 0.3.54
+      '@514labs/moose-cli-linux-arm64': 0.3.54
+      '@514labs/moose-cli-linux-x64': 0.3.54
     dev: false
 
   /@aashutoshrathi/word-wrap@1.2.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       gsap:
         specifier: file:gsap-bonus.tgz
         version: file:apps/moose-console/gsap-bonus.tgz
+      lowdb:
+        specifier: ^7.0.1
+        version: 7.0.1
       lucide-react:
         specifier: ^0.312.0
         version: 0.312.0(react@18.2.0)
@@ -7103,6 +7106,13 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
+  /lowdb@7.0.1:
+    resolution: {integrity: sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==}
+    engines: {node: '>=18'}
+    dependencies:
+      steno: 4.0.2
+    dev: false
+
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
@@ -9230,6 +9240,11 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       type-fest: 0.7.1
+    dev: false
+
+  /steno@4.0.2:
+    resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
+    engines: {node: '>=18'}
     dev: false
 
   /stop-iteration-iterator@1.0.0:


### PR DESCRIPTION
* Adds a in process db to the console in order to be able to take in requests
* Enables reading data posted to `/api/console`

```
curl  -X POST \
  'http://localhost:3000/api/console' \
  --header 'Accept: */*' \
  --header 'User-Agent: Thunder Client (https://www.thunderclient.com)' \
  --header 'Content-Type: application/json' \
  --data-raw '{"routes":[{"file_path":"/Users/nicolasjoseph/code/514-labs/dummy-test/app/datamodels/simple.prisma","route_path":"ingest/User","table_name":"User","view_name":"User_view"}],"tables":[{"database":"local","dependencies_table":[],"engine":"Memory","name":".inner_id.944ec5b2-cb20-4158-9907-7808f6254a7f","uuid":"b20bb688-ec33-4c5b-a200-b777b70d8ca1"},{"database":"local","dependencies_table":["User_view"],"engine":"Kafka","name":"User","uuid":"e611b78e-e491-467d-a820-d584bcd4632c"},{"database":"local","dependencies_table":[],"engine":"MaterializedView","name":"User_view","uuid":"944ec5b2-cb20-4158-9907-7808f6254a7f"}],"topics":["__consumer_offsets","User"]}'
```

Next up, having the CLI post to this endpoint whenever something changes locally