### PR TITLE
Added requests per second metric to console and adjusted metrics calculations

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -491,13 +491,24 @@ async fn router(
             .status(StatusCode::NOT_FOUND)
             .body(Full::new(Bytes::from("no match"))),
     };
-    metrics
-        .send_metric(MetricsMessage::HTTPLatency((
-            metrics_path,
-            now.elapsed(),
-            metrics_method,
-        )))
-        .await;
+
+    if metrics_path
+        .clone()
+        .into_os_string()
+        .to_str()
+        .unwrap()
+        .to_string()
+        != "metrics"
+    {
+        metrics
+            .send_metric(MetricsMessage::HTTPLatency((
+                metrics_path,
+                now.elapsed(),
+                metrics_method,
+            )))
+            .await;
+    }
+
     res
 }
 

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -492,14 +492,7 @@ async fn router(
             .body(Full::new(Bytes::from("no match"))),
     };
 
-    if metrics_path
-        .clone()
-        .into_os_string()
-        .to_str()
-        .unwrap()
-        .to_string()
-        != "metrics"
-    {
+    if metrics_path.clone().into_os_string().to_str().unwrap() != "metrics" {
         metrics
             .send_metric(MetricsMessage::HTTPLatency((
                 metrics_path,

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -14,6 +14,13 @@ use app::App;
 use event::Event;
 use handler::handle_key_events;
 
+type Sender = tokio::sync::mpsc::Sender<(f64, f64, Vec<(f64, f64, String)>)>;
+type Receiver = tokio::sync::mpsc::Receiver<(f64, f64, Vec<(f64, f64, String)>)>;
+struct ConsoleChannel {
+    sender: Sender,
+    receiver: Receiver,
+}
+
 pub async fn run_console() -> app::AppResult<()> {
     // Create an application.
     let mut app = App::new();
@@ -25,12 +32,19 @@ pub async fn run_console() -> app::AppResult<()> {
     let mut tui = tui::Tui::new(terminal, events);
     tui.init()?;
 
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<(f64, f64, Vec<(f64, f64, String)>)>(10);
+    let (tx, rx) = tokio::sync::mpsc::channel::<(f64, f64, Vec<(f64, f64, String)>)>(10);
+    let mut channel = ConsoleChannel {
+        sender: tx,
+        receiver: rx,
+    };
 
     tokio::spawn(async move {
         loop {
-            let (average, total_requests, summary) = client::client().await.unwrap();
-            let _ = tx.send((average, total_requests, summary)).await;
+            let (average, total_requests, summary) = client::getting_metrics_data().await.unwrap();
+            let _ = channel
+                .sender
+                .send((average, total_requests, summary))
+                .await;
             tokio::time::sleep(time::Duration::from_millis(1000)).await;
         }
     });
@@ -38,7 +52,7 @@ pub async fn run_console() -> app::AppResult<()> {
     // Start the main loop.
     while app.running {
         tokio::select! {
-            received = rx.recv() => {
+            received = channel.receiver.recv() => {
                 if let Some(v) = received {
                     app.req_per_sec(v.1);
                     app.set_metrics(v.0, v.1, v.2);

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -39,12 +39,9 @@ pub async fn run_console() -> app::AppResult<()> {
     while app.running {
         tokio::select! {
             received = rx.recv() => {
-                match received {
-                    Some(v) => {
-                        app.req_per_sec(v.1);
-                        app.set_metrics(v.0, v.1, v.2);},
-                    None => {
-                    }
+                if let Some(v) = received {
+                    app.req_per_sec(v.1);
+                    app.set_metrics(v.0, v.1, v.2);
                 };
             }
             // Handle events.

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -1,14 +1,14 @@
+use super::client::{ParsedMetricsData, PathMetricsData};
 use std::error;
 
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 
-#[derive(Debug)]
 pub struct App {
     pub running: bool,
     pub average: f64,
     pub requests_per_sec: f64,
     pub total_requests: f64,
-    pub summary: Vec<(f64, f64, String)>,
+    pub summary: Vec<PathMetricsData>,
     pub starting_row: usize,
 }
 
@@ -36,15 +36,10 @@ impl App {
         self.running = false;
     }
 
-    pub fn set_metrics(
-        &mut self,
-        average: f64,
-        total_requests: f64,
-        summary: Vec<(f64, f64, String)>,
-    ) {
-        self.average = average;
-        self.total_requests = total_requests;
-        self.summary = summary;
+    pub fn set_metrics(&mut self, parsed_data: ParsedMetricsData) {
+        self.average = parsed_data.average_latency;
+        self.total_requests = parsed_data.total_requests;
+        self.summary = parsed_data.paths_data_vec;
     }
 
     pub fn down(&mut self) {

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -6,6 +6,7 @@ pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 pub struct App {
     pub running: bool,
     pub average: f64,
+    pub requests_per_sec: f64,
     pub total_requests: f64,
     pub summary: Vec<(f64, f64, String)>,
     pub starting_row: usize,
@@ -16,6 +17,7 @@ impl Default for App {
         Self {
             running: true,
             average: 0.0,
+            requests_per_sec: 0.0,
             total_requests: 0.0,
             summary: vec![],
             starting_row: 0,
@@ -46,7 +48,7 @@ impl App {
     }
 
     pub fn down(&mut self) {
-        if self.starting_row < (self.summary.len() - 1) {
+        if (self.starting_row + 1) < self.summary.len() {
             self.starting_row += 1;
         }
     }
@@ -54,5 +56,9 @@ impl App {
         if self.starting_row > 0 {
             self.starting_row -= 1;
         }
+    }
+
+    pub fn req_per_sec(&mut self, new_total_requests: f64) {
+        self.requests_per_sec = new_total_requests - self.total_requests;
     }
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/client.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/client.rs
@@ -3,7 +3,7 @@ use reqwest;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-pub async fn client() -> Result<(f64, f64, Vec<(f64, f64, String)>)> {
+pub async fn getting_metrics_data() -> Result<(f64, f64, Vec<(f64, f64, String)>)> {
     let body = reqwest::get("http://localhost:4000/metrics")
         .await
         .unwrap()

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -39,7 +39,11 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 
     let inner_layout = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+        .constraints(vec![
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
         .split(paragraph_layout[0]);
 
     let mut rows: Vec<Row> = vec![];
@@ -107,9 +111,19 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         .bold()
         .white();
 
+    let req_per_sec = Block::new()
+        .title(format!(
+            "Requests Per Second: \n\n {}",
+            app.requests_per_sec
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white();
+
     frame.render_widget(block, outer_layout[0]);
     frame.render_widget(average_lat, inner_layout[0]);
     frame.render_widget(total_req, inner_layout[1]);
+    frame.render_widget(req_per_sec, inner_layout[2]);
     frame.render_widget(info_footer, outer_layout[3]);
     frame.render_stateful_widget(table, outer_layout[2], &mut table_state);
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -12,16 +12,6 @@ const INFO_TEXT: &str = "(q) quit | (↑) move up | (↓) move down";
 
 /// Renders the user interface widgets.
 pub fn render(app: &mut App, frame: &mut Frame) {
-    let mut summary_text = String::new();
-
-    for path in &app.summary {
-        summary_text += format!(
-            "Path: {} \n \t - Average Latency: {} \n \t - Number of Requests: {} \n\n",
-            path.2, path.0, path.1
-        )
-        .as_str();
-    }
-
     let outer_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints(vec![
@@ -51,12 +41,16 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     for x in &app.summary {
         rows.push(
             Row::new(vec![
-                format!("{}", x.2.to_string()),
+                format!("{}", x.path.to_string()),
                 format!(
                     "{}",
-                    ((((x.0 / x.1) * 1000.0) * 1000.0).round() / 1000.0).to_string()
+                    ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                        .to_string()
                 ),
-                format!("{}", (((x.1 * 1000.0).round()) / 1000.0).to_string()),
+                format!(
+                    "{}",
+                    (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                ),
             ])
             .not_bold(),
         )


### PR DESCRIPTION
The metrics console now gets data once a second and calculates requests a second. Also I have removed the metrics endpoint from all calculations because it skews the numbers since the console is constantly making requests to it.

New UI Look:
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/afc77faa-61be-4055-8b58-1d75faa9c06d">
