### PR TITLE
Metric console and moose metrics command

### DIFF
--- a/apps/framework-cli/Cargo.lock
+++ b/apps/framework-cli/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +277,21 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -497,6 +518,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "config"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,8 +675,12 @@ checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
+ "futures-core",
  "libc",
+ "mio",
  "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -1131,6 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1647,6 +1686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "lz4"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1841,7 @@ dependencies = [
  "config",
  "console",
  "convert_case 0.6.0",
+ "crossterm",
  "crypto-hash",
  "diagnostics",
  "fern",
@@ -1823,6 +1872,8 @@ dependencies = [
  "pathdiff",
  "predicates",
  "prometheus-client",
+ "prometheus-parse",
+ "ratatui",
  "rdkafka",
  "regex",
  "reqwest 0.12.4",
@@ -2416,6 +2467,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2538,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
+dependencies = [
+ "bitflags 2.5.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "stability",
+ "strum 0.26.2",
+ "strum_macros 0.26.4",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3081,6 +3165,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3237,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3272,9 @@ name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3636,10 +3754,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.12"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode_names2"

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -69,6 +69,9 @@ opentelemetry-appender-log ="0.4.0"
 walkdir = "2"
 comfy-table = "7.1.1"
 prometheus-client = "0.22.2"
+ratatui = "0.27.0"
+prometheus-parse = "0.2.5"
+crossterm = { version = "0.27.0", features = ["event-stream"] }
 
 [dev-dependencies]
 clickhouse = { version = "0.11.5", features = ["uuid", "test-util"] }

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -24,6 +24,7 @@ use log::{debug, info};
 use logger::setup_logging;
 use regex::Regex;
 use routines::ls::{list_db, list_streaming};
+use routines::metrics_console::run_console;
 use routines::plan;
 use routines::ps::show_processes;
 use settings::{read_settings, Settings};
@@ -605,6 +606,8 @@ async fn top_command_handler(
                 list_db(project_arc, version, limit).await
             }
         }
+
+        Commands::Metrics {} => run_console().await,
     }
 }
 

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -50,7 +50,9 @@ pub enum Commands {
     /// Generates missing migration files
     Generate(GenerateArgs),
     /// Bumps the version of the project
-    BumpVersion { new_version: Option<String> },
+    BumpVersion {
+        new_version: Option<String>,
+    },
     /// Clears all temporary data and stops development infrastructure
     Clean {},
     /// Transforms upstream data into materialized datasets for analysis
@@ -85,6 +87,8 @@ pub enum Commands {
         #[arg(short, long, default_value = "false")]
         streaming: bool,
     },
+
+    Metrics {},
 }
 
 #[derive(Debug, Args)]

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -50,9 +50,7 @@ pub enum Commands {
     /// Generates missing migration files
     Generate(GenerateArgs),
     /// Bumps the version of the project
-    BumpVersion {
-        new_version: Option<String>,
-    },
+    BumpVersion { new_version: Option<String> },
     /// Clears all temporary data and stops development infrastructure
     Clean {},
     /// Transforms upstream data into materialized datasets for analysis
@@ -88,6 +86,7 @@ pub enum Commands {
         streaming: bool,
     },
 
+    /// Opens metrics console for viewing live metrics from your moose app
     Metrics {},
 }
 

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -129,6 +129,7 @@ pub mod docker_packager;
 pub mod initialize;
 pub mod logs;
 pub mod ls;
+pub mod metrics_console;
 pub mod migrate;
 pub mod ps;
 pub mod stop;

