### PR TITLE
Refactor code to pull environment variables using the Config crate

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -288,53 +288,8 @@ async fn initialize_project_state(
     project: Arc<Project>,
     route_table: &mut HashMap<PathBuf, RouteMeta>,
 ) -> anyhow::Result<FrameworkObjectVersions> {
-    let mut clickhouse_config_clone = project.clickhouse_config.clone();
-    let mut redpanda_config_clone = project.redpanda_config.clone();
-
-    // TODO - Carlos / Nick to refactor this to use the Config crate
-    // TODO - The Config crate doesn't appear to work the way we believe it should, but for now the following
-    // TODO - code is a workaround that allows me to submit a considerable amount of work for review.
-    let clickhouse_host_env = std::env::var("MOOSE_CLICKHOUSE_CONFIG__HOST").unwrap_or_default();
-    if let Ok(host) = clickhouse_host_env.parse::<String>() {
-        if !host.is_empty() {
-            clickhouse_config_clone.db_name =
-                std::env::var("MOOSE_CLICKHOUSE_CONFIG__DB_NAME").unwrap_or_default();
-            clickhouse_config_clone.user =
-                std::env::var("MOOSE_CLICKHOUSE_CONFIG__USER").unwrap_or_default();
-            clickhouse_config_clone.password =
-                std::env::var("MOOSE_CLICKHOUSE_CONFIG__PASSWORD").unwrap_or_default();
-            clickhouse_config_clone.host = host;
-            clickhouse_config_clone.host_port = std::env::var("MOOSE_CLICKHOUSE_CONFIG__HOST_PORT")
-                .unwrap_or_default()
-                .parse()
-                .unwrap_or(clickhouse_config_clone.host_port);
-            clickhouse_config_clone.postgres_port =
-                std::env::var("MOOSE_CLICKHOUSE_CONFIG__POSTGRES_PORT")
-                    .unwrap_or_default()
-                    .parse()
-                    .unwrap_or(clickhouse_config_clone.postgres_port);
-            clickhouse_config_clone.kafka_port =
-                std::env::var("MOOSE_CLICKHOUSE_CONFIG__KAFKA_PORT")
-                    .unwrap_or_default()
-                    .parse()
-                    .unwrap_or(clickhouse_config_clone.kafka_port);
-        }
-    }
-
-    let redpanda_broker_env = std::env::var("MOOSE_REDPANDA_CONFIG__BROKER").unwrap_or_default();
-    if let Ok(host) = redpanda_broker_env.parse::<String>() {
-        if !host.is_empty() {
-            redpanda_config_clone.broker = host;
-            redpanda_config_clone.message_timeout_ms =
-                std::env::var("MOOSE_REDPANDA_CONFIG__MESSAGE_TIMEOUT_MS")
-                    .unwrap_or_default()
-                    .parse()
-                    .unwrap_or(redpanda_config_clone.message_timeout_ms);
-        }
-    }
-
-    let configured_client = olap::clickhouse::create_client(clickhouse_config_clone);
-    let producer = redpanda::create_producer(redpanda_config_clone);
+    let configured_client = olap::clickhouse::create_client(project.clickhouse_config.clone());
+    let producer = redpanda::create_producer(project.redpanda_config.clone());
 
     let mut old_version_dir = project.internal_dir()?;
     old_version_dir.push("versions");

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::path::PathBuf;
 
-use config::{Config, ConfigError, File};
+use config::{Config, ConfigError, Environment, File};
 use log::debug;
 use serde::Deserialize;
 use serde::Serialize;
@@ -101,6 +101,11 @@ impl Project {
 
         let mut project_config: Project = Config::builder()
             .add_source(File::from(project_file).required(true))
+            .add_source(
+                Environment::with_prefix("MOOSE")
+                    .prefix_separator("_")
+                    .separator("__"),
+            )
             .build()?
             .try_deserialize()?;
 


### PR DESCRIPTION
Because I had trouble getting the Rust Config crate to merge environment variables into the variables loaded from a config file, I fell back to doing this manually in an earlier PR.  This PR addresses the core issue that prevented me from succeeding on my earlier attempt.

The core issue was that I needed to use the Config `.prefix_separator("_")` in order to specify that environment variables will begin with MOOSE_ and that hierarchy would be represented with double underscore "dunderscore" as in the following example: `MOOSE_CLICKHOUSE__DB_NAME`

```rust
.add_source(Environment::with_prefix("MOOSE")
                    .prefix_separator("_")
                    .separator("__"),
```