### PR TITLE
fix typo and relative path changed to absolute path for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.moosejs.com/"><img src="logo-m-light.png" alt="moose logo" height="100px"></a>
+<a href="https://www.moosejs.com/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
 # MooseJS
 
@@ -7,9 +7,10 @@
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.moosejs.com/)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[MooseJS](https://www.moosejs.com/) is an open-source developer framework for your data & analytics stack. Moose is intended for any application where collecting data, processing data, and extracting insights from that data is at the heart of the application. Moose tries to take the decades-old best practices of frontend and backend developer frameworks, and bring them to the world of developing data-driven applications. 
+[MooseJS](https://www.moosejs.com/) is an open-source developer framework for your data & analytics stack. Moose is intended for any application where collecting data, processing data, and extracting insights from that data is at the heart of the application. Moose tries to take the decades-old best practices of frontend and backend developer frameworks, and bring them to the world of developing data-driven applications.
 
 **Highlights**
+
 - Abstract away middleware and infrastructure complexity: expertise in the data engineering ecosystem not required. MooseJS automatically configures your data stack based on the business logic of your code.
 - Developer-first: Develop in languages you know, in the IDE of your choice. Git-based based workflows for version control and change management. Plug into CI/CD and automated testing workflows. Iterate quickly with local development, then scale to the cloud
 - Hot-reload local dev server: run your whole data/analytics stack locally, and see the impact of changes in real time as you edit code - just like developing a web application
@@ -18,18 +19,23 @@
 - Data product APIs: Moose automatically creates API endpoints for your data products, and generates SDKs in the languages of your choice for easy discovery and consumption
 
 # Getting started
+
 To learn more and/or get started using Moose, check out the documentation: [https://docs.moosejs.com/](https://docs.moosejs.com/)
 
 # Alpha release
-Moose is still in Alpha, and is not yet recommended for critical production use cases. That being said, we’d love for you to get your hands on it and try it out. Moose is in active development, and we’re looking for feedback and insights on how to harden and improve, as we build towards the Beta release. You can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below. 
+
+Moose is still in Alpha, and is not yet recommended for critical production use cases. That being said, we’d love for you to get your hands on it and try it out. Moose is in active development, and we’re looking for feedback and insights on how to harden and improve, as we build towards the Beta release. You can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
 
 # Community
+
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg).
 
-Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers. 
+Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
 
 # Contributing
-We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md). 
+
+We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).
 
 # Made by 514
+
 Our mission at [fiveonefour](https://www.fiveonefour.com/) is to bring incredible developer experiences to the data stack. If you’re interested in enterprise solutions, commercial support, or design partnerships, then we’d love to [chat with you](https://fiveonefour.typeform.com/signup).

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -420,7 +420,7 @@ impl Webserver {
             MessageType::Success,
             Message {
                 action: "Started".to_string(),
-                details: "deveopment server.\n\n".to_string(),
+                details: "Development server.\n\n".to_string(),
             }
         );
 


### PR DESCRIPTION
* Changes the relative image url for the logo to be the absolute path so that it doesn't break when using the readme in templates
* Fixes a typo when starting the dev server