### PR TITLE
multiple versions SDK

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -503,10 +503,8 @@ async fn initialize_project_state(
 
         // TODO: add old versions to SDK
         if !PROJECT.lock().unwrap().is_production {
-            let sdk_location = typescript::generator::generate_sdk(
-                &project,
-                &framework_object_versions.current_models.typescript_objects,
-            )?;
+            let sdk_location =
+                typescript::generator::generate_sdk(&project, &framework_object_versions)?;
             let package_manager = package_managers::PackageManager::Npm;
             package_managers::install_packages(&sdk_location, &package_manager)?;
             package_managers::run_build(&sdk_location, &package_manager)?;

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -207,10 +207,7 @@ async fn process_events(
             .insert(fo.data_model.name.clone(), fo);
     }
 
-    let sdk_location = typescript::generator::generate_sdk(
-        &project,
-        &framework_object_versions.current_models.typescript_objects,
-    )?;
+    let sdk_location = typescript::generator::generate_sdk(&project, framework_object_versions)?;
 
     let package_manager = package_managers::PackageManager::Npm;
     package_managers::install_packages(&sdk_location, &package_manager)?;

--- a/apps/framework-cli/src/framework/typescript/templates.rs
+++ b/apps/framework-cli/src/framework/typescript/templates.rs
@@ -71,8 +71,7 @@ impl InterfaceTemplate {
     }
 }
 
-pub static SEND_FUNC_TEMPLATE: &str = r#"
-import \{ {interface_context.name} } from './{interface_context.file_name}';
+pub static SEND_FUNC_TEMPLATE: &str = r#"import \{ {interface_context.name} } from './{interface_context.file_name}';
 
 export async function {declaration_name}({interface_context.var_name}: {interface_context.name}) \{
     return fetch('{server_url}/{api_route_name}', \{
@@ -127,10 +126,9 @@ impl SendFunctionTemplate {
     }
 }
 
-pub static INDEX_TEMPLATE: &str = r#"
-{{- for ts_object in ts_objects}}
-import \{ {ts_object.interface_context.name} } from './{ts_object.interface_context.name}';
-import \{ {ts_object.send_function_context.declaration_name} } from './{ts_object.send_function_context.file_name}';
+pub static INDEX_TEMPLATE: &str = r#"{{- for ts_object in ts_objects}}
+import \{ {ts_object.interface_context.name} } from './{latest_version}/{ts_object.interface_context.name}';
+import \{ {ts_object.send_function_context.declaration_name} } from './{latest_version}/{ts_object.send_function_context.file_name}';
 {{endfor}}
 
 {{for ts_object in ts_objects}}
@@ -160,11 +158,16 @@ impl TypescriptObjectsContext {
 
 #[derive(Serialize)]
 struct IndexContext {
+    latest_version: String,
     ts_objects: Vec<TypescriptObjectsContext>,
 }
 impl IndexContext {
-    fn new(ts_objects: &HashMap<String, TypescriptObjects>) -> IndexContext {
+    fn new(
+        latest_version: String,
+        ts_objects: &HashMap<String, TypescriptObjects>,
+    ) -> IndexContext {
         IndexContext {
+            latest_version,
             ts_objects: ts_objects
                 .values()
                 .map(TypescriptObjectsContext::new)
@@ -175,10 +178,13 @@ impl IndexContext {
 pub struct IndexTemplate;
 
 impl IndexTemplate {
-    pub fn build(ts_objects: &HashMap<String, TypescriptObjects>) -> String {
+    pub fn build(
+        latest_version: &str,
+        latest_objects: &HashMap<String, TypescriptObjects>,
+    ) -> String {
         let mut tt = TinyTemplate::new();
         tt.add_template("index", INDEX_TEMPLATE).unwrap();
-        let context = IndexContext::new(ts_objects);
+        let context = IndexContext::new(latest_version.to_string(), latest_objects);
 
         tt.render("index", &context).unwrap()
     }

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -117,7 +117,7 @@ pub fn stop_containers(project: &Project) -> anyhow::Result<()> {
             "Failed to stop containers: {}",
             String::from_utf8_lossy(&output.stderr)
         );
-        Err(anyhow::anyhow!("Failed to strop containers"))
+        Err(anyhow::anyhow!("Failed to stop containers"))
     } else {
         Ok(())
     }
@@ -200,7 +200,11 @@ pub fn create_compose_file(project: &Project) -> std::io::Result<()> {
 pub fn run_rpk_cluster_info(project_name: &str) -> anyhow::Result<()> {
     let child = Command::new("docker")
         .arg("exec")
-        .arg(format!("{}-{}", project_name, REDPANDA_CONTAINER_NAME))
+        .arg(format!(
+            "{}-{}",
+            project_name.to_lowercase(),
+            REDPANDA_CONTAINER_NAME
+        ))
         .arg("rpk")
         .arg("cluster")
         .arg("info")
@@ -215,7 +219,7 @@ pub fn run_rpk_cluster_info(project_name: &str) -> anyhow::Result<()> {
             "Failed to stop containers: {}",
             String::from_utf8_lossy(&output.stderr)
         );
-        Err(anyhow::anyhow!("Failed to strop containers"))
+        Err(anyhow::anyhow!("Failed to stop containers"))
     } else {
         Ok(())
     }


### PR DESCRIPTION
With deno, we can write

```ts
import { UserActivity as UserActivityOld } from "sdk/0.0/UserActivity.ts";
import { UserActivity as UserActivityNew } from "sdk/0.1/UserActivity.ts";
```

if we have `deno.json`

```json
{
  "imports": {
    "sdk/": "./.moose/test-flow-sdk/"
  }
}
```

---

In another node project, I've tried `import {UserActivity as UserActivityOld } from 'test-flow-sdk/0.0/UserActivity'` with

```
  "dependencies": {
    "test-flow-sdk": "file:../test-flow/.moose/test-flow-sdk"
  }
```

in `package.json`.