### PR TITLE
Update internal moose to use latest cli

### DIFF
--- a/apps/framework-internal-app/package.json
+++ b/apps/framework-internal-app/package.json
@@ -3,10 +3,10 @@
   "version": "0.0",
   "scripts": {
     "dev": "moose-cli dev",
-    "build": "moose-cli build --docker"
+    "build": "moose-cli --version && moose-cli build --docker"
   },
   "dependencies": {},
   "devDependencies": {
-    "@514labs/moose-cli": "0.3.199"
+    "@514labs/moose-cli": "latest"
   }
 }


### PR DESCRIPTION
There was a CLI fix in https://github.com/514-labs/moose/releases/tag/v0.3.201 that's supposed to build the internal moose app as-is. But the latest deploy shows a data model is still missing. I think we need to bump the CLI version that internal moose app builds with.