### PR TITLE
Revert "Revert "Write state after watcher parses data models (#1499)"…

### DIFF
--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -329,18 +329,6 @@ async fn watch(
                 let bucketed_events = EventBuckets::new(events);
 
                 if bucketed_events.non_empty() {
-                    {
-                        let mut client = get_pool(&project.clickhouse_config).get_handle().await?;
-                        let aggregations = project.get_aggregations();
-                        store_current_state(
-                            &mut client,
-                            framework_object_versions,
-                            &aggregations,
-                            &project.clickhouse_config,
-                        )
-                        .await?
-                    }
-
                     if !bucketed_events.data_models.is_empty() {
                         with_spinner_async(
                             &format!(
@@ -400,6 +388,18 @@ async fn watch(
                             !project.is_production,
                         )
                         .await?;
+                    }
+
+                    {
+                        let mut client = get_pool(&project.clickhouse_config).get_handle().await?;
+                        let aggregations = project.get_aggregations();
+                        store_current_state(
+                            &mut client,
+                            framework_object_versions,
+                            &aggregations,
+                            &project.clickhouse_config,
+                        )
+                        .await?
                     }
 
                     let _ = verify_flows_against_datamodels(&project, framework_object_versions);


### PR DESCRIPTION
So ls has most up-to-date info. Tested with heart rate demo.