### PR TITLE
Fix docs URL to not point to nextra repo

### DIFF
--- a/apps/framework-docs/src/pages/building/make-changes.mdx
+++ b/apps/framework-docs/src/pages/building/make-changes.mdx
@@ -1,5 +1,5 @@
 # Changing your data models
-Change management in your data stack is critical to ensure that your data is always accurate and up to date based on your end user's expectations. Broken dashboards, reports, or machine learning models can to unhappy customers and lost revenue. MooseJS makes it easy to change your data models and ensure that your data stack is always up to date. To do so, we leverage git workflows to ensure that changes are tracked and can be rolled back if necessary.
+Change management in your data stack is critical to ensure that your data is always accurate and up to date based on your end user's expectations. Broken dashboards, reports, or machine learning models can lead to unhappy customers and lost revenue. MooseJS makes it easy to change your data models and ensure that your data stack is always up to date. To do so, we leverage git workflows to ensure that changes are tracked and can be rolled back if necessary.
 
 ## Adding a new data model
 Adding a new data source is as simple as adding a new model to an existing or new file in the `data models` directory. MooseJS will automatically detect the new model and add it to the data stack. 

--- a/apps/framework-docs/theme.config.jsx
+++ b/apps/framework-docs/theme.config.jsx
@@ -3,6 +3,7 @@ export default {
     project: {
       link: 'https://github.com/514-labs/moose'
     },
+    docsRepositoryBase: 'https://github.com/514-labs/moose/tree/main/apps/framework-docs',
     useNextSeoProps() {
         return {
           titleTemplate: '%s – MooseJS'

--- a/apps/moose-cli-npm/README.md
+++ b/apps/moose-cli-npm/README.md
@@ -1,6 +1,6 @@
 # Moose CLI
 
-The Moose CLI is your entrypoint to a seamless, local development experience for you data-intensive application. It's written in rust and supports building applications in TypeScript and Python.
+The Moose CLI is your entrypoint to a seamless, local development experience for your data-intensive application. It's written in rust and supports building applications in TypeScript and Python.
 
 ## Installation
 


### PR DESCRIPTION
There's a link in the docs taking users to https://github.com/shuding/nextra/src/pages/index.mdx. Looks like we can configure it with https://nextra.site/docs/docs-theme/theme-configuration#docs-repository.