### PR TITLE
Run moose dev with typescript schema

### DIFF
--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -494,7 +494,13 @@ fn ts_parse_property_signature(
         }
     };
     // match the type of the value and return the right column type
-    let TsTypeAnn { type_ann, .. } = *prop.type_ann.clone().expect("no type for property");
+    let TsTypeAnn { type_ann, .. } =
+        *prop
+            .type_ann
+            .clone()
+            .ok_or(ParsingError::UnsupportedDataTypeError {
+                type_name: "no type for property".to_string(),
+            })?;
     let data_type = ts_parse_type_ann(type_ann, enums, &mut primary_key)?;
 
     // match the optional flag
@@ -561,7 +567,7 @@ fn ts_parse_type_ref(
     }
 
     if type_ref_name == "Date" {
-        return Ok(ColumnType::DateTime);
+        Ok(ColumnType::DateTime)
     } else if is_enum_type(&type_ref_name, enums) {
         Ok(ColumnType::Enum(
             enums
@@ -575,6 +581,7 @@ fn ts_parse_type_ref(
     }
 }
 
+#[allow(clippy::vec_box)]
 fn ts_parse_union_or_intersection_type(
     union_or_intersection_type: Vec<Box<TsType>>,
     enums: &[DataEnum],

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -422,6 +422,12 @@ pub fn ts_ast_mapper(ast: Module) -> Result<FileObjects, ParsingError> {
         ModuleItem::Stmt(Stmt::Decl(Decl::TsInterface(decl))) => {
             ts_declarations.push(decl);
         }
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+            decl: Decl::TsEnum(decl),
+            ..
+        })) => {
+            enums.push(ts_enum_to_data_enum(decl));
+        }
         ModuleItem::Stmt(Stmt::Decl(Decl::TsEnum(decl))) => {
             enums.push(ts_enum_to_data_enum(decl));
         }
@@ -502,6 +508,11 @@ fn ts_parse_property_signature(
                 type_name: "no type for property".to_string(),
             })?;
     let data_type = ts_parse_type_ann(type_ann, enums, &mut primary_key)?;
