### PR TITLE
Update flows docs

### DIFF
--- a/apps/framework-cli/src/framework/data_model.rs
+++ b/apps/framework-cli/src/framework/data_model.rs
@@ -10,8 +10,6 @@ use std::{
 };
 
 use crate::framework::controller::FrameworkObject;
-use crate::utilities::constants::TS_INTERFACE_GENERATE_EXT;
-use crate::utilities::system::file_name_contains;
 
 #[derive(Debug, Clone)]
 pub struct DuplicateModelError {
@@ -56,5 +54,4 @@ pub fn is_schema_file(path: &Path) -> bool {
     path.extension()
         .map(|extension| extension == "prisma" || extension == "ts")
         .unwrap_or(false)
-        && !file_name_contains(path, TS_INTERFACE_GENERATE_EXT)
 }

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -66,5 +66,3 @@ This is a [MooseJs](https://www.moosejs.com/) project bootstrapped with the
 [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
 
 "#;
-
-pub const TS_INTERFACE_GENERATE_EXT: &str = ".generated.ts";

--- a/apps/framework-cli/src/utilities/git.rs
+++ b/apps/framework-cli/src/utilities/git.rs
@@ -26,7 +26,7 @@ pub fn create_init_commit(project: Arc<Project>, dir_path: &Path) {
     let mut git_ignore_entries = vec![CLI_USER_DIRECTORY];
     git_ignore_entries.append(&mut match project.language {
         SupportedLanguages::Typescript => {
-            vec!["node_modules", "dist", "coverage", "*.generated.ts"]
+            vec!["node_modules", "dist", "coverage"]
         }
     });
     let mut git_ignore = git_ignore_entries.join("\n");

--- a/apps/framework-docs/src/pages/building/flows/setup.mdx
+++ b/apps/framework-docs/src/pages/building/flows/setup.mdx
@@ -77,8 +77,8 @@ In the `flow.ts` file created, Moose provides starter code. This code includes i
 
 ```ts filename="flow.ts" copy {2-3,7}
 // Add your models & start the development server to import these types
-import { UserActivity } from "/path/to/UserActivity.ts";
-import { ParsedActivity } from "/path/to/ParsedActivity.ts";
+import { UserActivity } from "/path/to/UserActivity";
+import { ParsedActivity } from "/path/to/ParsedActivity";
 
 // The 'run' function transforms source data to destination format.
 // For more details on how Moose flows work, see: https://docs.moosejs.com
@@ -101,11 +101,10 @@ Here's an example `flow.ts` that converts timestamps to UTC:
 ```ts filename="flow.ts" copy {3-4,8}
 // Example flow function: Converts local timestamps in UserEvent data to UTC.
 // Imports: Source (UserActivity) and Destination (ParsedActivity) data models.
-import { UserActivity } from "/path/to/UserActivity.ts";
-import { ParsedActivity } from "/path/to/ParsedActivity.ts";
+import { UserActivity } from "/path/to/UserActivity";
+import { ParsedActivity } from "/path/to/ParsedActivity";
 
 // The 'convertUtc' function transforms UserActivity data to ParsedActivity format.
-// For more details on how Moose flows work, see: <https://docs.moosejs.com/flows>
 export default function convertUtc(event: UserActivity): ParsedActivity {
   // Convert local timestamp to UTC and return new ParsedActivity object.
   return {


### PR DESCRIPTION
Updated flows docs so it doesn't mention .ts in the imports anymore. Also, I don't think we're using the `.generated.ts` stuff anymore? Let me know if I should revert those deletes.