### PR TITLE
moose logs command

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -24,6 +24,7 @@ use settings::{read_settings, Settings};
 use crate::cli::routines::aggregation::create_aggregation_file;
 use crate::cli::routines::dev::{copy_old_schema, create_deno_files, create_models_volume};
 use crate::cli::routines::flow::{create_flow_directory, create_flow_file};
+use crate::cli::routines::logs::{follow_logs, show_logs};
 use crate::cli::routines::templates;
 use crate::cli::routines::version::BumpVersion;
 use crate::cli::routines::{RoutineFailure, RoutineSuccess};
@@ -429,6 +430,27 @@ async fn top_command_handler(
                         "Aggregation".to_string(),
                     )))
                 }
+            }
+        }
+        Commands::Logs { tail, filter } => {
+            info!("Running logs command");
+
+            let project = load_project()?;
+            let project_arc = Arc::new(project);
+
+            crate::utilities::capture::capture!(
+                ActivityType::LogsCommand,
+                project_arc.name().clone(),
+                &settings
+            );
+
+            let log_file_path = settings.logger.log_file.clone();
+            let filter_value = filter.clone().unwrap_or_else(|| "".to_string());
+
+            if *tail {
+                follow_logs(log_file_path, filter_value)
+            } else {
+                show_logs(log_file_path, filter_value)
             }
         }
     }

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -63,6 +63,16 @@ pub enum Commands {
     Flow(FlowArgs),
     /// Defines aggregate table views of upstream data models
     Aggregation(AggregationArgs),
+    /// View Moose logs
+    Logs {
+        /// Follow the logs in real-time
+        #[arg(short, long)]
+        tail: bool,
+
+        /// Filter logs by a specific string
+        #[arg(short, long)]
+        filter: Option<String>,
+    },
 }
 
 #[derive(Debug, Args)]

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -115,6 +115,7 @@ pub mod dev;
 pub mod docker_packager;
 pub mod flow;
 pub mod initialize;
+pub mod logs;
 pub mod migrate;
 pub mod stop;
 pub mod templates;

--- a/apps/framework-cli/src/cli/routines/logs.rs
+++ b/apps/framework-cli/src/cli/routines/logs.rs
@@ -1,0 +1,94 @@
+use std::{
+    io::{BufRead, BufReader},
+    process::{Command, Stdio},
+};
+
+use crate::cli::display::{Message, MessageType};
+
+use super::{RoutineFailure, RoutineSuccess};
+
+pub fn show_logs(log_file_path: String, filter: String) -> Result<RoutineSuccess, RoutineFailure> {
+    let child = Command::new("tail")
+        .arg(log_file_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| {
+            RoutineFailure::new(
+                Message::new("Failed".to_string(), "to show logs".to_string()),
+                err,
+            )
+        })?;
+
+    let output = child.wait_with_output().map_err(|err| {
+        RoutineFailure::new(
+            Message::new("Failed".to_string(), "to show logs".to_string()),
+            err,
+        )
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines = stdout.lines().filter(|line| line.contains(&filter));
+    for line in lines {
+        show_message!(
+            MessageType::Info,
+            Message {
+                action: "Log".to_string(),
+                details: line.to_string(),
+            }
+        );
+    }
+
+    Ok(RoutineSuccess::success(Message::new(
+        "".to_string(),
+        "".to_string(),
+    )))
+}
+
+pub fn follow_logs(
+    log_file_path: String,
+    filter: String,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    let child = Command::new("tail")
+        .arg("-f")
+        .arg(log_file_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| {
+            RoutineFailure::new(
+                Message::new("Failed".to_string(), "to show logs".to_string()),
+                err,
+            )
+        })?;
+
+    if let Some(out) = child.stdout {
+        let reader = BufReader::new(out);
+        for line_result in reader.lines() {
+            let line = match line_result {
+                Ok(line) => line,
+                Err(err) => {
+                    return Err(RoutineFailure::new(
+                        Message::new("Failed".to_string(), "to read line from logs".to_string()),
+                        err,
+                    ))
+                }
+            };
+
+            if line.contains(&filter) {
+                show_message!(
+                    MessageType::Info,
+                    Message {
+                        action: "Log".to_string(),
+                        details: line.clone(),
+                    }
+                );
+            }
+        }
+    }
+
+    Ok(RoutineSuccess::success(Message::new(
+        "".to_string(),
+        "".to_string(),
+    )))
+}

--- a/apps/framework-cli/src/utilities/capture.rs
+++ b/apps/framework-cli/src/utilities/capture.rs
@@ -35,6 +35,8 @@ pub enum ActivityType {
     InitCommand,
     #[serde(rename = "initTemplateCommand")]
     InitTemplateCommand,
+    #[serde(rename = "logsCommand")]
+    LogsCommand,
     #[serde(rename = "prodCommand")]
     ProdCommand,
     #[serde(rename = "stopCommand")]

--- a/apps/framework-docs/src/pages/moose-cli.mdx
+++ b/apps/framework-docs/src/pages/moose-cli.mdx
@@ -105,3 +105,11 @@ Clears all temporary data and stops development infrastructure.
 ```txt filename="Terminal" copy
 moose clean
 ```
+
+### Logs
+
+View logs to help debug how data moves through Moose.
+
+```txt filename="Terminal" copy
+moose logs <--tail> <--filter <search_string>>
+```


### PR DESCRIPTION
The default for `moose-cli logs` dumps the last few lines. Can add a `--filter <string>` or `--tail` or both. E.g:

<img width="1226" alt="Screenshot 2024-05-02 at 12 29 42 PM" src="https://github.com/514-labs/moose/assets/7286437/5aed6724-0edc-46de-86d3-54c401e9bc94">
