### PR TITLE
lower case project name for docker compose

### DIFF
--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -131,7 +131,7 @@ fn compose_command(project: &Project) -> Command {
         .arg("-f")
         .arg(project.internal_dir().unwrap().join("docker-compose.yml"))
         .arg("-p")
-        .arg(project.name());
+        .arg(project.name().to_lowercase());
     command
 }
 


### PR DESCRIPTION
```
invalid project name "MagicStuff": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number
```