### PR TITLE
Nicolas/enable different `moose.config.toml` for moose project file

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -90,7 +90,7 @@ WORKDIR /application
 COPY ./app ./app
 COPY ./package.json ./package.json
 
-// https://stackoverflow.com/questions/70096208/dockerfile-copy-folder-if-it-exists-conditional-copy/70096420#70096420
+# https://stackoverflow.com/questions/70096208/dockerfile-copy-folder-if-it-exists-conditional-copy/70096420#70096420
 COPY ./project.tom[l] ./project.toml
 COPY ./moose.config.tom[l] ./moose.config.toml
 COPY ./versions .moose/versions

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -1,7 +1,9 @@
 use super::{Routine, RoutineFailure, RoutineSuccess};
 use crate::cli::display::with_spinner;
 use crate::cli::routines::util::ensure_docker_running;
-use crate::utilities::constants::CLI_INTERNAL_VERSIONS_DIR;
+use crate::utilities::constants::{
+    APP_DIR, CLI_INTERNAL_VERSIONS_DIR, OLD_PROJECT_CONFIG_FILE, PACKAGE_JSON, PROJECT_CONFIG_FILE,
+};
 use crate::utilities::{constants, docker, system};
 use crate::{cli::display::Message, project::Project};
 use log::{error, info};
@@ -87,7 +89,8 @@ WORKDIR /application
 # Copy the application files to the container
 COPY ./app ./app
 COPY ./package.json ./package.json
-COPY ./project.toml ./project.toml
+COPY ./project.tom[l] ./project.toml
+COPY ./moose.config.tom[l] ./moose.config.toml
 COPY ./versions .moose/versions
 
 # We should get compatible with other package managers 
