### PR TITLE
chore: disable telemetry from cicd

### DIFF
--- a/.github/workflows/deploy-internal-app.yaml
+++ b/.github/workflows/deploy-internal-app.yaml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+    env:
+      MOOSE_TELEMETRY_ENABLED: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-internal-app.yaml
+++ b/.github/workflows/deploy-internal-app.yaml
@@ -21,8 +21,6 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    env:
-      MOOSE_TELEMETRY_ENABLED: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,6 +44,8 @@ jobs:
       - name: Run Build
         working-directory: ./apps/framework-internal-app
         run: pnpm run build
+        env:
+          MOOSE_TELEMETRY_ENABLED: "false"
 
       - uses: 1password/load-secrets-action@v1
         id: op-load-secret


### PR DESCRIPTION
`pnpm run build` is running `moose-cli build --docker`. We want to run that with telemetry disabled.