### PR TITLE
use explicit data table instead of inner table in materialized view

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -222,7 +222,7 @@ impl RoutineController {
 }
 
 // Starts the file watcher and the webserver
-pub async fn start_development_mode(project: &Project) -> Result<(), Error> {
+pub async fn start_development_mode(project: &Project) -> anyhow::Result<()> {
     show_message!(
         MessageType::Success,
         Message {
@@ -231,11 +231,11 @@ pub async fn start_development_mode(project: &Project) -> Result<(), Error> {
         }
     );
 
-    // TODO: Explore using a RWLock instead of a Mutex to ensure concurrent reads without locks
     let mut route_table = HashMap::<PathBuf, RouteMeta>::new();
 
     info!("Initializing project state");
     initialize_project_state(project.schemas_dir(), project, &mut route_table).await?;
+
     let route_table: &'static RwLock<HashMap<PathBuf, RouteMeta>> =
         Box::leak(Box::new(RwLock::new(route_table)));
 
@@ -258,7 +258,7 @@ async fn initialize_project_state(
     schema_dir: PathBuf,
     project: &Project,
     route_table: &mut HashMap<PathBuf, RouteMeta>,
-) -> Result<(), Error> {
+) -> anyhow::Result<()> {
     let configured_client = olap::clickhouse::create_client(project.clickhouse_config.clone());
     let producer = redpanda::create_producer(project.redpanda_config.clone());
 
@@ -294,7 +294,7 @@ async fn process_schemas_in_dir(
     project: &Project,
     configured_client: &ConfiguredDBClient,
     route_table: &mut HashMap<PathBuf, RouteMeta>,
-) -> Result<(), Error> {
+) -> anyhow::Result<()> {
     if schema_dir.is_dir() {
         for entry in std::fs::read_dir(schema_dir)? {
             let entry = entry?;

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -25,7 +25,7 @@ async fn process_event(
     event: notify::Event,
     route_table: &RwLock<HashMap<PathBuf, RouteMeta>>,
     configured_client: &ConfiguredDBClient,
-) -> Result<(), Error> {
+) -> anyhow::Result<()> {
     let mut route_table = route_table.write().await;
 
     debug!(
@@ -93,7 +93,7 @@ async fn create_framework_objects_from_schema_file_path(
     schema_file_path: &Path,
     route_table: &mut HashMap<PathBuf, RouteMeta>,
     configured_client: &ConfiguredDBClient,
-) -> Result<(), Error> {
+) -> anyhow::Result<()> {
     //! Creates the route, topics and tables from a path to the schema file
 
     if let Some(ext) = schema_file_path.extension() {

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -1,7 +1,7 @@
+use std::fmt::{Display, Formatter};
 use std::{
     collections::HashMap,
     fmt,
-    io::Error,
     path::{Path, PathBuf},
 };
 
@@ -37,6 +37,14 @@ pub enum ParsingError {
 pub struct UnsupportedDataTypeError {
     pub type_name: String,
 }
+
+impl Display for UnsupportedDataTypeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "UnsupportedDataTypeError: {}", self.type_name)
+    }
+}
+
+impl std::error::Error for UnsupportedDataTypeError {}
 
 /// A function that maps an input type to an output type
 type MapperFunc<I, O> = fn(i: I) -> O;
@@ -307,7 +315,7 @@ pub async fn process_schema_file(
     project: &Project,
     configured_client: &ConfiguredDBClient,
     route_table: &mut HashMap<PathBuf, RouteMeta>,
-) -> Result<(), Error> {
+) -> anyhow::Result<()> {
     let framework_objects = get_framework_objects_from_schema_file(schema_file_path)?;
     let mut compilable_objects: Vec<TypescriptObjects> = Vec::new();
     process_objects(

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
@@ -154,8 +154,7 @@ impl CreateKafkaTriggerViewQuery {
         tt.add_template("create_materialized_view", CREATE_KAFKA_TRIGGER_TEMPLATE)
             .unwrap();
         let context = CreateKafkaTriggerContext::new(view);
-        let rendered = tt.render("create_materialized_view", &context).unwrap();
-        rendered
+        tt.render("create_materialized_view", &context).unwrap()
     }
 }
 

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use tinytemplate::TinyTemplate;
+use tinytemplate::{format_unescaped, TinyTemplate};
 
 use crate::{
     framework::schema::{FieldArity, UnsupportedDataTypeError},
@@ -8,10 +8,10 @@ use crate::{
     },
 };
 
-use super::ClickhouseView;
+use super::ClickhouseKafkaTrigger;
 
-// TODO: Add column comment capability to the schemna and template
-pub static CREATE_TABLE_TEMPLATE: &str = r#"
+// TODO: Add column comment capability to the schema and template
+static CREATE_TABLE_TEMPLATE: &str = r#"
 CREATE TABLE IF NOT EXISTS {db_name}.{table_name} 
 (
 {{for field in fields}}{field.field_name} {field.field_type} {field.field_arity},
@@ -20,22 +20,44 @@ CREATE TABLE IF NOT EXISTS {db_name}.{table_name}
 PRIMARY KEY ({primary_key_string})
 {{endif}}
 )
-ENGINE = Kafka('{kafka_host}:{kafka_port}', '{topic}', 'clickhouse-group', 'JSONEachRow');
+ENGINE = {engine};
+"#;
+
+static CREATE_KAFKA_TRIGGER_TEMPLATE: &str = r#"
+CREATE MATERIALIZED VIEW IF NOT EXISTS {db_name}.{view_name} TO {db_name}.{dest_table_name}
+AS
+SELECT * FROM {db_name}.{source_table_name}
+SETTINGS
+stream_like_engine_allow_direct_select = 1;
 "#;
 
 pub struct CreateTableQuery;
 
 impl CreateTableQuery {
-    pub fn build(
+    pub fn kafka(
         table: ClickhouseTable,
         kafka_host: String,
         kafka_port: u16,
         topic: String,
     ) -> Result<String, UnsupportedDataTypeError> {
+        CreateTableQuery::build(
+            table,
+            format!(
+                "Kafka('{}:{}', '{}', 'clickhouse-group', 'JSONEachRow')",
+                kafka_host, kafka_port, topic,
+            ),
+        )
+    }
+
+    pub fn build(
+        table: ClickhouseTable,
+        engine: String,
+    ) -> Result<String, UnsupportedDataTypeError> {
         let mut tt = TinyTemplate::new();
+        tt.set_default_formatter(&format_unescaped); // by default it formats HTML-escaped and messes up single quotes
         tt.add_template("create_table", CREATE_TABLE_TEMPLATE)
             .unwrap();
-        let context = CreateTableContext::new(table, kafka_host, kafka_port, topic)?;
+        let context = CreateTableContext::new(table, engine)?;
         let rendered = tt.render("create_table", &context).unwrap();
         Ok(rendered)
     }
@@ -47,17 +69,13 @@ struct CreateTableContext {
     table_name: String,
     fields: Vec<CreateTableFieldContext>,
     primary_key_string: Option<String>,
-    kafka_host: String,
-    kafka_port: u16,
-    topic: String,
+    engine: String,
 }
 
 impl CreateTableContext {
     fn new(
         table: ClickhouseTable,
-        kafka_host: String,
-        kafka_port: u16,
-        topic: String,
+        engine: String,
     ) -> Result<CreateTableContext, UnsupportedDataTypeError> {
         let primary_key = table
             .columns
@@ -79,9 +97,7 @@ impl CreateTableContext {
             } else {
                 None
             },
-            kafka_host,
-            kafka_port,
-            topic,
+            engine,
         })
     }
 }
@@ -130,41 +146,29 @@ impl DropTableContext {
     }
 }
 
-pub static CREATE_MATERIALIZED_VIEW_TEMPLATE: &str = r#"
-CREATE MATERIALIZED VIEW IF NOT EXISTS {db_name}.{view_name} 
-ENGINE = Memory
-AS
-SELECT * FROM {db_name}.{source_table_name}
-SETTINGS
-stream_like_engine_allow_direct_select = 1;
-"#;
+pub struct CreateKafkaTriggerViewQuery;
 
-pub struct CreateMaterializedViewQuery;
-
-impl CreateMaterializedViewQuery {
-    pub fn build(view: ClickhouseView) -> Result<String, UnsupportedDataTypeError> {
+impl CreateKafkaTriggerViewQuery {
+    pub fn build(view: ClickhouseKafkaTrigger) -> String {
         let mut tt = TinyTemplate::new();
-        tt.add_template(
-            "create_materialized_view",
-            CREATE_MATERIALIZED_VIEW_TEMPLATE,
-        )
-        .unwrap();
-        let context = CreateMaterializedViewContext::new(view)?;
+        tt.add_template("create_materialized_view", CREATE_KAFKA_TRIGGER_TEMPLATE)
+            .unwrap();
+        let context = CreateKafkaTriggerContext::new(view);
         let rendered = tt.render("create_materialized_view", &context).unwrap();
-        Ok(rendered)
+        rendered
     }
 }
 
-pub static DROP_MATERIALIZED_VIEW_TEMPLATE: &str = r#"
-DROP TABLE IF EXISTS {db_name}.{view_name};
+pub static DROP_VIEW_TEMPLATE: &str = r#"
+DROP VIEW IF EXISTS {db_name}.{view_name};
 "#;
 
 pub struct DropMaterializedViewQuery;
 
 impl DropMaterializedViewQuery {
-    pub fn build(table: ClickhouseView) -> Result<String, UnsupportedDataTypeError> {
+    pub fn build(table: ClickhouseKafkaTrigger) -> Result<String, UnsupportedDataTypeError> {
         let mut tt = TinyTemplate::new();
-        tt.add_template("drop_materialized_view", DROP_MATERIALIZED_VIEW_TEMPLATE)
+        tt.add_template("drop_materialized_view", DROP_VIEW_TEMPLATE)
             .unwrap();
         let context = DropMaterializedViewContext::new(table)?;
         let rendered = tt.render("drop_materialized_view", &context).unwrap();
@@ -179,7 +183,9 @@ struct DropMaterializedViewContext {
 }
 
 impl DropMaterializedViewContext {
-    fn new(view: ClickhouseView) -> Result<DropMaterializedViewContext, UnsupportedDataTypeError> {
+    fn new(
+        view: ClickhouseKafkaTrigger,
+    ) -> Result<DropMaterializedViewContext, UnsupportedDataTypeError> {
         Ok(DropMaterializedViewContext {
             db_name: view.db_name,
             view_name: format!("{}_view", view.name),
@@ -188,21 +194,21 @@ impl DropMaterializedViewContext {
 }
 
 #[derive(Serialize)]
-struct CreateMaterializedViewContext {
+struct CreateKafkaTriggerContext {
     db_name: String,
     view_name: String,
     source_table_name: String,
+    dest_table_name: String,
 }
 
-impl CreateMaterializedViewContext {
-    fn new(
-        view: ClickhouseView,
-    ) -> Result<CreateMaterializedViewContext, UnsupportedDataTypeError> {
-        Ok(CreateMaterializedViewContext {
+impl CreateKafkaTriggerContext {
+    fn new(view: ClickhouseKafkaTrigger) -> CreateKafkaTriggerContext {
+        CreateKafkaTriggerContext {
             db_name: view.db_name,
             view_name: view.name,
-            source_table_name: view.source_table.name,
-        })
+            source_table_name: view.source_table_name,
+            dest_table_name: view.dest_table_name,
+        }
     }
 }
 

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -175,8 +175,8 @@ impl Project {
         let config_file = PackageJsonFile {
             name: self.name.clone(),
             version: "0.0".to_string(),
-            // For local development of the CLI
-            // change `moose-cli` to `<REPO_PATH>/apps/moose-kit-cli/target/debug/moose-cli`
+            // For local development of the CLI,
+            // change `moose-cli` to `<REPO_PATH>/apps/framework-cli/target/debug/moose-cli`
             scripts: HashMap::from([("dev".to_string(), "moose-cli dev".to_string())]),
             dependencies: HashMap::new(),
             dev_dependencies: HashMap::from([(


### PR DESCRIPTION
in preparation for the version sync trigger that writes to the data table