### PR TITLE
Enable eslint:recommended, plugin:@typescript-eslint/recommended

### DIFF
--- a/apps/framework-docs/src/pages/api/sentry-example-api.js
+++ b/apps/framework-docs/src/pages/api/sentry-example-api.js
@@ -1,5 +1,5 @@
 // A faulty API route to test Sentry's error monitoring
-export default function handler(_req, res) {
+export default function handler(_req, _res) {
   throw new Error("Sentry Example API Route Error");
-  res.status(200).json({ name: "John Doe" });
+  // res.status(200).json({ name: "John Doe" });
 }

--- a/apps/moose-cli-npm/src/index.ts
+++ b/apps/moose-cli-npm/src/index.ts
@@ -27,6 +27,7 @@ function getExePath() {
 
   try {
     // Since the binary will be located inside `node_modules`, we can simply call `require.resolve`
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require.resolve(
       `@514labs/moose-cli-${os}-${arch}/bin/moose-cli${extension}`
     );

--- a/apps/moose-console/src/app/infrastructure/databases/[databaseName]/tables/[tableId]/error.tsx
+++ b/apps/moose-console/src/app/infrastructure/databases/[databaseName]/tables/[tableId]/error.tsx
@@ -4,10 +4,10 @@ import { ReactNode, useEffect } from "react";
 
 export default function Error({
   error,
-  reset,
+  _reset,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  _reset: () => void;
 }): ReactNode {
   useEffect(() => {
     // Log the error to an error reporting service

--- a/apps/moose-console/src/app/infrastructure/databases/[databaseName]/tables/[tableId]/page.tsx
+++ b/apps/moose-console/src/app/infrastructure/databases/[databaseName]/tables/[tableId]/page.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 
 import {  createClient } from "@clickhouse/client-web";
-import { Field } from "app/mock";
 import Link from "next/link";
 import { Table, getCliData } from "app/db";
 import { unstable_noStore as noStore } from "next/cache";
 import TableTabs from "./table-tabs";
 import { clickhouseJSSnippet, clickhousePythonSnippet, jsSnippet, pythonSnippet } from "lib/snippets";
-import { getModelFromTable, getRelatedInfra } from "lib/utils";
+import { getModelFromTable } from "lib/utils";
 
 
 function getClient() {
@@ -29,7 +28,7 @@ function getClient() {
 }
 
 
-async function describeTable(databaseName: string, tableName: string): Promise<any> {
+async function _describeTable(databaseName: string, tableName: string): Promise<any> {
   const client = getClient();
 
   const resultSet = await client.query({
@@ -40,12 +39,6 @@ async function describeTable(databaseName: string, tableName: string): Promise<a
   return resultSet.json();
 
 }
-
-interface FieldsListCardProps {
-  fields: Field[]
-}
-
-
 
 const isView = (table: Table) => table.engine === "MaterializedView";
 
@@ -61,9 +54,7 @@ export default async function Page({
   const data = await getCliData();
 
   const table = data.tables.find((table) => table.uuid === params.tableId);
-  const tableMeta = await describeTable(params.databaseName, table.name);
   const model = getModelFromTable(table, data);
-  const infra = getRelatedInfra(model, data, table)
 
   return (
     <section className="p-4 max-h-screen flex-grow overflow-y-auto flex flex-col">

--- a/apps/moose-console/src/app/infrastructure/databases/[databaseName]/tables/[tableId]/table-tabs.tsx
+++ b/apps/moose-console/src/app/infrastructure/databases/[databaseName]/tables/[tableId]/table-tabs.tsx
@@ -9,7 +9,6 @@ import { Button } from "components/ui/button"
 import { CardHeader, CardContent, Card, CardTitle, CardDescription } from "components/ui/card"
 import { Separator } from "components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "components/ui/tabs"
-import { jsSnippet, pythonSnippet, clickhouseJSSnippet, clickhousePythonSnippet } from "lib/snippets"
 import { cn, getModelFromTable, getRelatedInfra, tableIsView } from "lib/utils"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
@@ -46,7 +45,7 @@ export default function TableTabs({table, cliData, jsSnippet, pythonSnippet, cli
     const router = useRouter();
     const pathName = usePathname();
 
-    const [selectedTab, setSelectedTab] = useState<string>(tab ? tab : "overview")
+    const [_selectedTab, setSelectedTab] = useState<string>(tab ? tab : "overview")
     const model = getModelFromTable(table, cliData);
     const infra = getRelatedInfra(model, cliData, table)
     const associated_view = cliData.tables.find((view) => view.name === table.dependencies_table[0]);

--- a/apps/moose-console/src/app/infrastructure/databases/tables/columns.tsx
+++ b/apps/moose-console/src/app/infrastructure/databases/tables/columns.tsx
@@ -4,14 +4,6 @@ import { Button } from "components/ui/button";
 import { Table, View } from "../../mock";
 import { ColumnDef } from "@tanstack/react-table"
 import { ArrowUpDown, ChevronRight } from "lucide-react"
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-  } from "components/ui/dropdown-menu"
 import Link from "next/link";
 
 

--- a/apps/moose-console/src/app/infrastructure/ingestion-points/[ingestionPointId]/ingestion-point-tabs.tsx
+++ b/apps/moose-console/src/app/infrastructure/ingestion-points/[ingestionPointId]/ingestion-point-tabs.tsx
@@ -2,15 +2,13 @@
 
 import { CliData, Route, Table } from "app/db"
 import CodeCard from "components/code-card"
-import QueryInterface from "components/query-interface"
 import SnippetCard from "components/snippet-card"
 import { tabListStyle, tabTriggerStyle } from "components/style-utils"
 import { Button } from "components/ui/button"
 import { CardHeader, CardContent, Card, CardTitle, CardDescription } from "components/ui/card"
 import { Separator } from "components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "components/ui/tabs"
-import { jsSnippet, pythonSnippet, clickhouseJSSnippet, clickhousePythonSnippet } from "lib/snippets"
-import { cn, getModelFromRoute, getModelFromTable, getRelatedInfra, tableIsView } from "lib/utils"
+import { cn, getModelFromRoute, getRelatedInfra } from "lib/utils"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useState } from "react"
@@ -24,7 +22,7 @@ interface IngestionPointTabsProps {
     clickhousePythonSnippet: string;
 }
 
-function ClickhouseTableRestriction(view: Table) {
+function _ClickhouseTableRestriction(view: Table) {
   return (
     <div className="py-4">
       <div className="text-muted-foreground max-w-xl">

--- a/apps/moose-console/src/app/infrastructure/ingestion-points/[ingestionPointId]/page.tsx
+++ b/apps/moose-console/src/app/infrastructure/ingestion-points/[ingestionPointId]/page.tsx
@@ -1,7 +1,5 @@
 import { Route, getCliData } from "app/db";
-import { tabListStyle, tabTriggerStyle } from "components/style-utils";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "components/ui/tabs";
-import { cn, getModelFromRoute } from "lib/utils";
+import { getModelFromRoute } from "lib/utils";
 
 import { unstable_noStore as noStore } from "next/cache";
 import Link from "next/link";
@@ -18,9 +16,6 @@ async function getIngestionPoint(ingestionPointId: string): Promise<Route> {
   }
   
 }
-
-
-
 
 export default async function Page({
   params,

--- a/apps/moose-console/src/app/infrastructure/mock.ts
+++ b/apps/moose-console/src/app/infrastructure/mock.ts
@@ -193,7 +193,7 @@ const generateDatabase = (): Database => {
     const tables = Array.from({ length: 5 }, generateTable);
     // generate a view that references a table
     const views = tables.map(table => {
-        const { status, ...sharedFields } = table;
+        const { status: _, ...sharedFields } = table;
 
         return {
             parentTable: table.id,

--- a/apps/moose-console/src/app/infrastructure/views/columns.tsx
+++ b/apps/moose-console/src/app/infrastructure/views/columns.tsx
@@ -39,7 +39,7 @@ export const viewColumns: ColumnDef<View>[] = [
     {
         id: "actions",
         cell: ({ row }) => {
-          const view = row.original
+          const _view = row.original
      
           return (
             <Link href={""}>

--- a/apps/moose-console/src/app/mock.ts
+++ b/apps/moose-console/src/app/mock.ts
@@ -110,10 +110,10 @@ export interface Primitive {
     version: string;
     consolePath: string;
     count: number;
-};
+}
 
 // Generate a primitive for each primitive type
-const generatePrimitives = (): Primitive[] => {
+const _generatePrimitives = (): Primitive[] => {
     const primitiveTypes = Object.values(PrimitiveType);
 
     return primitiveTypes.map((primitiveType) => {
@@ -132,7 +132,7 @@ const generatePrimitives = (): Primitive[] => {
 export interface HomeMock {
     modelMock: ModelMock;
     infrastructure: InfrastuctureMock  
-};
+}
 
 export const homeMock: HomeMock = {
     modelMock: modelMock,

--- a/apps/moose-console/src/app/primitives/models/[modelName]/page.tsx
+++ b/apps/moose-console/src/app/primitives/models/[modelName]/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { Separator } from "components/ui/separator";
 import { cn, getRelatedInfra } from "lib/utils";
 import { tabListStyle, tabTriggerStyle } from "components/style-utils";
-import { CliData, DataModel, Route, Table, column_type_mapper, getCliData } from "app/db";
+import { CliData, DataModel, getCliData } from "app/db";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "components/ui/card";
 import { Button } from "components/ui/button";
 import CodeCard from "components/code-card";

--- a/apps/moose-console/src/components/left-nav.tsx
+++ b/apps/moose-console/src/components/left-nav.tsx
@@ -24,10 +24,6 @@ interface Section {
     links?: NavLinks[];
 }
 
-interface LeftNavProps {
-    sections: Section[];
-}
-
 
 // There are two sections, a "Primitives" section and a "Infrastructure" Section. 
 // 
@@ -129,7 +125,6 @@ export const Item = ({ name, href }: NavLinks) => {
 
 
 export const LeftNav = () => {
-    const pathname = usePathname()
 
     return (
         <div className="flex flex-col w-64 py-8">

--- a/apps/moose-console/src/components/preview-table.tsx
+++ b/apps/moose-console/src/components/preview-table.tsx
@@ -33,4 +33,4 @@ export function PreviewTable({ rows, caption }: TableProps) {
         </TableBody>
       </Table>
     );
-  };
+  }

--- a/apps/moose-console/src/components/primitive-card.tsx
+++ b/apps/moose-console/src/components/primitive-card.tsx
@@ -2,14 +2,11 @@ import { Primitive } from "app/mock"
 import {
     Card,
     CardContent,
-    CardDescription,
     CardFooter,
     CardHeader,
     CardTitle,
   } from "components/ui/card"
   
-import { cn } from "lib/utils"
-
 interface PrimitiveCardProps {
     primitive: Primitive
 }

--- a/apps/moose-console/src/components/query-interface.tsx
+++ b/apps/moose-console/src/components/query-interface.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { table } from "console"
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "./ui/resizable"
 import { Textarea } from "./ui/textarea"
 import { Table } from "app/db"
@@ -160,7 +159,7 @@ const insertSomeText = (insert: string, originalValue: string, ref: MutableRefOb
     const selectionStart = ref.current.selectionStart;
     const selectionEnd = ref.current.selectionEnd;
  
-    let newValue =
+    const newValue =
       originalValue.substring(0, selectionStart) +
       insert +
       originalValue.substring(selectionEnd, originalValue.length);
@@ -240,7 +239,7 @@ export default function QueryInterface({ table, related }: QueryInterfaceProps) 
                                         </div>
                                         <div className="flex flex-row space-x-1 py-2 flex-wrap">
                                             {tables.slice(0, tableCount).map((word, index) => (
-                                                <Badge onClick={(e:any) => {
+                                                <Badge onClick={(_e:any) => {
                                                     insertSomeText(word, value, textareaRef, setValue)
                                                 }} className="text-nowrap my-1" variant="outline" key={index}>{word}</Badge>
                                             ))}
@@ -255,7 +254,7 @@ export default function QueryInterface({ table, related }: QueryInterfaceProps) 
                                         </div>
                                         <div className="flex flex-row space-x-1 py-2 flex-wrap">
                                             {sqlKeyWords.slice(0, sqlKeyWordCount).map((word, index) => (
-                                                <Badge onClick={(e: any ) => {
+                                                <Badge onClick={(_e: any ) => {
                                                     insertSomeText(word, value, textareaRef, setValue)
                                                 }} className="text-nowrap my-1" variant="outline" key={index}>{word}</Badge>
                                             ))}

--- a/apps/moose-console/src/components/queues-list-card.tsx
+++ b/apps/moose-console/src/components/queues-list-card.tsx
@@ -1,10 +1,7 @@
 import { Queue } from "app/infrastructure/mock"
 import { Card, CardContent } from "./ui/card"
 import { Badge, badgeVariants } from "./ui/badge"
-import { Button, buttonVariants } from "./ui/button"
 import { Separator } from "./ui/separator"
-import Link from "next/link"
-import { ChevronRight } from "lucide-react"
 import { ChevronRightButton } from "./chevron-right-button"
 
 interface QueuesListCardProps {

--- a/apps/moose-console/src/components/queues-overview-card.tsx
+++ b/apps/moose-console/src/components/queues-overview-card.tsx
@@ -3,7 +3,6 @@ import { Queue } from "app/infrastructure/mock"
 import {
     Card,
     CardContent,
-    CardDescription,
     CardFooter,
     CardHeader,
     CardTitle,

--- a/apps/moose-console/src/components/top-nav-menu.tsx
+++ b/apps/moose-console/src/components/top-nav-menu.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from "react"
-import Link from "next/link"
 
 import { cn } from "lib/utils"
 import {
@@ -11,7 +10,6 @@ import {
   NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
-  NavigationMenuViewport,
   navigationMenuTriggerStyle,
 } from "components/ui/navigation-menu"
 

--- a/apps/moose-console/src/components/ui/resizable.tsx
+++ b/apps/moose-console/src/components/ui/resizable.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { GripVertical } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "lib/utils"

--- a/apps/moose-console/src/lib/snippets.ts
+++ b/apps/moose-console/src/lib/snippets.ts
@@ -1,4 +1,4 @@
-import { CliData, DataModel, Route, Table, column_type_mapper } from "app/db";
+import { CliData, DataModel, column_type_mapper } from "app/db";
 import { getIngestionPointFromModel } from "./utils";
 
 export const jsSnippet = (data: CliData, model: DataModel) => {

--- a/apps/web/src/app/HeroTextMainComponent.tsx
+++ b/apps/web/src/app/HeroTextMainComponent.tsx
@@ -10,7 +10,7 @@ export const HeroTextMainComponent = () => {
   const titleRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
       const splitText = new SplitText(titleRef.current, { type: "words, chars" });

--- a/apps/web/src/app/HeroTextSubComponent.tsx
+++ b/apps/web/src/app/HeroTextSubComponent.tsx
@@ -10,7 +10,7 @@ export const HeroTextSubComponent = () => {
   const titleRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
       const splitText = new SplitText(titleRef.current, { type: "words, chars" });

--- a/apps/web/src/app/components/AnimateImage.tsx
+++ b/apps/web/src/app/components/AnimateImage.tsx
@@ -14,7 +14,7 @@ export const AnimateImage = ({src, alt, priority}: AnimateImageProps) => {
   const imageRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
       
       gsap.from(imageRef.current,{
         scrollTrigger: {

--- a/apps/web/src/app/components/AnimatedComponent.tsx
+++ b/apps/web/src/app/components/AnimatedComponent.tsx
@@ -39,7 +39,7 @@ export const AnimatedComponent = ({children, onScroll, triggerRef, className, po
     const computedTriggerRef = triggerRef || wrapperRef;
 
     useLayoutEffect(() => {
-        let ctx = gsap.context(() => {
+        const ctx = gsap.context(() => {
 
             const tl = onScroll ? gsap.timeline({
                 scrollTrigger: {

--- a/apps/web/src/app/components/AnimatedDescription.tsx
+++ b/apps/web/src/app/components/AnimatedDescription.tsx
@@ -31,7 +31,7 @@ export const AnimatedDescription = ({content, onScroll, triggerRef, className, p
 
     const descriptionRef = React.useRef(null);
     const computedTriggerRef = triggerRef || descriptionRef;
-    var computedPosition = position || 0;
+    let _computedPosition = position || 0;
 
     useLayoutEffect(() => {
         const splitText = new SplitText(descriptionRef.current, { type: "lines, words" });
@@ -43,7 +43,7 @@ export const AnimatedDescription = ({content, onScroll, triggerRef, className, p
 
         window.addEventListener("resize", resetSplitText);
 
-        let ctx = gsap.context(() => {
+        const ctx = gsap.context(() => {
 
             const tl = onScroll ? gsap.timeline({
                 scrollTrigger: {
@@ -51,7 +51,7 @@ export const AnimatedDescription = ({content, onScroll, triggerRef, className, p
                     onEnter: (self) => {
                         gsap.set(descriptionRef.current, { visibility: "visible" });
                         if (self.getVelocity() > 0) {
-                            computedPosition = 0;
+                            _computedPosition = 0;
                         }
                     }
                 },

--- a/apps/web/src/app/components/AnimatedHeading.tsx
+++ b/apps/web/src/app/components/AnimatedHeading.tsx
@@ -50,10 +50,10 @@ export const AnimatedHeading = ({content, size, onScroll, triggerRef, className,
 
     const headingRef = React.useRef(null);
     const computedTriggerRef = triggerRef || headingRef;
-    var computedPosition = position || 0;
+    let computedPosition = position || 0;
 
     useLayoutEffect(() => {
-        let ctx = gsap.context(() => {
+        const ctx = gsap.context(() => {
             const tl = onScroll ? gsap.timeline({
                 scrollTrigger: {
                     trigger: computedTriggerRef.current,

--- a/apps/web/src/app/components/AnimatedImage.tsx
+++ b/apps/web/src/app/components/AnimatedImage.tsx
@@ -41,22 +41,21 @@ export const AnimatedImage = ({
   delay,
   position,
   quality, // Include the quality prop
-  sizes, // Include the sizes prop
   coverPlacement,
 }: AnimateImageProps) => {
   const imageRef = React.useRef(null);
   const computedTriggerRef = triggerRef || imageRef;
-  var computedPosition = position || 0;
+  let _computedPosition = position || 0;
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
       const tl = onScroll ? gsap.timeline({
         scrollTrigger: {
           trigger: computedTriggerRef.current,
           onEnter: (self) => {
             gsap.set(imageRef.current, { visibility: "visible" });
             if (self.getVelocity() > 0) {
-              computedPosition = 0;
+              _computedPosition = 0;
             }
           },
         },

--- a/apps/web/src/app/components/CTAButton.tsx
+++ b/apps/web/src/app/components/CTAButton.tsx
@@ -7,7 +7,7 @@ export const CTAButton = () => {
   const buttonRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
 

--- a/apps/web/src/app/components/CTAComponent.tsx
+++ b/apps/web/src/app/components/CTAComponent.tsx
@@ -7,7 +7,7 @@ export const CTAComponent = () => {
   const buttonRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
 

--- a/apps/web/src/app/components/CodeBlockCTA.tsx
+++ b/apps/web/src/app/components/CodeBlockCTA.tsx
@@ -3,7 +3,6 @@ import { Button } from "ui";
 import { gsap } from "gsap";
 import React, { useLayoutEffect } from "react";
 import { SplitText } from "gsap/SplitText";
-import { AnimatedComponent } from "../components/AnimatedComponent";
 
 export const CodeBlockCTA = () => {
   const inboundRef = React.useRef(null);
@@ -11,7 +10,7 @@ export const CodeBlockCTA = () => {
   const wrapperRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
       const splitTextOutbound = new SplitText(outboundRef.current, { type: "words, chars, lines" });

--- a/apps/web/src/app/components/ItemGrid.tsx
+++ b/apps/web/src/app/components/ItemGrid.tsx
@@ -82,7 +82,7 @@ const grid_rows = {
     },
 }
 
-const getSmallStyles = (cols: number, rows: number) => {
+const getSmallStyles = (_cols: number, _rows: number) => {
     return ""
 }
 
@@ -101,7 +101,7 @@ const getXLargeStyles = (cols: number, rows: number) => {
 
 const composeSizes = (cols: number, rows: number) => {
     const combo = cols * rows;
-    var sizeStyles = getSmallStyles(1, combo) + " " + getMediumStyles(1, combo) + " " + getLargeStyles(cols, rows) + " " + getXLargeStyles(cols, rows);
+    let sizeStyles = getSmallStyles(1, combo) + " " + getMediumStyles(1, combo) + " " + getLargeStyles(cols, rows) + " " + getXLargeStyles(cols, rows);
     if (cols === 1) {
         sizeStyles += "space-y-10 lg:space-y-24";
     }

--- a/apps/web/src/app/components/Logo.tsx
+++ b/apps/web/src/app/components/Logo.tsx
@@ -10,7 +10,7 @@ export const LogoComponent = () => {
   const imgageRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
 

--- a/apps/web/src/app/components/LogoComponent.tsx
+++ b/apps/web/src/app/components/LogoComponent.tsx
@@ -1,8 +1,7 @@
 'use client'
-import React, { useLayoutEffect } from "react";
+import React from "react";
 import { gsap } from "gsap";
 import { SplitText } from "gsap/SplitText";
-import { AnimatedImage } from "./AnimatedImage";
 import { AnimatedComponent } from "./AnimatedComponent";
 import Image from 'next/image';
 

--- a/apps/web/src/app/components/Nav copy.tsx
+++ b/apps/web/src/app/components/Nav copy.tsx
@@ -5,7 +5,7 @@ import { SplitText } from "gsap/SplitText";
 import React from "react";
 import { Disclosure } from '@headlessui/react'
 import { Bars3Icon,  XMarkIcon } from '@heroicons/react/24/outline'
-import { useRouter, usePathname } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { AnimatedDescription } from "./AnimatedDescription";
 
 gsap.registerPlugin(SplitText);
@@ -19,7 +19,7 @@ const navigation = [
 ]
 
 export const Nav = () => {
-  const titleRef = React.useRef(null);
+  // const titleRef = React.useRef(null);
 
   useLayoutEffect(() => {
     // let ctx = gsap.context(() => {

--- a/apps/web/src/app/components/Nav.tsx
+++ b/apps/web/src/app/components/Nav.tsx
@@ -5,9 +5,8 @@ import { SplitText } from "gsap/SplitText";
 import React from "react";
 import { Disclosure } from '@headlessui/react'
 import { Bars3Icon,  XMarkIcon } from '@heroicons/react/24/outline'
-import { useRouter, usePathname } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { AnimatedDescription } from "./AnimatedDescription";
-import { AnimatedComponent } from "./AnimatedComponent";
 
 
 gsap.registerPlugin(SplitText);
@@ -21,7 +20,7 @@ const navigation = [
 ]
 
 export const Nav = () => {
-  const titleRef = React.useRef(null);
+  // const titleRef = React.useRef(null);
 
   useLayoutEffect(() => {
     // let ctx = gsap.context(() => {

--- a/apps/web/src/app/components/Rights.tsx
+++ b/apps/web/src/app/components/Rights.tsx
@@ -6,7 +6,7 @@ export const RightsComponent = () => {
   const titleRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
 
       const tl = gsap.timeline();
 

--- a/apps/web/src/app/components/RightsComponent copy.tsx
+++ b/apps/web/src/app/components/RightsComponent copy.tsx
@@ -1,7 +1,6 @@
 'use client'
-import React, { useLayoutEffect } from "react";
+import React from "react";
 import { AnimatedDescription } from "./AnimatedDescription";
-import { gsap } from "gsap";
 
 export const RightsComponent = () => {
   const titleRef = React.useRef(null);

--- a/apps/web/src/app/components/RightsComponent.tsx
+++ b/apps/web/src/app/components/RightsComponent.tsx
@@ -1,7 +1,6 @@
 'use client'
-import React, { useLayoutEffect } from "react";
+import React from "react";
 import { AnimatedDescription } from "./AnimatedDescription";
-import { gsap } from "gsap";
 
 export const RightsComponent = () => {
   const titleRef = React.useRef(null);

--- a/apps/web/src/app/components/SectionGrid.tsx
+++ b/apps/web/src/app/components/SectionGrid.tsx
@@ -27,7 +27,7 @@ const getLargeStyles =  "lg:grid-cols-12";
 const getXLargeStyles =  "xl:grid-cols-12";
 
 const composeSizes = () => {
-    var sizeStyles = getSmallStyles + " " + getMediumStyles + " " + getLargeStyles + " " + getXLargeStyles;
+    const sizeStyles = getSmallStyles + " " + getMediumStyles + " " + getLargeStyles + " " + getXLargeStyles;
 
     return sizeStyles;
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,17 +1,14 @@
 import { Metadata } from "next";
 import { AnimatedHeading } from "./components/AnimatedHeading";
 import { SectionGrid } from "./components/SectionGrid";
-import { gsap } from "gsap";
 
 import { AnimatedImage } from "./components/AnimatedImage";
-import { Button } from "./components/Button";
 import { AnimatedDescription } from "./components/AnimatedDescription";
 
 import heroImg from "../../public/bg-image-man/bg-image-hero_2x.webp";
 import middleImg from "../../public/bg-image-computer/bg-image-computer_2x.webp";
 import footerImg from "../../public/bg-image-moose/bg-image-moose_2x.webp";
 import { FooterSection } from "./sections//home/FooterSection";
-import { AnimatedComponent } from "./components/AnimatedComponent";
 import { CodeBlockCTA } from "./components/CodeBlockCTA";
 
 export const metadata: Metadata = {

--- a/apps/web/src/app/sections/home/CTASection.tsx
+++ b/apps/web/src/app/sections/home/CTASection.tsx
@@ -24,7 +24,7 @@ export const CTASection = () => {
   const featureDescriptionRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
       const tl = gsap.timeline({
         scrollTrigger: {
           trigger: featureDescriptionRef.current,

--- a/apps/web/src/app/sections/home/FeatureSection.tsx
+++ b/apps/web/src/app/sections/home/FeatureSection.tsx
@@ -52,7 +52,7 @@ export const FeatureSection = () => {
   const featureDescriptionRef = React.useRef([]);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
       const tl = gsap.timeline({
         scrollTrigger: {
           trigger: featureHeadingRef.current,

--- a/apps/web/src/app/sections/home/FooterSection.tsx
+++ b/apps/web/src/app/sections/home/FooterSection.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { RightsComponent } from "../../components/RightsComponent";
 import { LogoComponent } from "../../components/LogoComponent";
-import { AnimatedDescription } from "../../components/AnimatedDescription";
 
 export const FooterSection = () => {
   return (

--- a/apps/web/src/app/sections/home/HeroSection.tsx
+++ b/apps/web/src/app/sections/home/HeroSection.tsx
@@ -17,7 +17,7 @@ export const HeroSection = () => {
   const descriptionRef = React.useRef(null);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
       const tl = gsap.timeline();
       const splitText = new SplitText(headingRef.current, {
         type: "words, chars",

--- a/apps/web/src/app/sections/home/HowItWorksSection.tsx
+++ b/apps/web/src/app/sections/home/HowItWorksSection.tsx
@@ -44,7 +44,7 @@ export const HowItWorksSection = () => {
   const featureDescriptionRef = React.useRef([]);
 
   useLayoutEffect(() => {
-    let ctx = gsap.context(() => {
+    const ctx = gsap.context(() => {
       const tl = gsap.timeline({
         scrollTrigger: {
           trigger: featureHeadingRef.current,

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -1,7 +1,17 @@
 module.exports = {
-  extends: ["next", "turbo", "prettier"],
+  extends: ["next", "turbo", "prettier", "eslint:recommended", 'plugin:@typescript-eslint/recommended'],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
+    // Can mark a variable or an arg as unused by prefixing with _
+    "@typescript-eslint/no-unused-vars": ["error", {
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_",
+      "caughtErrorsIgnorePattern": "^_"
+    }],
+    // Temporarily (?) disabled
+    "@typescript-eslint/no-explicit-any": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -8,7 +8,9 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-config-turbo": "^1.9.3",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5",
+    "@typescript-eslint/eslint-plugin": "^6.2.0",
+    "@typescript-eslint/parser": "^6.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,36 +30,11 @@ importers:
         specifier: latest
         version: 1.11.3
 
-  apps/create-igloo-app:
-    dependencies:
-      '@514labs/igloo-cli':
-        specifier: latest
-        version: 0.3.63
-    devDependencies:
-      '@types/node':
-        specifier: 18.16.19
-        version: 18.16.19
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.62.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.62.0
-        version: 5.62.0(eslint@8.56.0)(typescript@4.9.5)
-      eslint:
-        specifier: ^8.46.0
-        version: 8.56.0
-      tsconfig:
-        specifier: workspace:0.0.0
-        version: link:../../packages/tsconfig
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
-
   apps/create-moose-app:
     dependencies:
       '@514labs/moose-cli':
         specifier: latest
-        version: 0.3.69
+        version: 0.3.73
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -150,54 +125,20 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
 
-  apps/igloo-cli-npm:
-    optionalDependencies:
-      '@514labs/igloo-cli-darwin-arm64':
-        specifier: latest
-        version: 0.3.63
-      '@514labs/igloo-cli-darwin-x64':
-        specifier: latest
-        version: 0.3.63
-      '@514labs/igloo-cli-linux-arm64':
-        specifier: latest
-        version: 0.3.63
-      '@514labs/igloo-cli-linux-x64':
-        specifier: latest
-        version: 0.3.63
-    devDependencies:
-      '@types/node':
-        specifier: 18.16.19
-        version: 18.16.19
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.62.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.62.0
-        version: 5.62.0(eslint@8.56.0)(typescript@4.9.5)
-      eslint:
-        specifier: ^8.46.0
-        version: 8.56.0
-      tsconfig:
-        specifier: workspace:0.0.0
-        version: link:../../packages/tsconfig
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
-
   apps/moose-cli-npm:
     optionalDependencies:
       '@514labs/moose-cli-darwin-arm64':
         specifier: latest
-        version: 0.3.69
+        version: 0.3.73
       '@514labs/moose-cli-darwin-x64':
         specifier: latest
-        version: 0.3.69
+        version: 0.3.73
       '@514labs/moose-cli-linux-arm64':
         specifier: latest
-        version: 0.3.69
+        version: 0.3.73
       '@514labs/moose-cli-linux-x64':
         specifier: latest
-        version: 0.3.69
+        version: 0.3.73
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -435,6 +376,12 @@ importers:
 
   packages/eslint-config-custom:
     dependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.2.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ^6.2.0
+        version: 6.21.0(eslint@8.56.0)(typescript@4.9.5)
       eslint-config-next:
         specifier: ^13.4.1
         version: 13.5.6(eslint@8.56.0)(typescript@4.9.5)
@@ -448,7 +395,7 @@ importers:
         specifier: 7.28.0
         version: 7.28.0(eslint@8.56.0)
       typescript:
-        specifier: ^4.9.4
+        specifier: ^4.9.5
         version: 4.9.5
 
   packages/tailwind-config:
@@ -491,88 +438,46 @@ importers:
 
 packages:
 
-  /@514labs/igloo-cli-darwin-arm64@0.3.63:
-    resolution: {integrity: sha512-RC8MiZtBLpRGo9LgovmsmFDheMF7Bsdim3JR/jp5pkwKcn/UADiq020phaFjaptJcOx+D9wTC04b+URUAy5OJA==}
+  /@514labs/moose-cli-darwin-arm64@0.3.73:
+    resolution: {integrity: sha512-SXqb7ilL/FPXjhvzq7lJ+PKGINYKj0KXusdYfKJZRCL9L0BrOE9+8pL4XBVOCCqstrH9q7EtfUdsYsL4xPEuoA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli-darwin-x64@0.3.63:
-    resolution: {integrity: sha512-0sroW7dk7I70CE4Ay3H8jnagGOhRobOR/czdfYfWDFhYxhi3TOJTQEkbjXz+7QaiVWijyxB/3S/89ssvO1sCIA==}
+  /@514labs/moose-cli-darwin-x64@0.3.73:
+    resolution: {integrity: sha512-ewNLi0G/1QWw+CDsYPobspf1BoZLVLDxXNKzkuKtWx86nEbcaaUC+o3lBhM5kAysCvNYeVpJMrOccSZV2y1oDQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli-linux-arm64@0.3.63:
-    resolution: {integrity: sha512-X/rFKjDz+EXglwaZvIQrK6MZnNE2Ga5U4rGe7QsZCtT4m2TtBzAG8PWA6dUDnRRABXwJ9acNgpNAIHKjOI4TRQ==}
+  /@514labs/moose-cli-linux-arm64@0.3.73:
+    resolution: {integrity: sha512-pLEXXD2Y596ZuHEyLS6XKm09oRG9AxadU3IsVzMToQK4OS99idziONaEZYJExN6OmsDZF+ILu8CLwl5hFLV5gA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli-linux-x64@0.3.63:
-    resolution: {integrity: sha512-SO9P2Rkrawid2OzT5Wcir1h0lis6Te5NKzQc2k04wIEfM+jQsvK33U+zKWhUsiBg1BwK0aqAE3DrxD2YYUG5SQ==}
+  /@514labs/moose-cli-linux-x64@0.3.73:
+    resolution: {integrity: sha512-3WrWo6ipWaQYCpH2EWs+Rhj/hOEUZ7Kly/ur4sjhWG3jH1ZCPqMZNxh0pqADrelpT+o98x+bLDgPV1xfDzFc4g==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@514labs/igloo-cli@0.3.63:
-    resolution: {integrity: sha512-WUT2xQIXRYhkMaooJnU4eV03SgVXPOXobbo8YEnG9/QY5pd35TGB7DSWBG3bjl7OU8u3GmarqP1Ixw3RURQGKw==}
+  /@514labs/moose-cli@0.3.73:
+    resolution: {integrity: sha512-5KfOgaA2z0NySRwgOD1PyFow/qtCPY4xDW/q9rSVDEH/d319y15eVnX+qjDyOOkqn3A0TXM0BWzVlceRECpaSg==}
     hasBin: true
     optionalDependencies:
-      '@514labs/igloo-cli-darwin-arm64': 0.3.63
-      '@514labs/igloo-cli-darwin-x64': 0.3.63
-      '@514labs/igloo-cli-linux-arm64': 0.3.63
-      '@514labs/igloo-cli-linux-x64': 0.3.63
-    dev: false
-
-  /@514labs/moose-cli-darwin-arm64@0.3.69:
-    resolution: {integrity: sha512-JjRl3VVzWifInmpwKPKGo5emWokVwUbJ4CMdWw6c6fgtPxhLhO/AT/bKptLJwHfb0BeSC8rNQ1EBsllp9J+DYw==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@514labs/moose-cli-darwin-x64@0.3.69:
-    resolution: {integrity: sha512-VF8e226DIGzSHNxqjGV7HldPm9LVfIAD25qP7L/v5xQZHM8HqjuB3MH5YzaGRS7Zx0HurfdrjADfR9l0J8/mjg==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@514labs/moose-cli-linux-arm64@0.3.69:
-    resolution: {integrity: sha512-J3f6vRKl1smgSB43mTWY+IxNh10u3n6XursIIWmaLll/Uqz4Jez9mQqElftZXLlNJ1L3oOtI2vz0BfJhdVDAyw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@514labs/moose-cli-linux-x64@0.3.69:
-    resolution: {integrity: sha512-aHYhMS1fl2dXCHI8rwo8kjB1bT1o1+PTFVbcAAVj7eQntCkcZ9we0dV1v4G20Hi3NY9BaFxm7zv/Dw5bBJXHNg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@514labs/moose-cli@0.3.69:
-    resolution: {integrity: sha512-olkCQQoVODQafLE1bz65C0N4wwvpSHYzHCZT3MMSNWtVLnsVSyE737Obt4yCen4b7yYwOxc2N4vT3blls9PLTg==}
-    hasBin: true
-    optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.3.69
-      '@514labs/moose-cli-darwin-x64': 0.3.69
-      '@514labs/moose-cli-linux-arm64': 0.3.69
-      '@514labs/moose-cli-linux-x64': 0.3.69
+      '@514labs/moose-cli-darwin-arm64': 0.3.73
+      '@514labs/moose-cli-darwin-x64': 0.3.73
+      '@514labs/moose-cli-linux-arm64': 0.3.73
+      '@514labs/moose-cli-linux-x64': 0.3.73
     dev: false
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -3280,7 +3185,6 @@ packages:
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-    dev: true
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -3340,7 +3244,6 @@ packages:
 
   /@types/semver@7.5.6:
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
-    dev: true
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -3402,6 +3305,35 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      eslint: 8.56.0
+      graphemer: 1.4.0
+      ignore: 5.3.0
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.2.1(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@4.9.5):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3420,6 +3352,28 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      eslint: 8.56.0
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
@@ -3427,6 +3381,15 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.21.0:
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+    dev: false
 
   /@typescript-eslint/type-utils@5.62.0(eslint@8.56.0)(typescript@4.9.5):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -3448,9 +3411,35 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils@6.21.0(eslint@8.56.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
+      debug: 4.3.4
+      eslint: 8.56.0
+      ts-api-utils: 1.2.1(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types@6.21.0:
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -3471,6 +3460,29 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@4.9.5):
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.2.1(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@4.9.5):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -3492,12 +3504,40 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@6.21.0(eslint@8.56.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.6
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
+      eslint: 8.56.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/visitor-keys@5.62.0:
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.21.0:
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+    dev: false
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -5093,11 +5133,11 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.5.6
       '@rushstack/eslint-patch': 1.7.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -5135,7 +5175,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -5145,8 +5185,8 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -5158,7 +5198,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5179,16 +5219,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5198,7 +5238,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@4.9.5)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -5207,7 +5247,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -9976,6 +10016,15 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
+  /ts-api-utils@1.2.1(typescript@4.9.5):
+    resolution: {integrity: sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 4.9.5
+    dev: false
+
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -9995,6 +10044,7 @@ packages:
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
@@ -10045,6 +10095,7 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
+    dev: true
 
   /tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}


### PR DESCRIPTION
Added `eslint:recommended` and `plugin:@typescript-eslint/recommended` to our `eslint-custom-config` file.

I chose to have the `no-explicit-any` rule disabled for now, as there were some uses and might make sense while we figure things out. Additionally unused_vars can be ignored by prefixing with an underscore, which will still allow you to write currently unused helper functions or helpers that take the same function signature for uniformity.

Side note: Looked into upgrading to eslint 8.4 flat config, but there's some existing lint plugins which aren't compatible atm, and the structure is a bit complicated for monorepo setups like ours. Current config gets deprecated at `9.0` version