### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.moosejs.com/)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-MooseJS is an open source developer framework for building data & analytics applications powered by a modern data stack. Moose takes the decades-old best practices of frontend and backend developer frameworks, and brings them to your data & analytics stack.
+MooseJS is an open-source developer framework for building data & analytics applications powered by a modern data stack. Moose takes the decades-old best practices of frontend and backend developer frameworks and brings them to your data & analytics stack.
 
 # Getting started
 To get started, check out the Moose documentation: [https://docs.moosejs.com/](https://docs.moosejs.com/)
@@ -18,7 +18,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers. 
 
 # Contributing
-We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING). 
+We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md). 
 
 # Made by 514
 Our mission at [fiveonefour](https://www.fiveonefour.com/) is to bring incredible developer experiences to the data stack. If you’re interested in enterprise solutions, commercial support, or design partnerships, then we’d love to [chat with you](https://xbac8793a37.typeform.com/to/KTf5bBbr?typeform-source=www.fiveonefour.com).


### PR DESCRIPTION
fixed link to the contribution guide; typos.

NOTE, typeform link "we'd love to chat" is, I think, still set to a private typeform, and doesn't allow interaction. @tg339