### PR TITLE
Nicolas/514 676 enable one click deploy of our internal moose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 **/target
 **/node_modules
 node_modules
+gha-creds-*.json

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -323,7 +323,6 @@ jobs:
         # TODO uncomment when ready
         # if: ${{ !inputs.dry-run }}
         run: |
-          docker images
           docker tag moose-df-deployment-x86_64-unknown-linux-gnu:latest 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
           docker push 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
 
@@ -340,6 +339,12 @@ jobs:
 
       - name: "Get credentials for the k8s cluster"
         run: |
-          gcloud info
           gcloud container clusters get-credentials moose-dev-cluster-1a --region=us-west1-a
-          kubectl get pods
+
+      - name: "Deploy the new image"
+        run: |
+          kubectl set image deployment/moosedeployment moosedeploy=514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
+
+      - name: "Watch for the deployment to finish"
+        run: |
+          kubectl rollout status deployment/moosedeployment

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -318,5 +318,6 @@ jobs:
 
       - name: Docker Push
         run: |
+          docker images
           docker tag moose-df-deployment-x86_64-unknown-linux-gnu:latest 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
           docker push 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -323,3 +323,8 @@ jobs:
           docker images
           docker tag moose-df-deployment-x86_64-unknown-linux-gnu:latest 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
           docker push 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
+
+      - uses: "google-github-actions/auth@v2"
+        with:
+          project_id: "extended-ward-415018"
+          workload_identity_provider: "projects/167275965848/locations/global/workloadIdentityPools/github/providers/github-actions-repos"

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -256,9 +256,9 @@ jobs:
 
   deploy-internal:
     runs-on: ubuntu-latest
