### PR TITLE
Update instrumentation url & data model

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -66,24 +66,22 @@ impl Default for LocalWebserverConfig {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RemoteWebserverConfig {
     pub host: String,
-    pub port: u16,
 }
 
 impl RemoteWebserverConfig {
-    pub fn new(host: String, port: u16) -> Self {
-        Self { host, port }
+    pub fn new(host: String) -> Self {
+        Self { host }
     }
 
     pub fn url(&self) -> String {
-        format!("http://{}:{}", self.host, self.port)
+        format!("https://{}", self.host)
     }
 }
 
 impl Default for RemoteWebserverConfig {
     fn default() -> Self {
         Self {
-            host: "34.82.14.129".to_string(),
-            port: 4000,
+            host: "moosefood.514.dev".to_string(),
         }
     }
 }

--- a/apps/framework-cli/src/utilities/capture.rs
+++ b/apps/framework-cli/src/utilities/capture.rs
@@ -36,7 +36,7 @@ pub enum ActivityType {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct MooseEvent {
+pub struct MooseActivity {
     pub id: Uuid,
     pub project: String,
     #[serde(rename = "activityType")]
@@ -52,7 +52,7 @@ pub struct MooseEvent {
 macro_rules! capture {
     ($activity_type:expr, $sequence_id:expr, $project_name:expr) => {
         use crate::project::PROJECT;
-        use crate::utilities::capture::{ActivityType, MooseEvent};
+        use crate::utilities::capture::{ActivityType, MooseActivity};
         use crate::utilities::constants;
         use chrono::Utc;
         // use reqwest::Client;
@@ -60,7 +60,7 @@ macro_rules! capture {
         use uuid::Uuid;
 
         #[allow(unused)]
-        let event = json!(MooseEvent {
+        let event = json!(MooseActivity {
             id: Uuid::new_v4(),
             project: $project_name,
             activity_type: $activity_type,
@@ -74,7 +74,7 @@ macro_rules! capture {
             guard.instrumentation_config.url().clone()
         };
         #[allow(unused)]
-        let prod_url = format!("{}/ingest/MooseEvent", remote_url);
+        let prod_url = format!("{}/ingest/MooseActivity", remote_url);
 
         // let client = Client::new();
         // let res = client

--- a/apps/framework-cli/src/utilities/capture.rs
+++ b/apps/framework-cli/src/utilities/capture.rs
@@ -17,26 +17,26 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize)]
 pub enum ActivityType {
-    #[serde(rename = "devCommand")]
-    DevCommand,
-    #[serde(rename = "initCommand")]
-    InitCommand,
     #[serde(rename = "buildCommand")]
     BuildCommand,
-    #[serde(rename = "dockerCommand")]
-    DockerCommand,
-    #[serde(rename = "cleanCommand")]
-    CleanCommand,
-    #[serde(rename = "stopCommand")]
-    StopCommand,
-    #[serde(rename = "prodCommand")]
-    ProdCommand,
     #[serde(rename = "bumpVersionCommand")]
     BumpVersionCommand,
+    #[serde(rename = "cleanCommand")]
+    CleanCommand,
+    #[serde(rename = "devCommand")]
+    DevCommand,
+    #[serde(rename = "dockerCommand")]
+    DockerCommand,
+    #[serde(rename = "initCommand")]
+    InitCommand,
+    #[serde(rename = "prodCommand")]
+    ProdCommand,
+    #[serde(rename = "stopCommand")]
+    StopCommand,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct UserActivity {
+pub struct MooseEvent {
     pub id: Uuid,
     pub project: String,
     #[serde(rename = "activityType")]
@@ -52,7 +52,7 @@ pub struct UserActivity {
 macro_rules! capture {
     ($activity_type:expr, $sequence_id:expr, $project_name:expr) => {
         use crate::project::PROJECT;
-        use crate::utilities::capture::{ActivityType, UserActivity};
+        use crate::utilities::capture::{ActivityType, MooseEvent};
         use crate::utilities::constants;
         use chrono::Utc;
         // use reqwest::Client;
@@ -60,7 +60,7 @@ macro_rules! capture {
         use uuid::Uuid;
 
         #[allow(unused)]
-        let event = &json!(UserActivity {
+        let event = json!(MooseEvent {
             id: Uuid::new_v4(),
             project: $project_name,
             activity_type: $activity_type,
@@ -74,7 +74,7 @@ macro_rules! capture {
             guard.instrumentation_config.url().clone()
         };
         #[allow(unused)]
-        let prod_url = format!("{}/ingest/UserActivity", remote_url);
+        let prod_url = format!("{}/ingest/MooseEvent", remote_url);
 
         // let client = Client::new();
         // let res = client

--- a/apps/framework-cli/src/utilities/capture.rs
+++ b/apps/framework-cli/src/utilities/capture.rs
@@ -55,7 +55,7 @@ macro_rules! capture {
         use crate::utilities::capture::{ActivityType, MooseActivity};
         use crate::utilities::constants;
         use chrono::Utc;
-        // use reqwest::Client;
+        use reqwest::Client;
         use serde_json::json;
         use uuid::Uuid;
 
@@ -68,23 +68,28 @@ macro_rules! capture {
             timestamp: Utc::now(),
             cli_version: constants::CLI_VERSION.to_string(),
         });
-
         let remote_url = {
             let guard = PROJECT.lock().unwrap();
             guard.instrumentation_config.url().clone()
         };
-        #[allow(unused)]
-        let prod_url = format!("{}/ingest/MooseActivity", remote_url);
 
-        // let client = Client::new();
-        // let res = client
-        //     .post(&dev_url)
-        //     .json(event)
-        //     .send()
-        //     .await
-        //     .unwrap();
+        // Sending this data can fail for a variety of reasons, so we don't want to
+        // block user & no need to handle the result
+        tokio::spawn(async move {
+            // TODO: Change this to MooseActivity after the table is verified
+            let instrumentation_url = format!("{}/ingest/UserActivity", remote_url);
+            // TODO: Delete this, use event from above instead
+            let fake_event = json!({
+                "eventId": "1234",
+                "userId": "123456",
+                "activity": $activity_type,
+                "timestamp": Utc::now(),
+            });
 
-        // println!("Sent to {}. Event: {}", prod_url, event);
+            let client = Client::new();
+            let request = client.post(&instrumentation_url).json(&fake_event);
+            request.send().await
+        });
     };
 }
 

--- a/apps/framework-internal-app/app/datamodels/models.prisma
+++ b/apps/framework-internal-app/app/datamodels/models.prisma
@@ -15,3 +15,11 @@ model ParsedActivity {
     activity  String
 }
 
+model MooseEvent {
+    id              String @id
+    project         String
+    activityType    String
+    sequenceId      String
+    timestamp       DateTime
+    cliVersion      String
+}

--- a/apps/framework-internal-app/app/datamodels/models.prisma
+++ b/apps/framework-internal-app/app/datamodels/models.prisma
@@ -15,7 +15,7 @@ model ParsedActivity {
     activity  String
 }
 
-model MooseEvent {
+model MooseActivity {
     id              String @id
     project         String
     activityType    String

--- a/apps/framework-internal-app/project.toml
+++ b/apps/framework-internal-app/project.toml
@@ -20,8 +20,7 @@ host = "localhost"
 port = 4000
 
 [instrumentation_config]
-host = "34.82.14.129"
-port = 4000
+host = "moosefood.514.dev"
 
 [console_config]
 host_port = 3001


### PR DESCRIPTION
This creates a new model instead of using UserActivity so folks can continue to send test data to UserActivity without adding noise to instrumentation. There will be a follow-up PR to actually enable instrumentation after I verify the new model gets deployed.