### PR TITLE
improvement: change default docker image tag in the build script to be latest

### DIFF
--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -280,7 +280,9 @@ pub fn buildx(
         .arg("--load")
         .arg("--no-cache")
         .arg("-t")
-        .arg(format!("moose-df-deployment-{}:{}", binarylabel, version))
+        // Using latest for the version tag as the user might want to use its own
+        // version tag, this makes it easy for the automation to re-label the image.
+        .arg(format!("moose-df-deployment-{}:latest", binarylabel))
         .arg(".")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
This will help with automation for deploying. We can now do:

```
docker tag moose-df-deployment-x86_64-unknown-linux-gnu: latest moose-df-deployment-x86_64-unknown-linux-gnu:<versionChosenByTheUser>
```

for all builds, while before we had to dynamically get the version that was used to run the build to specify the tag. 