### PR TITLE
Checking in push.sh shell script

### DIFF
--- a/apps/framework-cli/deploy/push.sh
+++ b/apps/framework-cli/deploy/push.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+version=$2
+
+if [ -z "$1" ]
+then
+      echo "You must specify the dockerhub repository as an argument. Example: ./push.sh container-repo-name"
+      echo "Note: you can also provide a second argument to supply a specific version tag - otherwise this script will use the same version as the latest moose-cli on Github."
+      exit 1
+fi
+
+if [ -z "$2" ]
+then
+      output=$(npx @514labs/moose-cli -V)
+      version=$(echo "$output" | sed -n '2p' | awk '{print $2}')
+fi
+
+echo "Using version: $version"
+arch="moose-df-deployment-aarch64-unknown-linux-gnu"
+docker tag $arch:$version $1/$arch:$version
+docker push $1/$arch:$version
+
+arch="moose-df-deployment-x86_64-unknown-linux-gnu"
+docker tag $arch:$version $1/$arch:$version
+docker push $1/$arch:$version


### PR DESCRIPTION
This PR checks in the push.sh shell script which is a working prototype of a future `moose docker push` command for pushing local docker images to container repositories.

I delayed submitting this script because I had to test it against a previous deployment to ensure proper operation with Docker Hub. 