@@ -255,9 +258,18 @@ impl Routine for BuildDockerfile {
 
         // Copy app & etc to packager directory
         let project_root_path = self.project.project_location.clone();
-        let items_to_copy = vec!["app", "package.json", "project.toml"];
+        let items_to_copy = vec![
+            APP_DIR,
+            PACKAGE_JSON,
+            PROJECT_CONFIG_FILE,
+            OLD_PROJECT_CONFIG_FILE,
+        ];
 
         for item in items_to_copy {
+            if !project_root_path.join(item).exists() {
+                continue;
+            }
+
             let copy_result = system::copy_directory(
                 &project_root_path.join(item),
                 &internal_dir.join("packager"),

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -89,6 +89,8 @@ WORKDIR /application
 # Copy the application files to the container
 COPY ./app ./app
 COPY ./package.json ./package.json
+
+// https://stackoverflow.com/questions/70096208/dockerfile-copy-folder-if-it-exists-conditional-copy/70096420#70096420
 COPY ./project.tom[l] ./project.toml
 COPY ./moose.config.tom[l] ./moose.config.toml
 COPY ./versions .moose/versions

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -6,7 +6,8 @@ pub const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const PACKAGE_JSON: &str = "package.json";
 pub const SETUP_PY: &str = "setup.py";
-pub const PROJECT_CONFIG_FILE: &str = "project.toml";
+pub const OLD_PROJECT_CONFIG_FILE: &str = "project.toml";
+pub const PROJECT_CONFIG_FILE: &str = "moose.config.toml";
 pub const PROJECT_NAME_ALLOW_PATTERN: &str = r"^[a-zA-Z0-9_-]+$";
 
 pub const CLI_CONFIG_FILE: &str = "config.toml";

--- a/apps/framework-cli/tests/cli_init.rs
+++ b/apps/framework-cli/tests/cli_init.rs
@@ -27,7 +27,7 @@ fn can_run_cli_init() -> Result<(), Box<dyn std::error::Error>> {
     temp.child("package.json")
         .assert(predicate::path::missing());
     temp.child("app").assert(predicate::path::missing());
-    temp.child("project.toml")
+    temp.child("moose.config.toml")
         .assert(predicate::path::missing());
 
     let mut cmd = Command::cargo_bin("moose-cli")?;
@@ -40,7 +40,8 @@ fn can_run_cli_init() -> Result<(), Box<dyn std::error::Error>> {
     // app is more stable
     temp.child("package.json").assert(predicate::path::exists());
     temp.child("app").assert(predicate::path::exists());
-    temp.child("project.toml").assert(predicate::path::exists());
+    temp.child("moose.config.toml")
+        .assert(predicate::path::exists());
 
     Ok(())
 }

--- a/apps/framework-docs/src/pages/building/dcm/concepts.mdx
+++ b/apps/framework-docs/src/pages/building/dcm/concepts.mdx
@@ -23,7 +23,7 @@ In the Moose Change Data Management model, code in the last commit of your `main
 branch is the current, latest version. It is accordingly tagged as such in the version
 property in the `package.json` file in your Moose application's top-level folder.
 
-Previous versions are tagged in the `project.toml` file, `[supported_old_versions]`
+Previous versions are tagged in the `moose.config.toml` file, `[supported_old_versions]`
 section. We decided to not use Git tags for workflow reasons and to let users leverage
 tags however they want. If you would rather manage versions through tags instead of a
 file committed in the repository, [please let us know](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg).

--- a/apps/framework-docs/src/pages/building/dcm/walkthrough.mdx
+++ b/apps/framework-docs/src/pages/building/dcm/walkthrough.mdx
@@ -40,7 +40,7 @@ and the inside of your app folder should look like the following:
   <FileTree.Folder name="dcm-walkthrough" defaultOpen>
     <FileTree.File name="README.md" />
     <FileTree.File name="package.json" />
-    <FileTree.File name="project.toml" />
+    <FileTree.File name="moose.config.toml" />
     <FileTree.Folder name="app" defaultOpen>
       <FileTree.Folder name="datamodels" defaultOpen>
         <FileTree.File name="models.ts" />
@@ -125,9 +125,9 @@ Let's see this in action.
   </Tabs.Tab>
 </Tabs>
 
-It will bump the version in your package.json file and add a pointer between the git commit and the previous version to the project.toml file.
+It will bump the version in your package.json file and add a pointer between the git commit and the previous version to the moose.config.toml file.
 
-```toml filename="./project.toml"
+```toml filename="./moose.config.toml"
 [supported_old_versions]
 "0.0" = "263297f"
 ```

--- a/apps/framework-docs/src/pages/getting-started/project-structure.mdx
+++ b/apps/framework-docs/src/pages/getting-started/project-structure.mdx
@@ -27,17 +27,17 @@ The following is the basic structure of a MooseJS project:
     </FileTree.Folder>
   </FileTree.Folder>
   <FileTree.File name="package.json" />
-  <FileTree.File name="project.toml" />
+  <FileTree.File name="moose.config.toml" />
 </FileTree>
 
 ## Top-level Folders and Files
 
-|              |                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------- |
-| app          | The main folder for your application.                                                                |
-| .moose       | Moose internals. You shouldn't ever have to touch anything in here.                                  |
-| package.json | The default [npm package manifest file](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) |
-| project.toml | Configuration file specific to Moose for your application.                                           |
+|                   |                                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| app               | The main folder for your application.                                                                |
+| .moose            | Moose internals. You shouldn't ever have to touch anything in here.                                  |
+| package.json      | The default [npm package manifest file](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) |
+| moose.config.toml | Configuration file specific to Moose for your application.                                           |
 
 ## App folders
 

--- a/apps/framework-docs/src/pages/moose-cli.mdx
+++ b/apps/framework-docs/src/pages/moose-cli.mdx
@@ -105,7 +105,7 @@ moose generate migrations
 
 ### Bump Version
 
-Bumps the `version` field in `package.json`, and adds an entry of the current version and commit hash to `[supported_old_versions]` section in `project.toml`. Learn more in the [Data Change Management docs](../building/dcm/intro).
+Bumps the `version` field in `package.json`, and adds an entry of the current version and commit hash to `[supported_old_versions]` section in `moose.config.toml`. Learn more in the [Data Change Management docs](../building/dcm/intro).
 
 ```txt filename="Terminal" copy
 moose bump-version <new_version>


### PR DESCRIPTION
* Renames `project.toml` to `moose.config.toml`

This is backward compatible so all current projects should continue working as is and we can remove the old code when that's not needed anymore