### PR TITLE
Fix Dockerfile expects versions folder to be present

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -72,8 +72,8 @@ impl Routine for CreateDockerfile {
 
         ensure_docker_running()?;
 
-        let file_path = internal_dir.join("packager/versions/.gitkeep");
-        let file_path_display = file_path.clone();
+        let mut file_path = internal_dir.join("packager/versions/.gitkeep");
+        let mut file_path_display = file_path.clone();
 
         info!("Creating versions at: {:?}", file_path_display);
         fs::create_dir_all(file_path.parent().unwrap()).map_err(|err| {
@@ -87,10 +87,10 @@ impl Routine for CreateDockerfile {
             )
         })?;
 
-        info!("Creating Dockerfile at: {:?}", file_path_display);
-        let file_path = internal_dir.join("packager/Dockerfile");
-        let file_path_display = file_path.clone();
+        file_path = internal_dir.join("packager/Dockerfile");
+        file_path_display = file_path.clone();
 
+        info!("Creating Dockerfile at: {:?}", file_path_display);
         fs::create_dir_all(file_path.parent().unwrap()).map_err(|err| {
             error!("Failed to create directory for project packaging: {}", err);
             RoutineFailure::new(

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -72,11 +72,10 @@ impl Routine for CreateDockerfile {
 
         ensure_docker_running()?;
 
-        let mut file_path = internal_dir.join("packager/versions/.gitkeep");
-        let mut file_path_display = file_path.clone();
+        let versions_file_path = internal_dir.join("packager/versions/.gitkeep");
 
-        info!("Creating versions at: {:?}", file_path_display);
-        fs::create_dir_all(file_path.parent().unwrap()).map_err(|err| {
+        info!("Creating versions at: {:?}", versions_file_path);
+        fs::create_dir_all(versions_file_path.parent().unwrap()).map_err(|err| {
             error!("Failed to create directory for app versions: {}", err);
             RoutineFailure::new(
                 Message::new(
@@ -87,10 +86,9 @@ impl Routine for CreateDockerfile {
             )
         })?;
 
-        file_path = internal_dir.join("packager/Dockerfile");
-        file_path_display = file_path.clone();
+        let file_path = internal_dir.join("packager/Dockerfile");
 
-        info!("Creating Dockerfile at: {:?}", file_path_display);
+        info!("Creating Dockerfile at: {:?}", file_path);
         fs::create_dir_all(file_path.parent().unwrap()).map_err(|err| {
             error!("Failed to create directory for project packaging: {}", err);
             RoutineFailure::new(
@@ -102,7 +100,7 @@ impl Routine for CreateDockerfile {
             )
         })?;
 
-        fs::write(file_path, DOCKER_FILE).map_err(|err| {
+        fs::write(&file_path, DOCKER_FILE).map_err(|err| {
             error!("Failed to write Docker file for project: {}", err);
             RoutineFailure::new(
                 Message::new(
@@ -113,7 +111,7 @@ impl Routine for CreateDockerfile {
             )
         })?;
 
-        info!("Dockerfile created at: {:?}", file_path_display);
+        info!("Dockerfile created at: {:?}", file_path);
         Ok(RoutineSuccess::success(Message::new(
             "Successfully".to_string(),
             "created dockerfile".to_string(),

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -72,10 +72,24 @@ impl Routine for CreateDockerfile {
 
         ensure_docker_running()?;
 
-        let file_path = internal_dir.join("packager/Dockerfile");
+        let file_path = internal_dir.join("packager/versions/.gitkeep");
         let file_path_display = file_path.clone();
 
+        info!("Creating versions at: {:?}", file_path_display);
+        fs::create_dir_all(file_path.parent().unwrap()).map_err(|err| {
+            error!("Failed to create directory for app versions: {}", err);
+            RoutineFailure::new(
+                Message::new(
+                    "Failed".to_string(),
+                    "to create directory for app versions".to_string(),
+                ),
+                err,
+            )
+        })?;
+
         info!("Creating Dockerfile at: {:?}", file_path_display);
+        let file_path = internal_dir.join("packager/Dockerfile");
+        let file_path_display = file_path.clone();
 
         fs::create_dir_all(file_path.parent().unwrap()).map_err(|err| {
             error!("Failed to create directory for project packaging: {}", err);


### PR DESCRIPTION
The Dockerfile build was failing because it expects a versions folder to be present - even if empty.

```
# Copy the application files to the container
COPY ./app ./app
COPY ./versions .moose/versions
```