### PR TITLE
fix: fix project references for going to production

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -255,7 +255,7 @@ async fn top_command_handler(
             info!("Running dev command");
 
             let mut project = load_project()?;
-            project.set_enviroment(false);
+            project.set_is_production_env(false);
             let project_arc = Arc::new(project);
 
             crate::utilities::capture::capture!(
@@ -305,7 +305,7 @@ async fn top_command_handler(
             info!("Running prod command");
             let mut project = load_project()?;
 
-            project.set_enviroment(true);
+            project.set_is_production_env(true);
             let project_arc = Arc::new(project);
 
             crate::utilities::capture::capture!(

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -29,8 +29,9 @@ use crate::cli::routines::dev::{copy_old_schema, create_deno_files};
 use crate::cli::routines::flow::{create_flow_directory, create_flow_file};
 use crate::cli::routines::initialize::initialize_project;
 use crate::cli::routines::logs::{follow_logs, show_logs};
+use crate::cli::routines::migrate::generate_migration;
 use crate::cli::routines::templates;
-use crate::cli::routines::version::BumpVersion;
+use crate::cli::routines::version::bump_version;
 use crate::cli::routines::{RoutineFailure, RoutineSuccess};
 use crate::cli::{
     display::{Message, MessageType},
@@ -44,7 +45,6 @@ use crate::utilities::git::is_git_repo;
 
 use self::routines::{
     clean::CleanProject, docker_packager::BuildDockerfile, docker_packager::CreateDockerfile,
-    migrate::GenerateMigration,
 };
 
 #[derive(Parser)]
@@ -254,8 +254,7 @@ async fn top_command_handler(
         Commands::Dev {} => {
             info!("Running dev command");
 
-            let project = load_project()?;
-
+            let mut project = load_project()?;
             project.set_enviroment(false);
             let project_arc = Arc::new(project);
 
@@ -289,15 +288,8 @@ async fn top_command_handler(
                 let project_arc = Arc::new(project);
 
                 check_project_name(&project_arc.name())?;
-
-                let mut controller = RoutineController::new();
-                let run_mode = RunMode::Explicit {};
-
                 copy_old_schema(&project_arc)?;
-
-                // TODO get rid of the routines and use functions instead
-                controller.add_routine(Box::new(GenerateMigration::new(project_arc)));
-                controller.run_routines(run_mode);
+                generate_migration(&project_arc)?;
 
                 Ok(RoutineSuccess::success(Message::new(
                     "Generated".to_string(),
@@ -311,7 +303,7 @@ async fn top_command_handler(
         },
         Commands::Prod {} => {
             info!("Running prod command");
-            let project = load_project()?;
+            let mut project = load_project()?;
 
             project.set_enviroment(true);
             let project_arc = Arc::new(project);
@@ -343,8 +335,6 @@ async fn top_command_handler(
             );
 
             check_project_name(&project_arc.name())?;
-            let mut controller = RoutineController::new();
-            let run_mode = RunMode::Explicit {};
 
             let new_version = match new_version {
                 None => {
@@ -365,9 +355,7 @@ async fn top_command_handler(
                 Some(new_version) => new_version.clone(),
             };
 
-            // TODO get rid of the routines and use functions instead
-            controller.add_routine(Box::new(BumpVersion::new(project_arc.clone(), new_version)));
-            controller.run_routines(run_mode);
+            bump_version(&project_arc, new_version)?;
 
             Ok(RoutineSuccess::success(Message::new(
                 "Bumped".to_string(),

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -12,7 +12,6 @@ use crate::infrastructure::stream::redpanda::ConfiguredProducer;
 
 use crate::infrastructure::console::ConsoleConfig;
 use crate::project::Project;
-use crate::project::PROJECT;
 use bytes::Buf;
 use http_body_util::BodyExt;
 use http_body_util::Full;
@@ -432,7 +431,7 @@ impl Webserver {
             }
         );
 
-        if !PROJECT.lock().unwrap().is_production {
+        if !project.is_production {
             show_message!(
             MessageType::Highlight,
             Message {

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -105,7 +105,7 @@ use crate::infrastructure::olap;
 use crate::infrastructure::olap::clickhouse::version_sync::{get_all_version_syncs, VersionSync};
 use crate::infrastructure::olap::clickhouse_alt_client::{get_pool, store_current_state};
 use crate::infrastructure::stream::redpanda;
-use crate::project::{AggregationSet, Project, PROJECT};
+use crate::project::{AggregationSet, Project};
 use crate::utilities::package_managers;
 
 use super::display::{with_spinner, with_spinner_async};
@@ -536,7 +536,7 @@ async fn initialize_project_state(
             .await;
 
             // TODO: add old versions to SDK
-            if !PROJECT.lock().unwrap().is_production {
+            if !project.is_production {
                 let sdk_location =
                     typescript::generator::generate_sdk(&project, &framework_object_versions)?;
                 let package_manager = package_managers::PackageManager::Npm;

--- a/apps/framework-cli/src/cli/routines/migrate.rs
+++ b/apps/framework-cli/src/cli/routines/migrate.rs
@@ -1,76 +1,65 @@
-use std::sync::Arc;
-
 use crate::cli::display::Message;
-use crate::cli::routines::{crawl_schema, Routine, RoutineFailure, RoutineSuccess};
+use crate::cli::routines::{crawl_schema, RoutineFailure, RoutineSuccess};
 use crate::infrastructure::olap::clickhouse::version_sync::{
     generate_sql_version_syncs, get_all_version_syncs, parse_version,
 };
 use crate::project::Project;
 
-pub struct GenerateMigration {
-    project: Arc<Project>,
-}
-impl GenerateMigration {
-    pub fn new(project: Arc<Project>) -> Self {
-        Self { project }
-    }
-}
+pub fn generate_migration(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
+    let previous_version = match project
+        .supported_old_versions
+        .keys()
+        .max_by_key(|v| parse_version(v))
+    {
+        None => {
+            return Ok(RoutineSuccess::info(Message {
+                action: "No".to_string(),
+                details: "old versions found".to_string(),
+            }))
+        }
+        Some(previous_version) => previous_version,
+    };
 
-impl Routine for GenerateMigration {
-    fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
-        let previous_version = match self
-            .project
-            .supported_old_versions
-            .keys()
-            .max_by_key(|v| parse_version(v))
-        {
-            None => {
-                return Ok(RoutineSuccess::info(Message {
-                    action: "No".to_string(),
-                    details: "old versions found".to_string(),
-                }))
-            }
-            Some(previous_version) => previous_version,
-        };
+    let fo_versions = crawl_schema(project, &project.old_versions_sorted()).map_err(|err| {
+        RoutineFailure::new(
+            Message::new("Failed".to_string(), "to crawl schema".to_string()),
+            err,
+        )
+    })?;
 
-        let fo_versions = crawl_schema(&self.project, &self.project.old_versions_sorted())
-            .map_err(|err| {
-                RoutineFailure::new(
-                    Message::new("Failed".to_string(), "to crawl schema".to_string()),
-                    err,
-                )
-            })?;
+    let version_syncs = get_all_version_syncs(project, &fo_versions).map_err(|err| {
+        RoutineFailure::new(
+            Message::new("Failed".to_string(), "to generate migrations".to_string()),
+            err,
+        )
+    })?;
 
-        let version_syncs = get_all_version_syncs(&self.project, &fo_versions).map_err(|err| {
+    let new_vs_list = generate_sql_version_syncs(
+        &project.clickhouse_config.db_name,
+        &fo_versions,
+        &version_syncs,
+        previous_version,
+    );
+
+    let flow_dir = project.flows_dir();
+    for vs in new_vs_list {
+        let file_path = flow_dir.join(format!(
+            "{}_migrate__{}__{}.sql",
+            vs.model_name,
+            vs.source_version.replace('.', "_"),
+            vs.dest_version.replace('.', "_")
+        ));
+        let file_content = vs.sql_migration_function();
+        std::fs::write(&file_path, file_content).map_err(|err| {
             RoutineFailure::new(
-                Message::new("Failed".to_string(), "to generate migrations".to_string()),
+                Message::new("Failed".to_string(), "to write migration file".to_string()),
                 err,
             )
         })?;
-
-        let new_vs_list =
-            generate_sql_version_syncs(&fo_versions, &version_syncs, previous_version);
-
-        let flow_dir = self.project.flows_dir();
-        for vs in new_vs_list {
-            let file_path = flow_dir.join(format!(
-                "{}_migrate__{}__{}.sql",
-                vs.model_name,
-                vs.source_version.replace('.', "_"),
-                vs.dest_version.replace('.', "_")
-            ));
-            let file_content = vs.sql_migration_function();
-            std::fs::write(&file_path, file_content).map_err(|err| {
-                RoutineFailure::new(
-                    Message::new("Failed".to_string(), "to write migration file".to_string()),
-                    err,
-                )
-            })?;
-        }
-
-        Ok(RoutineSuccess::success(Message {
-            action: "Generated".to_string(),
-            details: "migrations".to_string(),
-        }))
     }
+
+    Ok(RoutineSuccess::success(Message {
+        action: "Generated".to_string(),
+        details: "migrations".to_string(),
+    }))
 }

--- a/apps/framework-cli/src/cli/routines/version.rs
+++ b/apps/framework-cli/src/cli/routines/version.rs
@@ -1,52 +1,39 @@
 use regex::Regex;
 use std::fs;
-use std::sync::Arc;
 
 use toml_edit::{table, value, DocumentMut, Item, Value};
 
 use crate::cli::display::Message;
-use crate::cli::routines::{Routine, RoutineFailure, RoutineSuccess};
-use crate::project::{Project, PROJECT};
+use crate::cli::routines::{RoutineFailure, RoutineSuccess};
+use crate::project::Project;
 use crate::utilities::constants::{PACKAGE_JSON, PROJECT_CONFIG_FILE};
 use crate::utilities::git::current_commit_hash;
 
-pub struct BumpVersion {
-    project: Arc<Project>,
+pub fn bump_version(
+    project: &Project,
     new_version: String,
-}
+) -> Result<RoutineSuccess, RoutineFailure> {
+    add_current_version_to_config(project, project.version()).map_err(|err| {
+        RoutineFailure::new(
+            Message::new(
+                "Failed".to_string(),
+                format!("to update {}", PROJECT_CONFIG_FILE),
+            ),
+            err,
+        )
+    })?;
 
-impl BumpVersion {
-    pub fn new(project: Arc<Project>, new_version: String) -> Self {
-        Self {
-            project,
-            new_version,
-        }
-    }
-}
-impl Routine for BumpVersion {
-    fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
-        add_current_version_to_config(self.project.version()).map_err(|err| {
-            RoutineFailure::new(
-                Message::new(
-                    "Failed".to_string(),
-                    format!("to update {}", PROJECT_CONFIG_FILE),
-                ),
-                err,
-            )
-        })?;
+    bump_package_json_version(project.version(), &new_version).map_err(|err| {
+        RoutineFailure::new(
+            Message::new("Failed".to_string(), format!("to update {}", PACKAGE_JSON)),
+            err,
+        )
+    })?;
 
-        bump_package_json_version(self.project.version(), &self.new_version).map_err(|err| {
-            RoutineFailure::new(
-                Message::new("Failed".to_string(), format!("to update {}", PACKAGE_JSON)),
-                err,
-            )
-        })?;
-
-        Ok(RoutineSuccess::success(Message::new(
-            "Successfully".to_string(),
-            "bumped version".to_string(),
-        )))
-    }
+    Ok(RoutineSuccess::success(Message::new(
+        "Successfully".to_string(),
+        "bumped version".to_string(),
+    )))
 }
 
 fn bump_package_json_version(current_version: &str, new_version: &str) -> anyhow::Result<()> {
@@ -64,8 +51,8 @@ fn bump_package_json_version(current_version: &str, new_version: &str) -> anyhow
     Ok(())
 }
 
-fn add_current_version_to_config(current_version: &str) -> anyhow::Result<()> {
-    let commit = current_commit_hash(&PROJECT.lock().unwrap())?;
+fn add_current_version_to_config(project: &Project, current_version: &str) -> anyhow::Result<()> {
+    let commit = current_commit_hash(project)?;
 
     let contents = fs::read_to_string(PROJECT_CONFIG_FILE)?;
     let mut doc = contents.parse::<DocumentMut>()?;

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -143,7 +143,7 @@ async fn process_events(
     let mut route_table = route_table.write().await;
     for (_, fo) in deleted_objects {
         if let Some(table) = &fo.table {
-            drop_table(table, configured_client).await?;
+            drop_table(&project.clickhouse_config.db_name, table, configured_client).await?;
             syncing_process_registry.stop(&fo.topic, &table.name);
         }
 
@@ -168,7 +168,7 @@ async fn process_events(
 
     for (_, fo) in changed_objects.iter().chain(new_objects.iter()) {
         if let Some(table) = &fo.table {
-            create_or_replace_tables(table, configured_client).await?;
+            create_or_replace_tables(table, configured_client, project.is_production).await?;
             syncing_process_registry.start(
                 fo.topic.clone(),
                 fo.data_model.columns.clone(),

--- a/apps/framework-cli/src/framework/data_model/schema.rs
+++ b/apps/framework-cli/src/framework/data_model/schema.rs
@@ -7,7 +7,6 @@ use super::config::DataModelConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DataModel {
-    pub db_name: String,
     pub columns: Vec<Column>,
     pub name: String,
     pub config: DataModelConfig,
@@ -16,7 +15,6 @@ pub struct DataModel {
 impl DataModel {
     pub fn to_table(&self, version: &str) -> Table {
         Table {
-            db_name: self.db_name.clone(),
             table_type: TableType::Table,
             name: format!("{}_{}", self.name, version.replace('.', "_")),
             columns: self.columns.clone(),
@@ -53,7 +51,6 @@ pub enum TableType {
 
 #[derive(Debug, Clone)]
 pub struct Table {
-    pub db_name: String,
     pub table_type: TableType,
     pub name: String,
     pub columns: Vec<Column>,

--- a/apps/framework-cli/src/framework/prisma/parser.rs
+++ b/apps/framework-cli/src/framework/prisma/parser.rs
@@ -6,7 +6,6 @@ use crate::{
         is_enum_type, Column, ColumnDefaults, ColumnType, DataEnum, DataModel, EnumMember,
         EnumValue,
     },
-    project::PROJECT,
 };
 use diagnostics::Diagnostics;
 use schema_ast::ast::{Attribute, Field, WithName};
@@ -103,9 +102,7 @@ fn prisma_model_to_datamodel(
         .map(|(_id, f)| field_to_column(f, enums))
         .collect();
 
-    let project = PROJECT.lock().unwrap();
     Ok(DataModel {
-        db_name: project.clickhouse_config.db_name.to_string(),
         columns: columns?,
         name: schema_name,
         config: Default::default(),

--- a/apps/framework-cli/src/framework/typescript/parser.rs
+++ b/apps/framework-cli/src/framework/typescript/parser.rs
@@ -1,7 +1,4 @@
-use crate::{
-    framework::data_model::schema::{is_enum_type, ColumnType, EnumMember, EnumValue},
-    project::PROJECT,
-};
+use crate::framework::data_model::schema::{is_enum_type, ColumnType, EnumMember, EnumValue};
 use log::debug;
 use std::path::{Path, PathBuf};
 use swc_common::{self, sync::Lrc, SourceMap};
@@ -174,9 +171,7 @@ fn interface_to_model(
         })
         .collect();
 
-    let project = PROJECT.lock().unwrap();
     Ok(DataModel {
-        db_name: project.clickhouse_config.db_name.to_string(),
         columns: columns?,
         name: schema_name,
         config: Default::default(),

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
@@ -212,7 +212,7 @@ pub async fn check_is_table_new(
     info!("<DCM> Checking if {} table is new", table.name.clone());
     let result = client
         .query("select engine, total_rows from system.tables where database = ? AND name = ?")
-        .bind(table.db_name.clone())
+        .bind(configured_client.config.db_name.clone())
         .bind(table.name.clone())
         .fetch_all::<TableDetail>()
         .await?;
@@ -234,7 +234,8 @@ pub async fn check_table_size(
     let result: Vec<i64> = client
         .query(&format!(
             "select count(*) from {}.{}",
-            table.db_name, table.name
+            configured_client.config.db_name.clone(),
+            table.name
         ))
         .fetch_all::<i64>()
         .await?;

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mapper.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mapper.rs
@@ -59,7 +59,6 @@ pub fn std_table_to_clickhouse_table(table: Table) -> Result<ClickHouseTable, Cl
     }
 
     Ok(ClickHouseTable {
-        db_name: table.db_name,
         name: table.name,
         columns,
         table_type: clickhouse_table_type_mapper(table.table_type),

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/model.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/model.rs
@@ -268,7 +268,6 @@ pub struct ClickHouseSystemTable {
 
 #[derive(Debug, Clone)]
 pub struct ClickHouseTable {
-    pub db_name: String,
     pub name: String,
     pub columns: Vec<ClickHouseColumn>,
     pub table_type: ClickHouseTableType,
@@ -276,25 +275,23 @@ pub struct ClickHouseTable {
 
 impl ClickHouseTable {
     pub fn new(
-        db_name: String,
         name: String,
         columns: Vec<ClickHouseColumn>,
         table_type: ClickHouseTableType,
     ) -> ClickHouseTable {
         ClickHouseTable {
-            db_name,
             name,
             columns,
             table_type,
         }
     }
 
-    pub fn create_data_table_query(&self) -> Result<String, ClickhouseError> {
-        create_table_query(self.clone(), ClickhouseEngine::MergeTree)
+    pub fn create_data_table_query(&self, db_name: &str) -> Result<String, ClickhouseError> {
+        create_table_query(db_name, self.clone(), ClickhouseEngine::MergeTree)
     }
 
-    pub fn drop_data_table_query(&self) -> Result<String, ClickhouseError> {
-        drop_table_query(self.clone())
+    pub fn drop_data_table_query(&self, db_name: &str) -> Result<String, ClickhouseError> {
+        drop_table_query(db_name, self.clone())
     }
 }
 

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
@@ -33,17 +33,19 @@ fn create_alias_query(
 // This is used when a new table doesn't have a different schema from the old table
 // so we use a view to alias the old table to the new table name
 pub fn create_alias_query_from_table(
+    db_name: &str,
     old_table: &ClickHouseTable,
     new_table: &ClickHouseTable,
 ) -> Result<String, ClickhouseError> {
-    create_alias_query(&old_table.db_name, &new_table.name, &old_table.name)
+    create_alias_query(db_name, &new_table.name, &old_table.name)
 }
 
 pub fn create_alias_for_table(
+    db_name: &str,
     alias_name: &str,
     latest_table: &ClickHouseTable,
 ) -> Result<String, ClickhouseError> {
-    create_alias_query(&latest_table.db_name, alias_name, &latest_table.name)
+    create_alias_query(db_name, alias_name, &latest_table.name)
 }
 
 // TODO: Add column comment capability to the schema and template
@@ -62,6 +64,7 @@ pub enum ClickhouseEngine {
 }
 
 pub fn create_table_query(
+    db_name: &str,
     table: ClickHouseTable,
     engine: ClickhouseEngine,
 ) -> Result<String, ClickhouseError> {
@@ -83,7 +86,7 @@ pub fn create_table_query(
     };
 
     let template_context = json!({
-        "db_name": table.db_name,
+        "db_name": db_name,
         "table_name": table.name,
         "fields":  builds_field_context(&table.columns)?,
         "primary_key_string": if !primary_key.is_empty() {
@@ -163,11 +166,11 @@ pub static DROP_TABLE_TEMPLATE: &str = r#"
 DROP TABLE IF EXISTS {{db_name}}.{{table_name}};
 "#;
 
-pub fn drop_table_query(table: ClickHouseTable) -> Result<String, ClickhouseError> {
+pub fn drop_table_query(db_name: &str, table: ClickHouseTable) -> Result<String, ClickhouseError> {
     let reg = Handlebars::new();
 
     let context = json!({
-        "db_name": table.db_name,
+        "db_name": db_name,
         "table_name": table.name,
     });
 

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/version_sync.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/version_sync.rs
@@ -30,6 +30,7 @@ pub fn version_to_string(v: &[i32]) -> String {
 
 // to be removed when we move to all TS flow version syncs
 pub fn generate_sql_version_syncs(
+    db_name: &str,
     framework_object_versions: &FrameworkObjectVersions,
     version_sync_list: &[VersionSync],
     previous_version: &str,
@@ -54,7 +55,7 @@ pub fn generate_sql_version_syncs(
                 if let Some(new_table) = &fo.table {
                     if old_model.data_model.columns != fo.data_model.columns {
                         res.push(VersionSync {
-                            db_name: old_table.db_name.clone(),
+                            db_name: db_name.to_string(),
                             model_name: old_model.data_model.name.clone(),
                             source_version: previous_version.to_string(),
                             source_data_model: old_model.data_model.clone(),
@@ -122,7 +123,7 @@ pub fn get_all_version_syncs(
                                 if let Some(from_table) = &from_table_fo.table {
                                     if let Some(to_table) = &to_table_fo.table {
                                         let version_sync = VersionSync {
-                                            db_name: from_table.db_name.clone(),
+                                            db_name: project.clickhouse_config.db_name.clone(),
                                             model_name: from_table_fo.data_model.name.clone(),
                                             source_version: from_version.clone(),
                                             source_table: from_table.clone(),

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse_alt_client.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse_alt_client.rs
@@ -178,6 +178,7 @@ fn column_type_to_enum_mapping(t: &ClickHouseColumnType) -> Option<Vec<&str>> {
 }
 
 pub async fn select_all_as_json<'a>(
+    db_name: &str,
     table: &'a ClickHouseTable,
     client: &'a mut ClientHandle,
     offset: i64,
@@ -208,7 +209,7 @@ pub async fn select_all_as_json<'a>(
     let stream = client
         .query(&format!(
             "select * from {}.{} {} offset {}",
-            table.db_name, table.name, order_by, offset
+            db_name, table.name, order_by, offset
         ))
         .stream()
         .map(move |row| row_to_json(&row?, &enum_mapping));

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -154,8 +154,8 @@ impl Project {
         }
     }
 
-    pub fn set_enviroment(&mut self, production: bool) {
-        self.is_production = production;
+    pub fn set_is_production_env(&mut self, is_production: bool) {
+        self.is_production = is_production;
     }
 
     pub fn load(directory: PathBuf) -> Result<Project, ConfigError> {

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -11,11 +11,9 @@
 //! - `project_file_location` - The location of the project file on disk
 //! ```
 
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::Write;
-use std::sync::Mutex;
 pub mod typescript_project;
 
 use std::fmt::Debug;
@@ -61,20 +59,6 @@ use crate::utilities::constants::{
     CONSUMPTION_HELPERS, DENO_AGGREGATIONS, DENO_CONSUMPTION_API, DENO_DIR, DENO_TRANSFORM,
 };
 use crate::utilities::constants::{VSCODE_DIR, VSCODE_EXT_FILE, VSCODE_SETTINGS_FILE};
-
-lazy_static! {
-    pub static ref PROJECT: Mutex<Project> = Mutex::new(Project {
-        language: SupportedLanguages::Typescript,
-        is_production: false,
-        redpanda_config: RedpandaConfig::default(),
-        clickhouse_config: ClickHouseConfig::default(),
-        http_server_config: LocalWebserverConfig::default(),
-        console_config: ConsoleConfig::default(),
-        language_project_config: LanguageProjectConfig::Typescript(TypescriptProject::default()),
-        project_location: PathBuf::new(),
-        supported_old_versions: HashMap::new(),
-    });
-}
 
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to create or delete project files")]
@@ -170,9 +154,8 @@ impl Project {
         }
     }
 
-    pub fn set_enviroment(&self, production: bool) {
-        let mut proj = PROJECT.lock().unwrap();
-        proj.is_production = production;
+    pub fn set_enviroment(&mut self, production: bool) {
+        self.is_production = production;
     }
 
     pub fn load(directory: PathBuf) -> Result<Project, ConfigError> {
@@ -205,8 +188,6 @@ impl Project {
             }
         }
 
-        let mut proj = PROJECT.lock().unwrap();
-        *proj = project_config.clone();
         Ok(project_config)
     }
 


### PR DESCRIPTION
* Removes the global mutable project reference
* Do some refactors removing the Routines for the bump version and generate migration commands
* Removes the db_name from the Table object, it is a global project configuration

Currently in production, we can see some logs that should not be there since we are in prod mode. 

They are showing up because the production environment was only set on the global env and not on the local object

```rust
    pub fn set_enviroment(&self, production: bool) {
        let mut proj = PROJECT.lock().unwrap();
        proj.is_production = production;
    }
```

I removed the global. Through this, I am becoming more convinced that explicit dependency on the project object is necessary and will yield a return on the investment of punching through when necessary. It makes the dependency explicit, makes functions more testable, and reveals smells of code when abstractions are leaking in the wrong parts of the code. 

ie by making it explicit here, I started punching through `project` in places that did not make sense. That made me ask, why am I doing this? is it needed? The `db_name` property is a good example of that. 
