### PR TITLE
chore: clean up logs for production

### DIFF
--- a/apps/framework-cli/src/cli/routines/dev.rs
+++ b/apps/framework-cli/src/cli/routines/dev.rs
@@ -56,9 +56,11 @@ lazy_static! {
 }
 
 pub fn run_containers(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
-    let docker_compose_res = with_spinner("Starting local infrastructure", || {
-        docker::start_containers(project)
-    });
+    let docker_compose_res = with_spinner(
+        "Starting local infrastructure",
+        || docker::start_containers(project),
+        !project.is_production,
+    );
 
     match docker_compose_res {
         Ok(_) => Ok(RoutineSuccess::success(Message::new(

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -283,14 +283,18 @@ impl Routine for BuildDockerfile {
         }
 
         info!("Creating docker linux/amd64 image");
-        let buildx_result = with_spinner("Creating docker linux/amd64 image", || {
-            docker::buildx(
-                &internal_dir.join("packager"),
-                cli_version,
-                "linux/amd64",
-                "x86_64-unknown-linux-gnu",
-            )
-        });
+        let buildx_result = with_spinner(
+            "Creating docker linux/amd64 image",
+            || {
+                docker::buildx(
+                    &internal_dir.join("packager"),
+                    cli_version,
+                    "linux/amd64",
+                    "x86_64-unknown-linux-gnu",
+                )
+            },
+            !self.project.is_production,
+        );
         match buildx_result {
             Ok(_) => {
                 info!("Docker image created");
@@ -305,14 +309,18 @@ impl Routine for BuildDockerfile {
         }
 
         info!("Creating docker linux/arm64 image");
-        let buildx_result = with_spinner("Creating docker linux/arm64 image", || {
-            docker::buildx(
-                &internal_dir.join("packager"),
-                cli_version,
-                "linux/arm64",
-                "aarch64-unknown-linux-gnu",
-            )
-        });
+        let buildx_result = with_spinner(
+            "Creating docker linux/arm64 image",
+            || {
+                docker::buildx(
+                    &internal_dir.join("packager"),
+                    cli_version,
+                    "linux/arm64",
+                    "aarch64-unknown-linux-gnu",
+                )
+            },
+            !self.project.is_production,
+        );
         match buildx_result {
             Ok(_) => {
                 info!("Docker image created");

--- a/apps/framework-cli/src/cli/routines/stop.rs
+++ b/apps/framework-cli/src/cli/routines/stop.rs
@@ -18,17 +18,21 @@ impl StopLocalInfrastructure {
 impl Routine for StopLocalInfrastructure {
     fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
         ensure_docker_running()?;
-        with_spinner("Stopping local infrastructure", || {
-            docker::stop_containers(&self.project).map_err(|err| {
-                RoutineFailure::new(
-                    Message::new(
-                        "Failed".to_string(),
-                        "to stop local infrastructure".to_string(),
-                    ),
-                    err,
-                )
-            })
-        })?;
+        with_spinner(
+            "Stopping local infrastructure",
+            || {
+                docker::stop_containers(&self.project).map_err(|err| {
+                    RoutineFailure::new(
+                        Message::new(
+                            "Failed".to_string(),
+                            "to stop local infrastructure".to_string(),
+                        ),
+                        err,
+                    )
+                })
+            },
+            !self.project.is_production,
+        )?;
 
         Ok(RoutineSuccess::success(Message::new(
             "Successfully".to_string(),

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -274,6 +274,7 @@ async fn watch(
                         &configured_client,
                         syncing_process_registry,
                     ),
+                    !project.is_production,
                 )
                 .await
                 .map_err(|e| {

--- a/apps/framework-cli/src/framework/controller.rs
+++ b/apps/framework-cli/src/framework/controller.rs
@@ -474,6 +474,16 @@ pub async fn set_up_topic_and_tables_and_route(
         (Some(previous_fo), Some(current_table), Some(previous_table))
             if previous_fo.data_model == fo.data_model =>
         {
+            info!(
+                "Data model {} has not changed, using previous version table {} and topic {}",
+                fo.data_model.name,
+                previous_fo
+                    .table
+                    .clone()
+                    .map(|table| { table.name })
+                    .unwrap_or("None".to_string()),
+                previous_fo.topic
+            );
             // In this case no need for a topic on the current table since it is all the same as the previous table.
             match redpanda::delete_topics(&project.redpanda_config, vec![topic]).await {
                 Ok(_) => info!("Topics deleted successfully"),


### PR DESCRIPTION
* Removes the spinners when running in prod mode
* Adds the ability to output logs as Json
* Send spinner logs to stdout and not stdErrr