### PR TITLE
Rust based event capture sdk

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -63,6 +63,31 @@ impl Default for LocalWebserverConfig {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RemoteWebserverConfig {
+    pub host: String,
+    pub port: u16,
+}
+
+impl RemoteWebserverConfig {
+    pub fn new(host: String, port: u16) -> Self {
+        Self { host, port }
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}:{}", self.host, self.port)
+    }
+}
+
+impl Default for RemoteWebserverConfig {
+    fn default() -> Self {
+        Self {
+            host: "34.82.14.129".to_string(),
+            port: 4000,
+        }
+    }
+}
+
 #[derive(Clone)]
 struct RouteService {
     route_table: &'static RwLock<HashMap<PathBuf, RouteMeta>>,

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -130,8 +130,6 @@ async fn ingest_route(
 
             let body = req.collect().await.unwrap().to_bytes().to_vec();
 
-            debug!("Body: {:?}", String::from_utf8_lossy(&body));
-
             match serde_json::from_slice::<serde::de::IgnoredAny>(&body) {
                 Ok(_) => {}
                 Err(e) => {

--- a/apps/framework-cli/src/cli/logger.rs
+++ b/apps/framework-cli/src/cli/logger.rs
@@ -36,7 +36,8 @@
 
 use serde::Deserialize;
 use std::time::SystemTime;
-use uuid::Uuid;
+
+use crate::utilities::constants::{CONTEXT, CTX_SESSION_ID};
 
 use super::settings::user_directory;
 
@@ -90,7 +91,7 @@ impl Default for LoggerSettings {
 
 // TODO ensure that the log file rotates after a certain size
 pub fn setup_logging(settings: LoggerSettings) -> Result<(), fern::InitError> {
-    let session_id = Uuid::new_v4().to_string();
+    let session_id = CONTEXT.get(CTX_SESSION_ID).unwrap();
 
     let base_config = fern::Dispatch::new().level(settings.level.to_log_level());
 

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -26,7 +26,7 @@ use log::debug;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::cli::local_webserver::LocalWebserverConfig;
+use crate::cli::local_webserver::{LocalWebserverConfig, RemoteWebserverConfig};
 use crate::framework::languages::SupportedLanguages;
 use crate::framework::readme::BASE_README_TEMPLATE;
 use crate::framework::schema::templates::BASE_MODEL_TEMPLATE;
@@ -46,6 +46,7 @@ lazy_static! {
         redpanda_config: RedpandaConfig::default(),
         clickhouse_config: ClickhouseConfig::default(),
         http_server_config: LocalWebserverConfig::default(),
+        instrumentation_config: RemoteWebserverConfig::default(),
         console_config: ConsoleConfig::default(),
         language_project_config: LanguageProjectConfig::Typescript(TypescriptProject::default()),
         project_location: PathBuf::new(),
@@ -63,6 +64,7 @@ pub struct Project {
     pub redpanda_config: RedpandaConfig,
     pub clickhouse_config: ClickhouseConfig,
     pub http_server_config: LocalWebserverConfig,
+    pub instrumentation_config: RemoteWebserverConfig,
     pub console_config: ConsoleConfig,
 
     // This part of the configuration for the project is dynamic and not saved
@@ -118,6 +120,7 @@ impl Project {
                 redpanda_config: RedpandaConfig::default(),
                 clickhouse_config: ClickhouseConfig::default(),
                 http_server_config: LocalWebserverConfig::default(),
+                instrumentation_config: RemoteWebserverConfig::default(),
                 console_config: ConsoleConfig::default(),
                 language_project_config: LanguageProjectConfig::Typescript(TypescriptProject::new(
                     name,

--- a/apps/framework-cli/src/utilities/capture.rs
+++ b/apps/framework-cli/src/utilities/capture.rs
@@ -49,6 +49,7 @@ pub struct UserActivity {
 
 macro_rules! capture {
     ($activity_type:expr, $sequence_id:expr, $project_name:expr) => {
+        use crate::project::PROJECT;
         use crate::utilities::capture::{ActivityType, UserActivity};
         use crate::utilities::constants;
         use chrono::Utc;
@@ -66,17 +67,12 @@ macro_rules! capture {
             cli_version: constants::CLI_VERSION.to_string(),
         });
 
-        // Get the environment variables
-        // let moose_contributor = std::env::var("MOOSE_CONTRIBUTOR").unwrap_or("unknown".to_string());
-        let scheme = std::env::var("SCHEME").unwrap_or("http".to_string());
-        let host = std::env::var("HOST").unwrap_or("localhost".to_string());
-        let port = std::env::var("PORT").unwrap_or("4000".to_string());
-        let path = std::env::var("INGESTION_POINT").unwrap_or("UserActivity".to_string());
-
-        // Format a URL with the scheme, host, and port and the path as variables
+        let remote_url = {
+            let guard = PROJECT.lock().unwrap();
+            guard.instrumentation_config.url().clone()
+        };
         #[allow(unused)]
-        let dev_url = format!("{}://{}:{}/ingest/{}", scheme, host, port, path);
-        // let prod_url = format!("{}://{}/ingest/{}", scheme, host, path);
+        let prod_url = format!("{}/ingest/UserActivity", remote_url);
 
         // let client = Client::new();
         // let res = client
@@ -86,7 +82,7 @@ macro_rules! capture {
         //     .await
         //     .unwrap();
 
-        // println!("Sent to {}. Event: {}", dev_url, event);
+        // println!("Sent to {}. Event: {}", prod_url, event);
     };
 }
 

--- a/apps/framework-cli/src/utilities/capture.rs
+++ b/apps/framework-cli/src/utilities/capture.rs
@@ -2,8 +2,8 @@
 //!
 //! This module leverages moose to instrument moose. It includes a macro to easily capture data anywhere in the codebase.
 //!
-// use chrono::serde::ts_seconds;
-// use lazy_static::lazy_static;
+use chrono::serde::ts_seconds;
+use lazy_static::lazy_static;
 
 // Create a lazy static instance of the client
 lazy_static! {

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -1,3 +1,7 @@
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use uuid::Uuid;
+
 pub const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const PACKAGE_JSON: &str = "package.json";
@@ -29,3 +33,13 @@ pub const GITIGNORE: &str = ".gitignore";
 
 pub const DENO_DIR: &str = "deno";
 pub const DENO_TRANSFORM: &str = "transform.ts";
+
+pub const CTX_SESSION_ID: &str = "session_id";
+
+lazy_static! {
+    pub static ref CONTEXT: HashMap<String, String> = {
+        let mut map = HashMap::new();
+        map.insert(CTX_SESSION_ID.to_string(), Uuid::new_v4().to_string());
+        map
+    };
+}


### PR DESCRIPTION
Basic framework for capturing events. It's currently not sending the data anywhere. We can turn it on when there's a production moose app.

The capture macro is currently being called from top level CLI commands. We can add it to other places in the future. I also extracted out the session ID in the logger into a lazy static so other parts of the code can use the same session ID.


<img width="1501" alt="Screenshot 2024-03-14 at 2 56 21 PM" src="https://github.com/514-labs/moose/assets/7286437/f9536b38-68e3-416b-b6c8-57320ec86453">


