### PR TITLE
Setup models dir before starting prod server

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -22,7 +22,7 @@ use logger::setup_logging;
 use settings::{read_settings, Settings};
 
 use crate::cli::routines::flow::{CreateFlowDirectory, CreateFlowFile};
-use crate::cli::routines::start::CopyOldSchema;
+use crate::cli::routines::start::{CopyOldSchema, CreateModelsVolume};
 use crate::cli::routines::version::BumpVersion;
 use crate::cli::{
     display::{Message, MessageType},
@@ -281,6 +281,11 @@ async fn top_command_handler(settings: Settings, commands: &Commands) {
                     CONTEXT.get(CTX_SESSION_ID).unwrap().clone(),
                     project_arc.name().clone()
                 );
+
+                let mut controller = RoutineController::new();
+                let run_mode = RunMode::Explicit {};
+                controller.add_routine(Box::new(CreateModelsVolume::new(project_arc.clone())));
+                controller.run_routines(run_mode);
 
                 routines::start_production_mode(project_arc).await.unwrap();
             }


### PR DESCRIPTION
Prod flow initializes a moose project before running `moose prod`: https://github.com/514-labs/moose/blob/main/apps/framework-cli/src/cli/routines/docker_packager.rs#L51C1-L51C30.

But the `init` command no longer creates a .moose/models directory: https://github.com/514-labs/moose/blob/main/apps/framework-cli/src/cli/routines/initialize.rs#L18

So `moose prod` failed with error `called Result::unwrap() on an Err value: Models directory not found`

