### PR TITLE
Carlos/514 590 fix prod docker container naming

### DIFF
--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -331,7 +331,7 @@ pub fn buildx(
         .arg(architecture)
         .arg("--load")
         .arg("-t")
-        .arg("moose-df-deployment")
+        .arg(format!("moose-df-deployment:{}", version))
         .arg(".")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -331,7 +331,7 @@ pub fn buildx(
         .arg(architecture)
         .arg("--load")
         .arg("-t")
-        .arg(format!("moose-deployment-{}", binarylabel))
+        .arg("moose-df-deployment")
         .arg(".")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Updated moose docker container name for prod based on discussion with Nick.  The new version based on this PR will be `moose-df-deployment` where `df` is for dogfood followed by `:{version}`.  So the result will look like this: `moose-df-deployment:0.3.134`