### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/apps/framework-cli/Cargo.lock
+++ b/apps/framework-cli/Cargo.lock
@@ -177,12 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,18 +440,6 @@ dependencies = [
  "colored",
  "indoc",
  "pest",
-]
-
-[[package]]
-name = "dialoguer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "zeroize",
 ]
 
 [[package]]
@@ -1312,14 +1294,12 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "async-recursion",
- "bimap",
  "clap",
  "clickhouse",
  "config",
  "console",
  "convert_case",
  "diagnostics",
- "dialoguer",
  "fern",
  "git2",
  "home",
@@ -1485,9 +1465,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.6+3.1.4"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
@@ -2168,12 +2148,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2967,9 +2941,3 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -12,7 +12,6 @@ openssl = { version = "0.10", features = ["vendored"] }
 clap = { version = "4.3.17", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 console = "0.15.7"
-dialoguer = "0.10.4"
 hyper = { version = "1", features = ["full"] }
 notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
 toml = "0.5.8"
@@ -26,7 +25,6 @@ diagnostics = { git = "https://github.com/prisma/prisma-engines.git"}
 # datamodel-renderer = { git = "https://github.com/prisma/prisma-engines.git"}
 tinytemplate = "1.1"
 rdkafka = { version = "0.34" }
-bimap = "0.6.3"
 convert_case = "0.6.0"
 log = "0.4"
 fern = "0.6" 


### PR DESCRIPTION
Removes 2 unused dependencies:

```
➜  framework-cli git:(nico/dependency-optimization) cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in /Users/nicolasjoseph/code/514-labs/moose/apps/framework-cli:
moose-cli -- /Users/nicolasjoseph/code/514-labs/moose/apps/framework-cli/Cargo.toml:
	bimap
	dialoguer
	openssl

If you believe cargo-machete has detected an unused dependency incorrectly,
you can add the dependency to the list of dependencies to ignore in the
`[package.metadata.cargo-machete]` section of the appropriate Cargo.toml.
For example:

[package.metadata.cargo-machete]
ignored = ["prost"]

You can also try running it with the `--with-metadata` flag for better accuracy,
though this may modify your Cargo.lock files.

Done!
```