-    needs:
-      - version
-      - publish-npm-base
+    # needs:
+    # - version
+    # - publish-npm-base
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -264,8 +264,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Install dependencies
-        run: npm install
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
-      - name: Deploy
-        run: npm run deploy -- --dry-run=${{ github.event.inputs.dry-run }}
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Build
+        working-directory: ./apps/framework-internal-app
+        run: pnpm run build

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -204,7 +204,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: 514iceman
-          password: $${{ steps.op-load-secret.outputs.SECRET }}
+          password: $${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
 
       # TODO - convert to use 1password for the secret
       - name: Build and push
@@ -259,7 +259,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: 514iceman
-          password: $${{ steps.op-load-secret.outputs.SECRET }}
+          password: $${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -314,4 +314,4 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: 514iceman
-          password: $${{ steps.op-load-secret.outputs.SECRET }}
+          password: $${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -329,5 +329,15 @@ jobs:
 
       - uses: "google-github-actions/auth@v2"
         with:
-          project_id: "extended-ward-415018"
+          service_account: "github-actions@extended-ward-415018.iam.gserviceaccount.com"
           workload_identity_provider: "projects/167275965848/locations/global/workloadIdentityPools/github/providers/github-actions-repos"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 363.0.0"
+
+      - name: "Get credentials for the k8s cluster"
+        run: |
+          gcloud info
+          gcloud container clusters get-credentials moose-dev-cluster-1a --region=us-west1-a

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -275,6 +275,8 @@ jobs:
 
   deploy-internal:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: none
     needs:
       - version
     # - publish-npm-base

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -171,6 +171,7 @@ jobs:
 
       - name: Notify Sentry release
         uses: getsentry/action-release@v1
+        if: ${{ !inputs.dry-run }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -213,6 +214,7 @@ jobs:
 
       - name: Notify Sentry release
         uses: getsentry/action-release@v1
+        if: ${{ !inputs.dry-run }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -276,7 +276,8 @@ jobs:
   deploy-internal:
     runs-on: ubuntu-latest
     permissions:
-      id-token: none
+      contents: "read"
+      id-token: "write"
     needs:
       - version
     # - publish-npm-base

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -336,8 +336,10 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v2"
         with:
           version: ">= 363.0.0"
+          install_components: "gke-gcloud-auth-plugin, kubectl"
 
       - name: "Get credentials for the k8s cluster"
         run: |
           gcloud info
           gcloud container clusters get-credentials moose-dev-cluster-1a --region=us-west1-a
+          kubectl get pods

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -169,6 +169,7 @@ jobs:
         shell: bash
         run: ./apps/create-moose-app/scripts/release.sh ${{ needs.version.outputs.version }}
 
+      # TODO - convert to use 1password for the secret
       - name: Notify Sentry release
         uses: getsentry/action-release@v1
         if: ${{ !inputs.dry-run }}
@@ -191,12 +192,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - uses: 1password/load-secrets-action@v1
+        id: op-load-secret
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DOCKER_HUB_ACCESS_KEY: "op://drqe7p6legi6ug2ijq2fnrkmjq/Docker Hub - Bot/Access Token"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: 514iceman
+          password: $${{ steps.op-load-secret.outputs.SECRET }}
 
+      # TODO - convert to use 1password for the secret
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -212,6 +222,7 @@ jobs:
             TURBO_TEAM=${{ vars.TURBO_TEAM }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      # TODO - convert to use 1password for the secret
       - name: Notify Sentry release
         uses: getsentry/action-release@v1
         if: ${{ !inputs.dry-run }}
@@ -236,11 +247,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - uses: 1password/load-secrets-action@v1
+        id: op-load-secret
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DOCKER_HUB_ACCESS_KEY: "op://drqe7p6legi6ug2ijq2fnrkmjq/Docker Hub - Bot/Access Token"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: 514iceman
+          password: $${{ steps.op-load-secret.outputs.SECRET }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -282,3 +301,17 @@ jobs:
       - name: Run Build
         working-directory: ./apps/framework-internal-app
         run: pnpm run build
+
+      - uses: 1password/load-secrets-action@v1
+        id: op-load-secret
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DOCKER_HUB_ACCESS_KEY: "op://drqe7p6legi6ug2ijq2fnrkmjq/Docker Hub - Bot/Access Token"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: 514iceman
+          password: $${{ steps.op-load-secret.outputs.SECRET }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 10
+          fetch-depth: 20
 
       - name: Generate Version
         id: version
@@ -317,6 +317,8 @@ jobs:
           password: ${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
 
       - name: Docker Push
+        # TODO uncomment when ready
+        # if: ${{ !inputs.dry-run }}
         run: |
           docker images
           docker tag moose-df-deployment-x86_64-unknown-linux-gnu:latest 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -251,3 +251,21 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             FRAMEWORK_VERSION=${{ needs.version.outputs.version }}
+
+  deploy-internal:
+    runs-on: ubuntu-latest
+    needs:
+      - version
+      - publish-npm-base
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Deploy
+        run: npm run deploy -- --dry-run=${{ github.event.inputs.dry-run }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -204,7 +204,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: 514iceman
-          password: $${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
+          password: ${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
 
       # TODO - convert to use 1password for the secret
       - name: Build and push
@@ -259,7 +259,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: 514iceman
-          password: $${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
+          password: ${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -314,4 +314,4 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: 514iceman
-          password: $${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
+          password: ${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -275,8 +275,8 @@ jobs:
 
   deploy-internal:
     runs-on: ubuntu-latest
-    # needs:
-    # - version
+    needs:
+      - version
     # - publish-npm-base
     steps:
       - name: Checkout
@@ -315,3 +315,8 @@ jobs:
         with:
           username: 514iceman
           password: ${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
+
+      - name: Docker Push
+        run: |
+          docker tag moose-df-deployment-x86_64-unknown-linux-gnu:latest 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
+          docker push 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 20
+          fetch-depth: 10
 
       - name: Generate Version
         id: version
@@ -320,8 +320,7 @@ jobs:
           password: ${{ steps.op-load-secret.outputs.DOCKER_HUB_ACCESS_KEY }}
 
       - name: Docker Push
-        # TODO uncomment when ready
-        # if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run }}
         run: |
           docker tag moose-df-deployment-x86_64-unknown-linux-gnu:latest 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
           docker push 514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
@@ -342,9 +341,11 @@ jobs:
           gcloud container clusters get-credentials moose-dev-cluster-1a --region=us-west1-a
 
       - name: "Deploy the new image"
+        if: ${{ !inputs.dry-run }}
         run: |
           kubectl set image deployment/moosedeployment moosedeploy=514labs/moose-df-deployment-x86_64-unknown-linux-gnu:${{needs.version.outputs.version}}
 
       - name: "Watch for the deployment to finish"
+        if: ${{ !inputs.dry-run }}
         run: |
           kubectl rollout status deployment/moosedeployment

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -280,7 +280,7 @@ jobs:
       id-token: "write"
     needs:
       - version
-    # - publish-npm-base
+      - publish-npm-base
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Cargo.lock
 console.db
 
 .vscode/launch.json
+gha-creds-*.json

--- a/apps/framework-cli/src/cli/routines/clean.rs
+++ b/apps/framework-cli/src/cli/routines/clean.rs
@@ -149,19 +149,26 @@ impl DeleteVersions {
 impl Routine for DeleteVersions {
     fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
         let versions_dir = self.internal_dir.join("versions");
-        fs::remove_dir_all(&versions_dir).map_err(|err| {
-            RoutineFailure::new(
-                Message::new(
-                    "Failed".to_string(),
-                    format!("to remove versions directory at {}", versions_dir.display()),
-                ),
-                err,
-            )
-        })?;
+        if !versions_dir.exists() {
+            return Ok(RoutineSuccess::success(Message::new(
+                "ok".to_string(),
+                "No versions directory to remove".to_string(),
+            )));
+        } else {
+            fs::remove_dir_all(&versions_dir).map_err(|err| {
+                RoutineFailure::new(
+                    Message::new(
+                        "Failed".to_string(),
+                        format!("to remove versions directory at {}", versions_dir.display()),
+                    ),
+                    err,
+                )
+            })?;
 
-        Ok(RoutineSuccess::success(Message::new(
-            "Successfully".to_string(),
-            "removed versions directory".to_string(),
-        )))
+            Ok(RoutineSuccess::success(Message::new(
+                "Successfully".to_string(),
+                "removed versions directory".to_string(),
+            )))
+        }
     }
 }

--- a/apps/framework-cli/src/project/typescript_project.rs
+++ b/apps/framework-cli/src/project/typescript_project.rs
@@ -23,7 +23,10 @@ impl Default for TypescriptProject {
             version: "0.0".to_string(),
             // For local development of the CLI,
             // change `moose-cli` to `<REPO_PATH>/apps/framework-cli/target/debug/moose-cli`
-            scripts: HashMap::from([("dev".to_string(), "moose-cli dev".to_string())]),
+            scripts: HashMap::from([
+                ("dev".to_string(), "moose-cli dev".to_string()),
+                ("build".to_string(), "moose-cli build --docker".to_string()),
+            ]),
             dependencies: HashMap::new(),
             dev_dependencies: HashMap::from([(
                 "@514labs/moose-cli".to_string(),

--- a/apps/framework-internal-app/package.json
+++ b/apps/framework-internal-app/package.json
@@ -2,7 +2,8 @@
   "name": "internal-app",
   "version": "0.0",
   "scripts": {
-    "dev": "moose-cli dev"
+    "dev": "moose-cli dev",
+    "build": "moose-cli build --docker"
   },
   "dependencies": {},
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
     dependencies:
       '@514labs/moose-cli':
         specifier: latest
-        version: 0.3.168
+        version: 0.3.170
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -129,7 +129,7 @@ importers:
     devDependencies:
       '@514labs/moose-cli':
         specifier: latest
-        version: 0.3.168
+        version: 0.3.170
 
   apps/framework-landing:
     dependencies:
@@ -208,16 +208,16 @@ importers:
     optionalDependencies:
       '@514labs/moose-cli-darwin-arm64':
         specifier: latest
-        version: 0.3.168
+        version: 0.3.170
       '@514labs/moose-cli-darwin-x64':
         specifier: latest
-        version: 0.3.168
+        version: 0.3.170
       '@514labs/moose-cli-linux-arm64':
         specifier: latest
-        version: 0.3.168
+        version: 0.3.170
       '@514labs/moose-cli-linux-x64':
         specifier: latest
-        version: 0.3.168
+        version: 0.3.170
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -535,42 +535,42 @@ importers:
 
 packages:
 
-  /@514labs/moose-cli-darwin-arm64@0.3.168:
-    resolution: {integrity: sha512-/Efopd3SmgXxfdYX0tsd0T3VVXZZBka6q2pUmO8LRSnmPXCMOTOb65VNw5v1Z6LT/LVSPxXHwc+yxjITIIhkDg==}
+  /@514labs/moose-cli-darwin-arm64@0.3.170:
+    resolution: {integrity: sha512-w0nvms3rXe7r1xnNTFp+F7DSH+z4oMMHw8JvG9L30U3pZqbqtpo3UVf9KvB1jSSiAKqAS376n64BtgAdRjMrRQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@514labs/moose-cli-darwin-x64@0.3.168:
-    resolution: {integrity: sha512-+uawgRCp0Io2hrNfob/OaMvTXtio7QeVAIP/1qa/3qFSdjjmrizTl500q4rPhkJjv6S4zR7GHhYXWZqX2BpZPQ==}
+  /@514labs/moose-cli-darwin-x64@0.3.170:
+    resolution: {integrity: sha512-Nq0md/M6qrCLvR/uXVBZXjd1CyMLIuJ/LkC11mOh+qHifxZ4HEduknnptMT+8NbwBvT2xSVzI7CHGazuNgKiLA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@514labs/moose-cli-linux-arm64@0.3.168:
-    resolution: {integrity: sha512-+RRoVUln5iSP/kCFNhMG4LDVFbQyEhSnF9Qo5+AjRVudA4Jqs9sSoPSjsDCAFlqsSOe+IxOr0IWlT+ShTRH0CQ==}
+  /@514labs/moose-cli-linux-arm64@0.3.170:
+    resolution: {integrity: sha512-5J7VvYm9VSBCTgjTgCC6+k4x9g5rej8B985mRCgin/KVM95okK+veusxZgc4b9++NAtU4WXvqYa0XvutjknBjA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@514labs/moose-cli-linux-x64@0.3.168:
-    resolution: {integrity: sha512-kSXJTw4TAGdtCngcDVWx4Wdc6C9IAmtY6NfDdNEouL0sYIjiGJhEa9V7n2uXKz+1yV995/rFFxhhyIXnNUbojg==}
+  /@514labs/moose-cli-linux-x64@0.3.170:
+    resolution: {integrity: sha512-mgvODS0M/HhJ0UNcHqShUgXcm+gygrQqY55Yh2pOG+9i6gt+iS3U02XT3kARBPfGhOQceI3MQ3Q36P8dOpMlCA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@514labs/moose-cli@0.3.168:
-    resolution: {integrity: sha512-60s4yEmsvgN6KsHZZ1BUL4cOznjv5k2AYPrT4j1zEu3EMijGUm0yMu1zmgapmkv2yDvCMcpx41VI6q6diF8vWA==}
+  /@514labs/moose-cli@0.3.170:
+    resolution: {integrity: sha512-Ca6pp0DY3al2TGeNpiQdHH2pTssqo8g2g+rhPbi0hcC+ckC6TYnawijpfjao6/1DnHm9B+5mHUUw3YT81VyADw==}
     hasBin: true
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.3.168
-      '@514labs/moose-cli-darwin-x64': 0.3.168
-      '@514labs/moose-cli-linux-arm64': 0.3.168
-      '@514labs/moose-cli-linux-x64': 0.3.168
+      '@514labs/moose-cli-darwin-arm64': 0.3.170
+      '@514labs/moose-cli-darwin-x64': 0.3.170
+      '@514labs/moose-cli-linux-arm64': 0.3.170
+      '@514labs/moose-cli-linux-x64': 0.3.170
 
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}


### PR DESCRIPTION
* Adds Workflow to automatically update our moose project when moose gets updated
* Adds integration between 1password and github actions to be able to use secrets from 514's 1password
* Adds integration between Github Action and github to be able to use github actions for continuous delivery
* Fixes an issue when the `versions` directory was not created and a build was run
* Changes the Docker Hub credentials to use one from a service account 
* Adds a build command to the project template when running init