### PR TITLE
Add filewatcher to flows for local dev

### DIFF
--- a/apps/framework-cli/src/cli/routines/initialize.rs
+++ b/apps/framework-cli/src/cli/routines/initialize.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::{fs, path::PathBuf};
 
+use crate::utilities::constants::DENO_DIR;
 use crate::{
     cli::display::Message,
     framework::{languages::create_models_dir, typescript::create_typescript_models_dir},
@@ -372,7 +373,7 @@ impl Routine for CreateDenoDirectory {
             )
         })?;
 
-        let deno_dir = internal_dir.join("deno");
+        let deno_dir = internal_dir.join(DENO_DIR);
         match fs::create_dir_all(deno_dir.clone()) {
             Ok(_) => Ok(RoutineSuccess::success(Message::new(
                 "Created".to_string(),


### PR DESCRIPTION
I tried [Deno.watchFs](https://examples.deno.land/watching-files), but it seemed unreliable with Docker volumes. Specifically, I would delete a flow file locally, see it deleted in the container, but Deno's filewatcher wasn't picking it up.

[Chokidar](https://www.npmjs.com/package/chokidar) was able to because of its polling feature:

> It is typically necessary to set this to true to successfully watch files over a network, and it may be necessary to successfully watch files in other non-standard situations. 
