### PR TITLE
fix: properly error when there is a problem with initializing using the user home directory

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -249,7 +249,7 @@ async fn top_command_handler(
 
             let project = load_project()?;
 
-            let _ = project.set_enviroment(false);
+            project.set_enviroment(false);
             let project_arc = Arc::new(project);
 
             crate::utilities::capture::capture!(
@@ -303,7 +303,7 @@ async fn top_command_handler(
             info!("Running prod command");
             let project = load_project()?;
 
-            let _ = project.set_enviroment(true);
+            project.set_enviroment(true);
             let project_arc = Arc::new(project);
 
             crate::utilities::capture::capture!(

--- a/apps/framework-cli/src/cli/routines/dev.rs
+++ b/apps/framework-cli/src/cli/routines/dev.rs
@@ -3,7 +3,6 @@ use std::fs;
 
 use crate::cli::display::with_spinner;
 use crate::cli::routines::util::ensure_docker_running;
-use crate::framework::languages::create_models_dir;
 use crate::utilities::constants::{
     AGGREGATIONS_CONTAINER_NAME, CLI_PROJECT_INTERNAL_DIR, CONSUMPTION_CONTAINER_NAME,
     FLOWS_CONTAINER_NAME,
@@ -23,7 +22,6 @@ use super::{
 
 pub fn run_local_infrastructure(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
     create_deno_files(project)?;
-    create_models_volume(project)?;
     create_docker_compose_file(project)?;
 
     copy_old_schema(project)?;
@@ -136,21 +134,10 @@ pub fn copy_old_schema(project: &Project) -> Result<RoutineSuccess, RoutineFailu
 
 pub fn create_deno_files(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
     project.create_deno_files().map_err(|err| {
-        RoutineFailure::new(Message::new("Failed".to_string(), "".to_string()), err)
-    })?;
-
-    Ok(RoutineSuccess::success(Message::new(
-        "Created".to_string(),
-        "deno files".to_string(),
-    )))
-}
-
-pub fn create_models_volume(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
-    create_models_dir(project).map_err(|err| {
         RoutineFailure::new(
             Message::new(
                 "Failed".to_string(),
-                format!("to create models volume in {}", err),
+                "to setup internal files, check your folder permissions or contact us.".to_string(),
             ),
             err,
         )
@@ -158,7 +145,7 @@ pub fn create_models_volume(project: &Project) -> Result<RoutineSuccess, Routine
 
     Ok(RoutineSuccess::success(Message::new(
         "Created".to_string(),
-        "Models volume".to_string(),
+        "deno files".to_string(),
     )))
 }
 

--- a/apps/framework-cli/src/cli/routines/initialize.rs
+++ b/apps/framework-cli/src/cli/routines/initialize.rs
@@ -1,68 +1,38 @@
-use std::sync::Arc;
-
 use crate::utilities::constants::{SAMPLE_FLOWS_DEST, SAMPLE_FLOWS_SOURCE};
 use crate::{cli::display::Message, project::Project};
 
 use super::flow::create_flow_directory;
-use super::{Routine, RoutineFailure, RoutineSuccess, RunMode};
+use super::{RoutineFailure, RoutineSuccess};
 
-pub struct InitializeProject {
-    run_mode: RunMode,
-    project: Arc<Project>,
-}
-impl InitializeProject {
-    pub fn new(run_mode: RunMode, project: Arc<Project>) -> Self {
-        Self { run_mode, project }
-    }
-}
-impl Routine for InitializeProject {
-    fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
-        let run_mode: RunMode = self.run_mode;
+pub fn initialize_project(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
+    project.setup_app_dir().map_err(|err| {
+        RoutineFailure::new(
+            Message::new(
+                "Failed".to_string(),
+                "to create 'app' directory. Check permissions or contact us`".to_string(),
+            ),
+            err,
+        )
+    })?;
 
-        self.project.setup_app_dir().map_err(|err| {
-            RoutineFailure::new(
-                Message::new(
-                    "Failed".to_string(),
-                    "to create app directory. Check permissions or contact us`".to_string(),
-                ),
-                err,
-            )
-        })?;
+    create_flow_directory(
+        project,
+        SAMPLE_FLOWS_SOURCE.to_string(),
+        SAMPLE_FLOWS_DEST.to_string(),
+    )?;
 
-        create_flow_directory(
-            &self.project,
-            SAMPLE_FLOWS_SOURCE.to_string(),
-            SAMPLE_FLOWS_DEST.to_string(),
-        )?;
+    project.create_base_app_files().map_err(|err| {
+        RoutineFailure::new(
+            Message::new(
+                "Failed".to_string(),
+                "to create 'app' files, Check permissions or contact us".to_string(),
+            ),
+            err,
+        )
+    })?;
 
-        CreateBaseAppFiles::new(self.project.clone()).run(run_mode)?;
-
-        Ok(RoutineSuccess::info(Message::new(
-            "Created".to_string(),
-            "Moose app with file scaffolding".to_string(),
-        )))
-    }
-}
-
-pub struct CreateBaseAppFiles {
-    project: Arc<Project>,
-}
-
-impl CreateBaseAppFiles {
-    pub fn new(project: Arc<Project>) -> Self {
-        Self { project }
-    }
-}
-
-impl Routine for CreateBaseAppFiles {
-    fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
-        self.project.create_base_app_files().map_err(|err| {
-            RoutineFailure::new(Message::new("Failed".to_string(), "".to_string()), err)
-        })?;
-
-        Ok(RoutineSuccess::info(Message::new(
-            "Created".to_string(),
-            "base app files".to_string(),
-        )))
-    }
+    Ok(RoutineSuccess::info(Message::new(
+        "Created".to_string(),
+        "starting `app` files".to_string(),
+    )))
 }

--- a/apps/framework-cli/src/framework/languages.rs
+++ b/apps/framework-cli/src/framework/languages.rs
@@ -1,10 +1,5 @@
-use std::io::{Error, ErrorKind};
-use std::path::PathBuf;
-
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
-
-use crate::project::Project;
 
 #[derive(ValueEnum, Copy, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum SupportedLanguages {
@@ -30,25 +25,5 @@ impl std::str::FromStr for SupportedLanguages {
             "ts" => Ok(SupportedLanguages::Typescript),
             _ => Err(format!("{} is not a supported language", s)),
         }
-    }
-}
-
-pub fn create_models_dir(project: &Project) -> Result<PathBuf, std::io::Error> {
-    let internal_dir = project.internal_dir()?;
-    std::fs::create_dir_all(internal_dir.join("models").clone())?;
-    Ok(internal_dir)
-}
-
-pub fn get_models_dir(project: &Project) -> Result<PathBuf, std::io::Error> {
-    let internal_dir = project.internal_dir()?;
-    let models_dir = internal_dir.join("models");
-
-    if models_dir.exists() {
-        Ok(models_dir)
-    } else {
-        Err(Error::new(
-            ErrorKind::NotFound,
-            "Models directory not found",
-        ))
     }
 }

--- a/apps/framework-cli/src/framework/typescript/generator.rs
+++ b/apps/framework-cli/src/framework/typescript/generator.rs
@@ -29,6 +29,7 @@ pub enum TypescriptGeneratorError {
     },
     FileWritingError(#[from] std::io::Error),
     RenderingError(#[from] TypescriptRenderingError),
+    ProjectFile(#[from] crate::project::ProjectFileError),
 }
 
 #[derive(Debug, Clone)]

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -157,10 +157,9 @@ impl Project {
         }
     }
 
-    pub fn set_enviroment(&self, production: bool) -> () {
+    pub fn set_enviroment(&self, production: bool) {
         let mut proj = PROJECT.lock().unwrap();
         proj.is_production = production;
-        ()
     }
 
     pub fn load(directory: PathBuf) -> Result<Project, ConfigError> {

--- a/apps/framework-cli/src/project/typescript_project.rs
+++ b/apps/framework-cli/src/project/typescript_project.rs
@@ -6,6 +6,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::utilities::constants::PACKAGE_JSON;
 
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to create or delete project files")]
+#[non_exhaustive]
+pub enum TSProjectFileError {
+    IO(#[from] std::io::Error),
+    JSONSerde(#[from] serde_json::Error),
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TypescriptProject {
@@ -56,7 +64,7 @@ impl TypescriptProject {
             .try_deserialize()
     }
 
-    pub fn write_to_disk(&self, project_location: PathBuf) -> Result<(), anyhow::Error> {
+    pub fn write_to_disk(&self, project_location: PathBuf) -> Result<(), TSProjectFileError> {
         let mut package_json_location = project_location.clone();
         package_json_location.push(PACKAGE_JSON);
 

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -6,6 +6,7 @@ pub const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const PACKAGE_JSON: &str = "package.json";
 pub const PROJECT_CONFIG_FILE: &str = "project.toml";
+pub const PROJECT_NAME_ALLOW_PATTERN: &str = r"^[a-zA-Z0-9_-]+$";
 
 pub const CLI_CONFIG_FILE: &str = "config.toml";
 pub const CLI_USER_DIRECTORY: &str = ".moose";

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -11,6 +11,14 @@ use crate::utilities::constants::{CLI_VERSION, REDPANDA_CONTAINER_NAME};
 
 static COMPOSE_FILE: &str = include_str!("docker-compose.yml");
 
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to create or delete project files")]
+#[non_exhaustive]
+pub enum DockerError {
+    ProjectFile(#[from] crate::project::ProjectFileError),
+    IO(#[from] std::io::Error),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ContainerRow {
@@ -257,9 +265,9 @@ fn get_container_id(container_name: &str) -> anyhow::Result<String> {
     }
 }
 
-pub fn create_compose_file(project: &Project) -> std::io::Result<()> {
+pub fn create_compose_file(project: &Project) -> Result<(), DockerError> {
     let compose_file = project.internal_dir()?.join("docker-compose.yml");
-    std::fs::write(compose_file, COMPOSE_FILE)
+    Ok(std::fs::write(compose_file, COMPOSE_FILE)?)
 }
 
 pub fn run_rpk_cluster_info(project_name: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
* Do not panic when user directory is protected, properly fail
* Refactor the initialize routine to not use `Routines`
* Check project name for special characters to prevent a user from calling their project with a dot in there
* Removes `models` folder (not used)
* Adds some errors with the new error pattern