--- a/apps/framework-cli/src/cli/routines/metrics_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console.rs
@@ -1,0 +1,20 @@
+use crate::cli::{display::Message, routines::RoutineSuccess};
+
+mod run_console;
+
+use super::RoutineFailure;
+
+pub async fn run_console() -> Result<RoutineSuccess, RoutineFailure> {
+    let result = run_console::run_console().await;
+
+    match result {
+        Ok(_) => Ok(RoutineSuccess::success(Message::new(
+            "".to_string(),
+            "".to_string(),
+        ))),
+        _ => Err(RoutineFailure::error(Message::new(
+            "".to_string(),
+            "".to_string(),
+        ))),
+    }
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -1,0 +1,44 @@
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+use std::io;
+
+mod app;
+mod client;
+mod event;
+mod handler;
+mod tui;
+mod ui;
+
+use app::App;
+use event::Event;
+use handler::handle_key_events;
+
+pub async fn run_console() -> app::AppResult<()> {
+    // Create an application.
+    let mut app = App::new();
+
+    // Initialize the terminal user interface.
+    let backend = CrosstermBackend::new(io::stderr());
+    let terminal = Terminal::new(backend)?;
+    let events = event::EventHandler::new(250);
+    let mut tui = tui::Tui::new(terminal, events);
+    tui.init()?;
+
+    // Start the main loop.
+    while app.running {
+        let (average, total_requests, summary) = client::client().await.unwrap();
+        app.set_metrics(average, total_requests, summary);
+
+        // Render the user interface.
+        tui.draw(&mut app)?;
+        // Handle events.
+        match tui.events.next().await? {
+            Event::Tick => app.tick(),
+            Event::Key(key_event) => handle_key_events(key_event, &mut app)?,
+        }
+    }
+
+    // Exit the user interface.
+    tui.exit()?;
+    Ok(())
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -9,7 +9,6 @@ pub struct App {
     pub total_requests: f64,
     pub summary: Vec<(f64, f64, String)>,
     pub starting_row: usize,
-    pub selected_row: usize,
 }
 
 impl Default for App {
@@ -20,7 +19,6 @@ impl Default for App {
             total_requests: 0.0,
             summary: vec![],
             starting_row: 0,
-            selected_row: 0,
         }
     }
 }
@@ -50,13 +48,11 @@ impl App {
     pub fn down(&mut self) {
         if self.starting_row < (self.summary.len() - 1) {
             self.starting_row += 1;
-            self.selected_row = 0;
         }
     }
     pub fn up(&mut self) {
         if self.starting_row > 0 {
             self.starting_row -= 1;
-            self.selected_row = 0;
         }
     }
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -1,0 +1,62 @@
+use std::error;
+
+pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
+
+#[derive(Debug)]
+pub struct App {
+    pub running: bool,
+    pub average: f64,
+    pub total_requests: f64,
+    pub summary: Vec<(f64, f64, String)>,
+    pub starting_row: usize,
+    pub selected_row: usize,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            running: true,
+            average: 0.0,
+            total_requests: 0.0,
+            summary: vec![],
+            starting_row: 0,
+            selected_row: 0,
+        }
+    }
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn tick(&self) {}
+
+    pub fn quit(&mut self) {
+        self.running = false;
+    }
+
+    pub fn set_metrics(
+        &mut self,
+        average: f64,
+        total_requests: f64,
+        summary: Vec<(f64, f64, String)>,
+    ) {
+        self.average = average;
+        self.total_requests = total_requests;
+        self.summary = summary;
+    }
+
+    pub fn down(&mut self) {
+        if self.starting_row < (self.summary.len() - 1) {
+            self.starting_row += 1;
+            self.selected_row = 0;
+        }
+    }
+    pub fn up(&mut self) {
+        if self.starting_row > 0 {
+            self.starting_row -= 1;
+            self.selected_row = 0;
+        }
+    }
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/client.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/client.rs
@@ -1,0 +1,72 @@
+use prometheus_parse::{self};
+use reqwest;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+pub async fn client() -> Result<(f64, f64, Vec<(f64, f64, String)>)> {
+    let body = reqwest::get("http://localhost:4000/metrics")
+        .await
+        .unwrap()
+        .text();
+    let lines: Vec<_> = body
+        .await
+        .unwrap()
+        .lines()
+        .map(|s| Ok(s.to_owned()))
+        .collect();
+
+    let metrics = prometheus_parse::Scrape::parse(lines.into_iter())?;
+
+    let metrics_vec = metrics.samples;
+
+    let mut average_latency: f64 = 0.0;
+    let mut total_requests: f64 = 0.0;
+    let mut paths_latency_average_vec: Vec<(f64, f64, String)> = vec![];
+
+    let mut i = 0;
+    while i < metrics_vec.len() {
+        if &metrics_vec[i].metric == "total_latency_sum" {
+            let value = match &metrics_vec[i].value {
+                prometheus_parse::Value::Histogram(v) => v[0].count,
+                prometheus_parse::Value::Untyped(v) => *v,
+                _ => 0.0,
+            };
+            average_latency = value;
+        }
+        if &metrics_vec[i].metric == "total_latency_count" {
+            let value = match &metrics_vec[i].value {
+                prometheus_parse::Value::Histogram(v) => v[0].count,
+                prometheus_parse::Value::Untyped(v) => *v,
+                _ => 0.0,
+            };
+            total_requests = value;
+            average_latency = (average_latency / value) * 1000.0;
+        }
+
+        i += 1;
+    }
+
+    let mut j = 0;
+    while j < metrics_vec.len() {
+        if metrics_vec[j].metric == "latency_sum" {
+            let sum_value = match &metrics_vec[j].value {
+                prometheus_parse::Value::Histogram(v) => v[0].count,
+                prometheus_parse::Value::Untyped(v) => *v,
+                _ => 0.0,
+            };
+            let count_value = match &metrics_vec[j + 1].value {
+                prometheus_parse::Value::Histogram(v) => v[0].count,
+                prometheus_parse::Value::Untyped(v) => *v,
+                _ => 0.0,
+            };
+            paths_latency_average_vec.push((
+                sum_value,
+                count_value,
+                (metrics_vec[j].labels["path"]).to_string(),
+            ));
+        }
+        j += 1;
+    }
+
+    Ok((average_latency, total_requests, paths_latency_average_vec))
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/event.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/event.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use crossterm::event::{Event as CrosstermEvent, KeyEvent};
+use futures::{FutureExt, StreamExt};
+use tokio::sync::mpsc;
+
+use crate::cli::routines::metrics_console::run_console::app::AppResult;
+
+/// Terminal events.
+#[derive(Clone, Copy, Debug)]
+pub enum Event {
+    /// Terminal tick.
+    Tick,
+    /// Key press.
+    Key(KeyEvent),
+}
+
+/// Terminal event handler.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct EventHandler {
+    /// Event sender channel.
+    sender: mpsc::UnboundedSender<Event>,
+    /// Event receiver channel.
+    receiver: mpsc::UnboundedReceiver<Event>,
+    /// Event handler thread.
+    handler: tokio::task::JoinHandle<()>,
+}
+
+impl EventHandler {
+    /// Constructs a new instance of [`EventHandler`].
+    pub fn new(tick_rate: u64) -> Self {
+        let tick_rate = Duration::from_millis(tick_rate);
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let _sender = sender.clone();
+        let handler = tokio::spawn(async move {
+            let mut reader = crossterm::event::EventStream::new();
+            let mut tick = tokio::time::interval(tick_rate);
+            loop {
+                let tick_delay = tick.tick();
+                let crossterm_event = reader.next().fuse();
+                tokio::select! {
+                  _ = _sender.closed() => {
+                    break;
+                  }
+                  _ = tick_delay => {
+                    _sender.send(Event::Tick).unwrap();
+                  }
+                  Some(Ok(evt)) = crossterm_event => {
+                    match evt {
+                      CrosstermEvent::Key(key) => {
+                        if key.kind == crossterm::event::KeyEventKind::Press {
+                          _sender.send(Event::Key(key)).unwrap();
+                        }
+                      },
+                      CrosstermEvent::FocusLost => {
+                      },
+                      CrosstermEvent::FocusGained => {
+                      },
+                      CrosstermEvent::Paste(_) => {
+                      },
+                      _ => {}
+                    }
+                  }
+                };
+            }
+        });
+        Self {
+            sender,
+            receiver,
+            handler,
+        }
+    }
+
+    /// Receive the next event from the handler thread.
+    ///
+    /// This function will always block the current thread if
+    /// there is no data available and it's possible for more data to be sent.
+    pub async fn next(&mut self) -> AppResult<Event> {
+        self.receiver
+            .recv()
+            .await
+            .ok_or(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "This is an IO error",
+            )))
+    }
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -1,0 +1,25 @@
+use crate::cli::routines::metrics_console::run_console::app::{App, AppResult};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
+    match key_event.code {
+        KeyCode::Char('q') => {
+            app.quit();
+        }
+        KeyCode::Char('c') | KeyCode::Char('C') => {
+            if key_event.modifiers == KeyModifiers::CONTROL {
+                app.quit();
+            }
+        }
+
+        KeyCode::Down => {
+            app.down();
+        }
+
+        KeyCode::Up => {
+            app.up();
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/lib.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/lib.rs
@@ -1,0 +1,16 @@
+/// Application.
+pub mod app;
+
+/// Terminal events handler.
+pub mod event;
+
+/// Widget renderer.
+pub mod ui;
+
+/// Terminal user interface.
+pub mod tui;
+
+/// Event handler.
+pub mod handler;
+
+pub mod client;

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/tui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/tui.rs
@@ -1,0 +1,76 @@
+use crate::cli::routines::metrics_console::run_console::app::{App, AppResult};
+use crate::cli::routines::metrics_console::run_console::event::EventHandler;
+use crate::cli::routines::metrics_console::run_console::ui;
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::backend::Backend;
+use ratatui::Terminal;
+use std::io;
+use std::panic;
+
+/// Representation of a terminal user interface.
+///
+/// It is responsible for setting up the terminal,
+/// initializing the interface and handling the draw events.
+#[derive(Debug)]
+pub struct Tui<B: Backend> {
+    /// Interface to the Terminal.
+    terminal: Terminal<B>,
+    /// Terminal event handler.
+    pub events: EventHandler,
+}
+
+impl<B: Backend> Tui<B> {
+    /// Constructs a new instance of [`Tui`].
+    pub fn new(terminal: Terminal<B>, events: EventHandler) -> Self {
+        Self { terminal, events }
+    }
+
+    /// Initializes the terminal interface.
+    ///
+    /// It enables the raw mode and sets terminal properties.
+    pub fn init(&mut self) -> AppResult<()> {
+        terminal::enable_raw_mode()?;
+        crossterm::execute!(io::stderr(), EnterAlternateScreen, EnableMouseCapture)?;
+
+        // Define a custom panic hook to reset the terminal properties.
+        // This way, you won't have your terminal messed up if an unexpected error happens.
+        let panic_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |panic| {
+            Self::reset().expect("failed to reset the terminal");
+            panic_hook(panic);
+        }));
+
+        self.terminal.hide_cursor()?;
+        self.terminal.clear()?;
+        Ok(())
+    }
+
+    /// [`Draw`] the terminal interface by [`rendering`] the widgets.
+    ///
+    /// [`Draw`]: ratatui::Terminal::draw
+    /// [`rendering`]: crate::ui::render
+    pub fn draw(&mut self, app: &mut App) -> AppResult<()> {
+        self.terminal.draw(|frame| ui::render(app, frame))?;
+        Ok(())
+    }
+
+    /// Resets the terminal interface.
+    ///
+    /// This function is also used for the panic hook to revert
+    /// the terminal properties if unexpected errors occur.
+    fn reset() -> AppResult<()> {
+        terminal::disable_raw_mode()?;
+        crossterm::execute!(io::stderr(), LeaveAlternateScreen, DisableMouseCapture)?;
+        Ok(())
+    }
+
+    /// Exits the terminal interface.
+    ///
+    /// It disables the raw mode and reverts back the terminal properties.
+    pub fn exit(&mut self) -> AppResult<()> {
+        Self::reset()?;
+        self.terminal.show_cursor()?;
+        Ok(())
+    }
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -1,0 +1,110 @@
+use ratatui::{
+    layout::Alignment,
+    style::{Color, Style, Stylize},
+    Frame,
+};
+
+use ratatui::{prelude::*, widgets::*};
+
+use crate::cli::routines::metrics_console::run_console::app::App;
+
+const INFO_TEXT: &str = "(q) quit | (↑) move up | (↓) move down";
+
+/// Renders the user interface widgets.
+pub fn render(app: &mut App, frame: &mut Frame) {
+    let mut summary_text = String::new();
+
+    for path in &app.summary {
+        summary_text += format!(
+            "Path: {} \n \t - Average Latency: {} \n \t - Number of Requests: {} \n\n",
+            path.2, path.0, path.1
+        )
+        .as_str();
+    }
+
+    let outer_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(vec![
+            Constraint::Max(2),
+            Constraint::Max(2),
+            Constraint::Fill(80),
+            Constraint::Max(3),
+        ])
+        .split(frame.size());
+
+    let paragraph_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(vec![Constraint::Max(30)])
+        .split(outer_layout[1]);
+
+    let inner_layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(paragraph_layout[0]);
+
+    let mut rows: Vec<Row> = vec![];
+
+    for x in &app.summary {
+        rows.push(
+            Row::new(vec![
+                format!("{}", x.2.to_string()),
+                format!("{:.6} ms", ((x.0 / x.1) * 1000.0).to_string()),
+                format!("{:.6}", x.1.to_string()),
+            ])
+            .not_bold(),
+        )
+    }
+    let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
+    let mut table_state = TableState::default();
+    *table_state.offset_mut() = app.selected_row;
+    table_state.select(Some(app.starting_row));
+
+    let table = Table::new(rows, widths)
+        .widths(widths)
+        .column_spacing(1)
+        .style(Style::new().green())
+        .header(
+            Row::new(vec!["Path", "Latency", "Requests"])
+                .style(Style::new().bold())
+                .bottom_margin(1)
+                .underlined(),
+        )
+        .block(Block::bordered().title("Endpoint Metrics Table").bold())
+        .highlight_style(Style::new().reversed())
+        .highlight_symbol(">>");
+
+    let info_footer = Paragraph::new(Line::from(INFO_TEXT).green())
+        .centered()
+        .block(
+            Block::bordered()
+                .border_type(BorderType::Double)
+                .border_style(Style::new().fg(Color::Green)),
+        );
+
+    let block = Block::new()
+        .title("Metrics Console")
+        .title_alignment(Alignment::Center)
+        .bold()
+        .borders(Borders::TOP)
+        .green();
+    let average_lat = Block::new()
+        .title(format!("Average Latency: \n {:.6}", app.average))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white()
+        .padding(Padding::top(50));
+    let total_req = Block::new()
+        .title(format!(
+            "Total Number of Requests: \n\n {}",
+            app.total_requests
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white();
+
+    frame.render_widget(block, outer_layout[0]);
+    frame.render_widget(average_lat, inner_layout[0]);
+    frame.render_widget(total_req, inner_layout[1]);
+    frame.render_widget(info_footer, outer_layout[3]);
+    frame.render_stateful_widget(table, outer_layout[2], &mut table_state);
+}

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -59,7 +59,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     }
     let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
     let mut table_state = TableState::default();
-    *table_state.offset_mut() = app.selected_row;
     table_state.select(Some(app.starting_row));
 
     let table = Table::new(rows, widths)

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -64,7 +64,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         .column_spacing(1)
         .style(Style::new().green())
         .header(
-            Row::new(vec!["Path", "Latency", "Requests"])
+            Row::new(vec!["Path", "Latency", "Number of Requests"])
                 .style(Style::new().bold())
                 .bottom_margin(1)
                 .underlined(),

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -48,8 +48,11 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         rows.push(
             Row::new(vec![
                 format!("{}", x.2.to_string()),
-                format!("{:.6} ms", ((x.0 / x.1) * 1000.0).to_string()),
-                format!("{:.6}", x.1.to_string()),
+                format!(
+                    "{}",
+                    ((((x.0 / x.1) * 1000.0) * 1000.0).round() / 1000.0).to_string()
+                ),
+                format!("{}", (((x.1 * 1000.0).round()) / 1000.0).to_string()),
             ])
             .not_bold(),
         )
@@ -64,7 +67,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         .column_spacing(1)
         .style(Style::new().green())
         .header(
-            Row::new(vec!["Path", "Latency", "Number of Requests"])
+            Row::new(vec!["Path", "Latency (ms)", "Number of Requests"])
                 .style(Style::new().bold())
                 .bottom_margin(1)
                 .underlined(),
@@ -88,7 +91,10 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         .borders(Borders::TOP)
         .green();
     let average_lat = Block::new()
-        .title(format!("Average Latency: \n {:.6}", app.average))
+        .title(format!(
+            "Average Latency: \n {}",
+            (app.average * 1000.0).round() / 1000.0
+        ))
         .title_alignment(Alignment::Center)
         .bold()
         .white()


### PR DESCRIPTION
Created a ratatui terminal ui that displays average latency and the total number of requests. It also has a table that shows the path of each endpoint that a request has been sent to and its average latency and the number of requests sent to that http endpoint. The user can view this console by running moose metrics in a separate terminal window

<img width="567" alt="Screenshot 2024-07-11 at 11 17 19 AM" src="https://github.com/514-labs/moose/assets/115904204/4a506d79-e595-45b6-8934-3cbfebea3809">

