### PR TITLE
fix quick start doc

### DIFF
--- a/apps/framework-docs/src/pages/getting-started/new-project.mdx
+++ b/apps/framework-docs/src/pages/getting-started/new-project.mdx
@@ -43,13 +43,13 @@ There are a couple of different ways you can utilize the Moose CLI:
   <Tabs.Tab>
     Alternatively, the Moose CLI comes packaged with your Moose application. You
     can install the dependency locally and then run the Moose CLI within your
-    project with: ```txt filename="Terminal" copy npm install npm run dev ```
+    project with. ```txt filename="Terminal" copy npm install && npm run dev ```
   </Tabs.Tab>
   <Tabs.Tab>
     Finally, you can install the Moose CLI globally using NPM. This will get you
     a cleaner command interface, and better performance on the CLI. You can then
     run the Moose CLI anywhere. ```txt filename="Terminal" copy npm install -g
-    @514labs/moose-cli moose dev ```
+    @514labs/moose-cli && moose dev ```
   </Tabs.Tab>
 </Tabs>
 

--- a/apps/framework-docs/src/pages/getting-started/new-project.mdx
+++ b/apps/framework-docs/src/pages/getting-started/new-project.mdx
@@ -37,19 +37,32 @@ There are a couple of different ways you can utilize the Moose CLI:
 <Tabs items={["No Install", "Project-level Install", "Global Install"]}>
   <Tabs.Tab>
     The simplest method to run the CLI is via NPX. No extra installation is
-    necessary for this method. ```txt filename="Terminal" copy npx
-    @514labs/moose-cli dev ```
+    necessary for this method.
+
+    ```txt filename="Terminal" copy
+    npx @514labs/moose-cli dev
+    ```
+
   </Tabs.Tab>
   <Tabs.Tab>
     Alternatively, the Moose CLI comes packaged with your Moose application. You
     can install the dependency locally and then run the Moose CLI within your
-    project with. ```txt filename="Terminal" copy npm install && npm run dev ```
+    project with.
+
+    ```txt filename="Terminal" copy
+    npm install && npm run dev
+    ```
+
   </Tabs.Tab>
   <Tabs.Tab>
     Finally, you can install the Moose CLI globally using NPM. This will get you
     a cleaner command interface, and better performance on the CLI. You can then
-    run the Moose CLI anywhere. ```txt filename="Terminal" copy npm install -g
-    @514labs/moose-cli && moose dev ```
+    run the Moose CLI anywhere.
+
+    ```txt filename="Terminal" copy
+    npm install -g @514labs/moose-cli && moose dev
+    ```
+
   </Tabs.Tab>
 </Tabs>
 


### PR DESCRIPTION
What it looked like:

<img width="1072" alt="Screenshot 2024-04-12 at 10 00 30 AM" src="https://github.com/514-labs/moose/assets/7286437/3a50af8c-cf8b-43df-af0b-3b60b82520fa">
<img width="1014" alt="Screenshot 2024-04-12 at 10 00 34 AM" src="https://github.com/514-labs/moose/assets/7286437/c0c1bbe8-e074-43bf-8572-86b3176148e5">
<img width="1000" alt="Screenshot 2024-04-12 at 10 00 39 AM" src="https://github.com/514-labs/moose/assets/7286437/8fead9ce-ab88-4f37-aa1a-874f93649b39">
