### PR TITLE
chore: start plan feature with some ground work

### DIFF
--- a/apps/framework-cli/Cargo.lock
+++ b/apps/framework-cli/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "toml",
  "toml_edit 0.22.13",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -69,6 +69,7 @@ opentelemetry_sdk = { version = "0.23.0",features = ["logs", "logs_level_enabled
 opentelemetry-semantic-conventions = "0.15.0"
 opentelemetry = "0.23.0"
 opentelemetry-appender-log ="0.4.0"
+walkdir = "2"
 
 [dev-dependencies]
 clickhouse = { version = "0.11.5", features = ["uuid", "test-util"] }

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -397,7 +397,7 @@ async fn top_command_handler(
 
             let new_version = match new_version {
                 None => {
-                    let current = parse_version(project_arc.version());
+                    let current = parse_version(project_arc.cur_version());
                     let bump_location = if current.len() > 1 { 1 } else { 0 };
 
                     let new_version = current

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -455,7 +455,7 @@ impl Webserver {
         let route_service = RouteService {
             host: self.host.clone(),
             route_table,
-            current_version: project.version().to_string(),
+            current_version: project.cur_version().to_string(),
             configured_producer: producer,
             console_config: project.console_config.clone(),
         };

--- a/apps/framework-cli/src/cli/routines/flow.rs
+++ b/apps/framework-cli/src/cli/routines/flow.rs
@@ -296,7 +296,7 @@ fn grep_datamodel(project: &Project, datamodel: &str) -> anyhow::Result<()> {
         .arg("--include=*.ts")
         .arg("-E")
         .arg(format!("export\\s+interface\\s+\\b{}\\b", &datamodel))
-        .arg(project.schemas_dir())
+        .arg(project.data_models_dir())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;

--- a/apps/framework-cli/src/cli/routines/version.rs
+++ b/apps/framework-cli/src/cli/routines/version.rs
@@ -14,7 +14,7 @@ pub fn bump_version(
     project: &Project,
     new_version: String,
 ) -> Result<RoutineSuccess, RoutineFailure> {
-    add_current_version_to_config(project, project.version()).map_err(|err| {
+    add_current_version_to_config(project, project.cur_version()).map_err(|err| {
         RoutineFailure::new(
             Message::new(
                 "Failed".to_string(),
@@ -26,7 +26,7 @@ pub fn bump_version(
 
     match project.language {
         SupportedLanguages::Python => {
-            bump_setup_py_version(project.version(), &new_version).map_err(|err| {
+            bump_setup_py_version(project.cur_version(), &new_version).map_err(|err| {
                 RoutineFailure::new(
                     Message::new("Failed".to_string(), format!("to update {}", SETUP_PY)),
                     err,
@@ -34,7 +34,7 @@ pub fn bump_version(
             })?;
         }
         SupportedLanguages::Typescript => {
-            bump_package_json_version(project.version(), &new_version).map_err(|err| {
+            bump_package_json_version(project.cur_version(), &new_version).map_err(|err| {
                 RoutineFailure::new(
                     Message::new("Failed".to_string(), format!("to update {}", PACKAGE_JSON)),
                     err,

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -54,7 +54,7 @@ async fn process_data_models_changes(
         events, route_table
     );
 
-    let schema_files = project.schemas_dir();
+    let schema_files = project.data_models_dir();
 
     let paths = events
         .into_iter()
@@ -73,7 +73,7 @@ async fn process_data_models_changes(
     let old_objects = &framework_object_versions.current_models.models;
 
     let aggregations = AggregationSet {
-        current_version: project.version().to_owned(),
+        current_version: project.cur_version().to_owned(),
         names: project.get_aggregations(),
     };
 
@@ -88,7 +88,7 @@ async fn process_data_models_changes(
             let obj_in_new_file = get_framework_objects_from_schema_file(
                 &project,
                 &path,
-                project.version(),
+                project.cur_version(),
                 &aggregations,
             )
             .await?;

--- a/apps/framework-cli/src/framework/controller.rs
+++ b/apps/framework-cli/src/framework/controller.rs
@@ -397,7 +397,7 @@ pub async fn process_objects(
     route_table: &mut HashMap<PathBuf, RouteMeta>,
     version: &str,
 ) -> anyhow::Result<()> {
-    let is_latest = version == project.version();
+    let is_latest = version == project.cur_version();
 
     for (_, fo) in framework_objects.iter() {
         let ingest_route = schema_file_path_to_ingest_route(

--- a/apps/framework-cli/src/framework/core.rs
+++ b/apps/framework-cli/src/framework/core.rs
@@ -21,3 +21,4 @@
 /// └──────────────┘                     └──────────────┘
 ///
 pub mod code_loader;
+pub mod primitive_map;

--- a/apps/framework-cli/src/framework/core/primitive_map.rs
+++ b/apps/framework-cli/src/framework/core/primitive_map.rs
@@ -67,6 +67,7 @@ mod tests {
     };
 
     #[test]
+    #[ignore]
     fn test_load_primitive_map() {
         let project = Project::new(
             Path::new("/Users/nicolas/code/514/test"),

--- a/apps/framework-cli/src/framework/core/primitive_map.rs
+++ b/apps/framework-cli/src/framework/core/primitive_map.rs
@@ -1,0 +1,80 @@
+use std::{collections::HashMap, path::PathBuf};
+use walkdir::WalkDir;
+
+use crate::{
+    framework::data_model::{
+        parser::parse_data_model_file,
+        schema::{DataEnum, DataModel},
+    },
+    project::Project,
+};
+
+#[derive(Debug)]
+pub struct PrimitiveMap {
+    // This probably should not be a top level item and should be nested under the datamodels
+    enums: Vec<DataEnum>,
+    datamodels: HashMap<PathBuf, DataModel>,
+    // TODO add flows
+    // TODO add dbblocks
+    // TODO add consumption apis
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrimitiveMapLoadingError {
+    #[error("Failure walking the tree")]
+    WalkDir(#[from] walkdir::Error),
+    #[error("Failed to parse the data model file")]
+    DataModelParsing(#[from] crate::framework::data_model::parser::DataModelParsingError),
+}
+
+impl PrimitiveMap {
+    // Currently limited to the current version - will need to layout previous versions in the future
+    pub fn load(project: &Project) -> Result<PrimitiveMap, PrimitiveMapLoadingError> {
+        let mut primitive_map = PrimitiveMap {
+            enums: Vec::new(),
+            datamodels: HashMap::new(),
+        };
+
+        let data_models_dir = project.data_models_dir();
+        for res_entry in WalkDir::new(project.app_dir()) {
+            let entry = res_entry?;
+
+            if entry.path().starts_with(&data_models_dir) && entry.file_type().is_file() {
+                let file_objects =
+                    parse_data_model_file(entry.path(), project.cur_version(), project)?;
+                for model in file_objects.models {
+                    primitive_map
+                        .datamodels
+                        .insert(entry.path().to_path_buf(), model);
+                }
+                for enu in file_objects.enums {
+                    primitive_map.enums.push(enu);
+                }
+            }
+        }
+
+        Ok(primitive_map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::{
+        framework::{core::primitive_map::PrimitiveMap, languages::SupportedLanguages},
+        project::Project,
+    };
+
+    #[test]
+    fn test_load_primitive_map() {
+        let project = Project::new(
+            Path::new("/Users/nicolas/code/514/test"),
+            "test".to_string(),
+            SupportedLanguages::Typescript,
+        );
+        let primitive_map = PrimitiveMap::load(&project);
+        println!("{:?}", primitive_map);
+        assert!(primitive_map.is_ok());
+    }
+}

--- a/apps/framework-cli/src/framework/data_model/parser.rs
+++ b/apps/framework-cli/src/framework/data_model/parser.rs
@@ -33,15 +33,16 @@ impl FileObjects {
 
 pub fn parse_data_model_file(
     path: &Path,
+    version: &str,
     project: &Project,
 ) -> Result<FileObjects, DataModelParsingError> {
     if let Some(ext) = path.extension() {
         match ext.to_str() {
-            Some("prisma") => Ok(prisma::parser::extract_data_model_from_file(path)?),
+            Some("prisma") => Ok(prisma::parser::extract_data_model_from_file(path, version)?),
             Some("ts") => Ok(typescript::parser::extract_data_model_from_file(
-                path, project,
+                path, project, version,
             )?),
-            Some("py") => Ok(python::parser::extract_data_model_from_file(path)?),
+            Some("py") => Ok(python::parser::extract_data_model_from_file(path, version)?),
             _ => Err(DataModelParsingError::UnsupportedFileType),
         }
     } else {

--- a/apps/framework-cli/src/framework/data_model/parser.rs
+++ b/apps/framework-cli/src/framework/data_model/parser.rs
@@ -19,7 +19,7 @@ pub enum DataModelParsingError {
     UnsupportedFileType,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct FileObjects {
     pub models: Vec<DataModel>,
     pub enums: Vec<DataEnum>,

--- a/apps/framework-cli/src/framework/data_model/schema.rs
+++ b/apps/framework-cli/src/framework/data_model/schema.rs
@@ -198,7 +198,7 @@ impl<'de> Visitor<'de> for ColumnTypeVisitor {
         let mut name = None;
         let mut values = None;
         let mut columns = None;
-        while let Some(key) = map.next_key::<&str>()? {
+        while let Some(key) = map.next_key::<String>()? {
             if key == "elementType" {
                 return Ok(ColumnType::Array(Box::new(
                     map.next_value::<ColumnType>().map_err(|e| {

--- a/apps/framework-cli/src/framework/data_model/schema.rs
+++ b/apps/framework-cli/src/framework/data_model/schema.rs
@@ -2,6 +2,7 @@ use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
+use std::path::PathBuf;
 
 use super::config::DataModelConfig;
 
@@ -11,6 +12,8 @@ pub struct DataModel {
     pub name: String,
     #[serde(default)]
     pub config: DataModelConfig,
+    pub file_path: PathBuf,
+    pub version: String,
 }
 
 impl DataModel {

--- a/apps/framework-cli/src/framework/prisma/parser.rs
+++ b/apps/framework-cli/src/framework/prisma/parser.rs
@@ -100,7 +100,7 @@ fn prisma_ast_to_internal_ast(
 }
 
 fn prisma_model_to_datamodel(
-    file_path: &PathBuf,
+    file_path: &Path,
     version: &str,
     m: &Model,
     enums: &[DataEnum],
@@ -116,7 +116,7 @@ fn prisma_model_to_datamodel(
         columns: columns?,
         name: schema_name,
         config: Default::default(),
-        file_path: file_path.clone(),
+        file_path: file_path.to_path_buf(),
         version: version.to_string(),
     })
 }

--- a/apps/framework-cli/src/framework/typescript/parser.rs
+++ b/apps/framework-cli/src/framework/typescript/parser.rs
@@ -118,7 +118,6 @@ pub fn extract_data_model_from_file(
         }
     }
 
-    // TODO: parsing with Value as an intermediate step fails, but works fine if we parse from slice
     Ok(serde_json::from_value(output_json)?)
 }
 

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -247,8 +247,8 @@ impl Project {
     pub fn create_base_app_files(&self) -> Result<(), std::io::Error> {
         let readme_file_path = self.project_location.join("README.md");
         let base_model_file_path = match self.language {
-            SupportedLanguages::Typescript => self.schemas_dir().join("models.ts"),
-            SupportedLanguages::Python => self.schemas_dir().join("models.py"),
+            SupportedLanguages::Typescript => self.data_models_dir().join("models.ts"),
+            SupportedLanguages::Python => self.data_models_dir().join("models.py"),
         };
 
         let flow_file_name = match self.language {
@@ -301,7 +301,7 @@ impl Project {
                 // Create __init__.py file in the app directory tree
                 std::fs::File::create(self.app_dir().join("__init__.py"))?;
 
-                std::fs::File::create(self.schemas_dir().join("__init__.py"))?;
+                std::fs::File::create(self.data_models_dir().join("__init__.py"))?;
                 std::fs::File::create(self.aggregations_dir().join("__init__.py"))?;
                 std::fs::File::create(self.consumption_dir().join("__init__.py"))?;
                 std::fs::File::create(self.flows_dir().join("__init__.py"))?;
@@ -350,7 +350,7 @@ impl Project {
         app_dir
     }
 
-    pub fn schemas_dir(&self) -> PathBuf {
+    pub fn data_models_dir(&self) -> PathBuf {
         let mut schemas_dir = self.app_dir();
         schemas_dir.push(SCHEMAS_DIR);
 
@@ -456,7 +456,7 @@ impl Project {
         Ok(())
     }
 
-    pub fn version(&self) -> &str {
+    pub fn cur_version(&self) -> &str {
         match &self.language_project_config {
             LanguageProjectConfig::Typescript(package_json) => &package_json.version,
             LanguageProjectConfig::Python(package_json) => &package_json.version,

--- a/apps/framework-cli/src/utilities/git.rs
+++ b/apps/framework-cli/src/utilities/git.rs
@@ -107,7 +107,7 @@ pub fn dump_old_version_schema(
 ) -> Result<(), Error> {
     let repo = Repository::discover(project.project_location.clone())?;
 
-    let schema_dir = project.schemas_dir();
+    let schema_dir = project.data_models_dir();
     let schema_relative_path_from_repo_root = schema_dir
         .strip_prefix(repo.path().parent().unwrap())
         .unwrap();


### PR DESCRIPTION
* renaming `schema_dir` to `data_model_dir` for consistency
* renaming `version()` to `cur_version` on the project for clarity 
* Add the `PrimitiveMap` object, it will be an object that will hold all the primitives as defined by the user. We will then transform that into the `InfrastructureMap` which will form a map of all the infra.
* Adds `file_path` and `version` to the `DataModel` to enable tracing it through changes and disambiguate through versions