+
+    println!(
+        "name: {}, data_type: {:?}, primary_key: {:?}",
+        name, data_type, primary_key
+    );
 
     // match the optional flag
     let arity = FieldArity::Required;

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -25,7 +25,7 @@ use std::{
 use crate::framework::controller::FrameworkObject;
 use diagnostics::Diagnostics;
 
-use log::{debug, info};
+use log::debug;
 use schema_ast::ast::{Enum, Model};
 use schema_ast::{
     ast::{Attribute, Field, SchemaAst, Top, WithName},
@@ -38,8 +38,9 @@ use crate::project::PROJECT;
 
 use swc_common::{self, sync::Lrc, SourceMap};
 use swc_ecma_ast::{
-    Decl, Expr, Module, ModuleItem, Stmt, TsEnumDecl, TsEnumMember, TsEnumMemberId,
-    TsInterfaceDecl, TsKeywordTypeKind, TsType, TsTypeAnn, TsTypeRef,
+    Decl, ExportDecl, Expr, Module, ModuleDecl, ModuleItem, Stmt, TsEnumDecl, TsEnumMember,
+    TsEnumMemberId, TsInterfaceDecl, TsIntersectionType, TsKeywordTypeKind, TsPropertySignature,
+    TsType, TsTypeAnn, TsTypeRef, TsUnionOrIntersectionType, TsUnionType,
 };
 use swc_ecma_parser::{lexer::Lexer, Capturing, Parser, StringInput, Syntax};
 
@@ -406,13 +407,18 @@ pub fn prisma_ast_mapper(ast: SchemaAst) -> Result<FileObjects, ParsingError> {
 }
 
 pub fn ts_ast_mapper(ast: Module) -> Result<FileObjects, ParsingError> {
-    let models = Vec::new();
     let mut enums = Vec::new();
 
     let mut ts_declarations = Vec::new();
 
     // collect all inteface and enum declarations
     ast.body.iter().for_each(|item| match item {
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+            decl: Decl::TsInterface(decl),
+            ..
+        })) => {
+            ts_declarations.push(decl);
+        }
         ModuleItem::Stmt(Stmt::Decl(Decl::TsInterface(decl))) => {
             ts_declarations.push(decl);
         }
@@ -422,12 +428,12 @@ pub fn ts_ast_mapper(ast: Module) -> Result<FileObjects, ParsingError> {
         _ => {}
     });
 
-    info!(
-        "the interfaces {:#?}",
-        ts_interface_to_model(ts_declarations[0], &enums)
-    );
+    let parsed_models = ts_declarations
+        .into_iter()
+        .map(|m| ts_interface_to_model(m, &enums))
+        .collect::<Result<Vec<DataModel>, ParsingError>>()?;
 
-    Ok(FileObjects::new(models, enums))
+    Ok(FileObjects::new(parsed_models, enums))
 }
 
 fn ts_enum_to_data_enum(enum_decl: &TsEnumDecl) -> DataEnum {
@@ -457,69 +463,141 @@ fn ts_interface_to_model(
         .body
         .iter()
         .filter_map(|field| match field {
-            swc_ecma_ast::TsTypeElement::TsPropertySignature(prop) => Some({
-                // match the key's sym if it's an ident
-                let name = match *prop.key.clone() {
-                    Expr::Ident(ident) => ident.sym.to_string(),
-                    _ => return None,
-                };
-                // match the type of the value and return the right column type
-                let TsTypeAnn { type_ann, .. } =
-                    *prop.type_ann.clone().expect("no type for property");
-                let data_type = match *type_ann {
-                    TsType::TsKeywordType(keyword) => match keyword.kind {
-                        TsKeywordTypeKind::TsStringKeyword => ColumnType::String,
-                        TsKeywordTypeKind::TsBooleanKeyword => ColumnType::Boolean,
-                        TsKeywordTypeKind::TsNumberKeyword => ColumnType::Float,
-
-                        _ => {
-                            debug!("found a weird type{:?}", keyword);
-                            ColumnType::Unsupported
-                        }
-                    },
-                    // match the enum type as a tstyperef
-                    TsType::TsTypeRef(TsTypeRef { type_name, .. }) => {
-                        let enum_name = match type_name {
-                            swc_ecma_ast::TsEntityName::Ident(ident) => ident.sym.to_string(),
-                            _ => {
-                                debug!("found a weird type{:?}", type_name);
-                                "unsupported".to_string()
-                            }
-                        };
-                        ColumnType::Enum(
-                            enums.iter().find(|e| e.name == enum_name).unwrap().clone(),
-                        )
-                    }
-                    _ => {
-                        debug!("found a weird type{:?}", type_ann);
-                        ColumnType::Unsupported
-                    }
-                };
-
-                // match the optional flag
-                let arity = FieldArity::Required;
-                let unique = false;
-                let primary_key = false;
-                let default = None;
-
-                Ok(Column {
-                    name,
-                    data_type,
-                    arity,
-                    unique,
-                    primary_key,
-                    default,
-                })
-            }),
+            swc_ecma_ast::TsTypeElement::TsPropertySignature(prop) => {
+                Some(ts_parse_property_signature(prop, enums))
+            }
             _ => None,
         })
         .collect();
 
+    let project = PROJECT.lock().unwrap();
     Ok(DataModel {
-        db_name: "local".to_string(),
+        db_name: project.clickhouse_config.db_name.to_string(),
         columns: columns?,
         name: schema_name,
     })
+}
+
+fn ts_parse_property_signature(
+    prop: &TsPropertySignature,
+    enums: &[DataEnum],
+) -> Result<Column, ParsingError> {
+    let mut primary_key = false;
+
+    // match the key's sym if it's an ident
+    let name = match *prop.key.clone() {
+        Expr::Ident(ident) => ident.sym.to_string(),
+        _ => {
+            return Err(ParsingError::UnsupportedDataTypeError {
+                type_name: "unsupported".to_string(),
+            })
+        }
+    };
+    // match the type of the value and return the right column type
+    let TsTypeAnn { type_ann, .. } = *prop.type_ann.clone().expect("no type for property");
+    let data_type = ts_parse_type_ann(type_ann, enums, &mut primary_key)?;
+
+    // match the optional flag
+    let arity = FieldArity::Required;
+    let unique = false;
+    let default = None;
+
+    Ok(Column {
+        name,
+        data_type,
+        arity,
+        unique,
+        primary_key,
+        default,
+    })
+}
+
+fn ts_parse_type_ann(
+    type_ann: Box<TsType>,
+    enums: &[DataEnum],
+    primary_key: &mut bool,
+) -> Result<ColumnType, ParsingError> {
+    match *type_ann {
+        TsType::TsKeywordType(keyword) => ts_parse_keyword_type(keyword),
+        TsType::TsTypeRef(type_ref) => ts_parse_type_ref(type_ref, enums, primary_key),
+        TsType::TsUnionOrIntersectionType(
+            TsUnionOrIntersectionType::TsIntersectionType(TsIntersectionType { types, .. })
+            | TsUnionOrIntersectionType::TsUnionType(TsUnionType { types, .. }),
+        ) => ts_parse_union_or_intersection_type(types, enums, primary_key),
+        _ => {
+            debug!("found a weird type {:?}", type_ann);
+            Ok(ColumnType::Unsupported)
+        }
+    }
+}
+
+fn ts_parse_keyword_type(keyword: swc_ecma_ast::TsKeywordType) -> Result<ColumnType, ParsingError> {
+    match keyword.kind {
+        TsKeywordTypeKind::TsStringKeyword => Ok(ColumnType::String),
+        TsKeywordTypeKind::TsBooleanKeyword => Ok(ColumnType::Boolean),
+        TsKeywordTypeKind::TsNumberKeyword => Ok(ColumnType::Float),
+        _ => {
+            debug!("found a weird type {:?}", keyword);
+            Ok(ColumnType::Unsupported)
+        }
+    }
+}
+
+fn ts_parse_type_ref(
+    type_ref: TsTypeRef,
+    enums: &[DataEnum],
+    primary_key: &mut bool,
+) -> Result<ColumnType, ParsingError> {
+    let type_ref_name = match type_ref.type_name {
+        swc_ecma_ast::TsEntityName::Ident(ident) => ident.sym.to_string(),
+        _ => {
+            debug!("found a weird type {:?}", type_ref.type_name);
+            "unsupported".to_string()
+        }
+    };
+
+    if type_ref_name == "Key" {
+        *primary_key = true;
+    }
+
+    if type_ref_name == "Date" {
+        return Ok(ColumnType::DateTime);
+    } else if is_enum_type(&type_ref_name, enums) {
+        Ok(ColumnType::Enum(
+            enums
+                .iter()
+                .find(|e| e.name == type_ref_name)
+                .unwrap()
+                .clone(),
+        ))
+    } else {
+        Ok(ColumnType::Unsupported)
+    }
+}
+
+fn ts_parse_union_or_intersection_type(
+    union_or_intersection_type: Vec<Box<TsType>>,
+    enums: &[DataEnum],
+    primary_key: &mut bool,
+) -> Result<ColumnType, ParsingError> {
+    let union_type: Vec<ColumnType> = union_or_intersection_type
+        .iter()
+        .map(|t| match &**t {
+            TsType::TsKeywordType(keyword) => ts_parse_keyword_type(keyword.clone()).unwrap(),
+            TsType::TsTypeRef(type_ref) => {
+                ts_parse_type_ref(type_ref.clone(), enums, primary_key).unwrap()
+            }
+            _ => {
+                debug!("found a weird type {:?}", t);
+                ColumnType::Unsupported
+            }
+        })
+        .collect();
+
+    Ok(union_type
+        .first()
+        .cloned()
+        .unwrap_or(ColumnType::Unsupported))
 }
 
 pub fn parse_ts_schema_file(path: &Path) -> Module {
@@ -583,6 +661,7 @@ mod tests {
 
         let result = parse_ts_schema_file(&test_file);
         println!("{:#?}", result);
+        let _ = ts_ast_mapper(result);
         assert!(true);
     }
 

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -38,9 +38,8 @@ use crate::project::PROJECT;
 
 use swc_common::{self, sync::Lrc, SourceMap};
 use swc_ecma_ast::{
-    Decl, ExportDecl, Expr, Module, ModuleDecl, ModuleItem, Stmt, TsEnumDecl, TsEnumMember,
-    TsEnumMemberId, TsInterfaceDecl, TsKeywordTypeKind, TsPropertySignature, TsType, TsTypeAnn,
-    TsTypeRef,
+    Decl, ExportDecl, Expr, Module, ModuleDecl, ModuleItem, Stmt, TsEnumDecl, TsEnumMemberId,
+    TsInterfaceDecl, TsKeywordTypeKind, TsPropertySignature, TsType, TsTypeAnn, TsTypeRef,
 };
 use swc_ecma_parser::{lexer::Lexer, Capturing, Parser, StringInput, Syntax};
 
@@ -447,12 +446,9 @@ fn ts_enum_to_data_enum(enum_decl: &TsEnumDecl) -> DataEnum {
     let values = enum_decl
         .members
         .iter()
-        .map(|member| match member {
-            TsEnumMember {
-                id: TsEnumMemberId::Ident(ident),
-                ..
-            } => ident.sym.to_string(),
-            _ => "unsupported".to_string(),
+        .map(|member| match &member.id {
+            TsEnumMemberId::Ident(ident) => ident.sym.to_string(),
+            TsEnumMemberId::Str(str) => str.value.to_string(),
         })
         .collect();
     DataEnum { name, values }

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -560,6 +560,7 @@ fn ts_parse_keyword_type(keyword: swc_ecma_ast::TsKeywordType) -> Result<ColumnT
     }
 }
 
+#[allow(clippy::needless_return_with_question_mark)]
 fn ts_parse_type_ref(
     type_ref: TsTypeRef,
     enums: &[DataEnum],

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -489,6 +489,8 @@ fn ts_parse_property_signature(
     enums: &[DataEnum],
 ) -> Result<Column, ParsingError> {
     let mut primary_key = false;
+    let unique = false;
+    let default = None;
 
     // match the key's sym if it's an ident
     let name = match *prop.key.clone() {
@@ -499,6 +501,13 @@ fn ts_parse_property_signature(
             })
         }
     };
+
+    // match the optional flag
+    let arity = match prop.optional {
+        true => FieldArity::Optional,
+        false => FieldArity::Required,
+    };
+
     // match the type of the value and return the right column type
     let TsTypeAnn { type_ann, .. } =
         *prop
@@ -509,15 +518,10 @@ fn ts_parse_property_signature(
             })?;
     let data_type = ts_parse_type_ann(type_ann, enums, &mut primary_key)?;
 
-    println!(
-        "name: {}, data_type: {:?}, primary_key: {:?}",
-        name, data_type, primary_key
+    debug!(
+        "name: {}, data_type: {:?}, primary_key: {:?}, arity: {:?}",
+        name, data_type, primary_key, arity
     );
-
-    // match the optional flag
-    let arity = FieldArity::Required;
-    let unique = false;
-    let default = None;
 
     Ok(Column {
         name,
@@ -679,7 +683,6 @@ mod tests {
 
         let result = parse_ts_schema_file(&test_file);
         println!("{:#?}", result);
-        let _ = ts_ast_mapper(result);
         assert!(true);
     }
 

--- a/apps/framework-cli/src/framework/schema.rs
+++ b/apps/framework-cli/src/framework/schema.rs
@@ -410,27 +410,23 @@ pub fn ts_ast_mapper(ast: Module) -> Result<FileObjects, ParsingError> {
 
     let mut ts_declarations = Vec::new();
 
-    // collect all inteface and enum declarations
-    ast.body.iter().for_each(|item| match item {
-        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-            decl: Decl::TsInterface(decl),
-            ..
-        })) => {
-            ts_declarations.push(decl);
+    // collect all interface and enum declarations
+    ast.body.iter().for_each(|item| {
+        let decl = match item {
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { decl, .. }))
+            | ModuleItem::Stmt(Stmt::Decl(decl)) => decl,
+            _ => return,
+        };
+
+        match decl {
+            Decl::TsInterface(decl) => {
+                ts_declarations.push(decl);
+            }
+            Decl::TsEnum(decl) => {
+                enums.push(ts_enum_to_data_enum(decl));
+            }
+            _ => {}
         }
-        ModuleItem::Stmt(Stmt::Decl(Decl::TsInterface(decl))) => {
-            ts_declarations.push(decl);
-        }
-        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-            decl: Decl::TsEnum(decl),
-            ..
-        })) => {
-            enums.push(ts_enum_to_data_enum(decl));
-        }
-        ModuleItem::Stmt(Stmt::Decl(Decl::TsEnum(decl))) => {
-            enums.push(ts_enum_to_data_enum(decl));
-        }
-        _ => {}
     });
 
     let parsed_models = ts_declarations

--- a/apps/framework-cli/tests/ts/extend.m.ts
+++ b/apps/framework-cli/tests/ts/extend.m.ts
@@ -1,13 +1,10 @@
-export interface Base {
-  id: string;
-}
+type Key<T extends string | number> = T;
 
-type Key = string;
+export interface Base {
+  id: Key<string>;
+}
 
 interface User extends Base {
   name: string;
   email: string;
-  id: Key;
 }
-
-type UserKey = User["id" & "name"];

--- a/apps/framework-cli/tests/ts/simple.ts
+++ b/apps/framework-cli/tests/ts/simple.ts
@@ -8,4 +8,6 @@ interface MyModel {
   name: string;
   age: number;
   abc: MyEnum;
+  flag: boolean;
+  opt?: string;
 }

--- a/apps/framework-cli/tests/ts/simple.ts
+++ b/apps/framework-cli/tests/ts/simple.ts
@@ -1,3 +1,5 @@
+type Key<T extends string | number> = T;
+
 enum MyEnum {
   A,
   B,
@@ -5,7 +7,7 @@ enum MyEnum {
 }
 
 interface MyModel {
-  name: string;
+  name: Key<string>;
   age: number;
   abc: MyEnum;
   flag: boolean;


### PR DESCRIPTION
This allows us to run moose with typescript schema. The sdk is also generated. I tested with a schema like this:

```
type Key<T extends string | number> = T;

export interface UserActivity {
    eventId: Key<string>;
    timestamp: Date;
    userId: string;
    activity: string;
}

export interface ParsedActivity {
    eventId: Key<string>;
    timestamp: Date;
    userId: string;
    activity: string;
}

export enum MyEnum {
    A, B, C
}

export interface MyTsModel {
    id: Key<number>;
    age: number;
    flag: boolean;
    abc: MyEnum;
    opt?: string;
}
```

There are still some todos, like handling more enum cases brought up in the original PR. I believe those are tracked in https://linear.app/514/issue/514-624/support-enum-values. I also created a ticket for figuring out how we want the user to import Key https://linear.app/514/issue/514-854/investigate-moose-utils-package. 