### PR TITLE
Show no results found msg

### DIFF
--- a/apps/moose-console/src/components/query-interface.tsx
+++ b/apps/moose-console/src/components/query-interface.tsx
@@ -169,6 +169,7 @@ export default function QueryInterface({
   );
 
   const [results, setResults] = useState<any[]>([]);
+  const [hasQueried, setHasQueried] = useState(false);
   const [sqlKeyWordCount, setSqlKeyWordCount] = useState(12);
   const [tableCount, setTableCount] = useState(12);
 
@@ -178,6 +179,7 @@ export default function QueryInterface({
         runQuery(project, value).then((results) => {
           e.preventDefault();
           setResults(results);
+          setHasQueried(true);
         });
       }
     };
@@ -321,13 +323,18 @@ export default function QueryInterface({
                     onClick={async () => {
                       const results = await runQuery(project, value);
                       setResults(results);
+                      setHasQueried(true);
                     }}
                   >
                     Run
                   </Button>
                 </div>
-                {results.length != 0 ? (
-                  <PreviewTable rows={results} caption="query results" />
+                {hasQueried ? (
+                  results.length != 0 ? (
+                    <PreviewTable rows={results} caption="query results" />
+                  ) : (
+                    "no results found"
+                  )
                 ) : (
                   "query results will appear here"
                 )}


### PR DESCRIPTION
Part of Chris' demo flow is to land on the query interface, where we initially show where the query results appear:

<img width="1491" alt="Screenshot 2024-05-15 at 11 50 29 AM" src="https://github.com/514-labs/moose/assets/7286437/f10fc230-0a21-4809-a19e-f39cee0ca24d">

&nbsp;
Then the demo clicks run to show that there's initially no data in there, so we want to show a different message:
&nbsp;

<img width="1489" alt="Screenshot 2024-05-15 at 11 50 44 AM" src="https://github.com/514-labs/moose/assets/7286437/df4b4ca2-db6a-411e-a449-fb297874e446">
