### PR TITLE
Detailed metrics views for each http endpoint

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -492,18 +492,13 @@ async fn router(
             .body(Full::new(Bytes::from("no match"))),
     };
 
-    if metrics_path
-        .clone()
-        .into_os_string()
-        .to_str()
-        .unwrap()
-        .contains("ingest/")
+    if metrics_path.to_str().unwrap().starts_with("ingest/")
         || metrics_path
             .clone()
             .into_os_string()
             .to_str()
             .unwrap()
-            .contains("consumption/")
+            .starts_with("consumption/")
     {
         metrics
             .send_metric(MetricsMessage::HTTPLatency((

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -492,7 +492,19 @@ async fn router(
             .body(Full::new(Bytes::from("no match"))),
     };
 
-    if metrics_path.clone().into_os_string().to_str().unwrap() != "metrics" {
+    if metrics_path
+        .clone()
+        .into_os_string()
+        .to_str()
+        .unwrap()
+        .contains("ingest/")
+        || metrics_path
+            .clone()
+            .into_os_string()
+            .to_str()
+            .unwrap()
+            .contains("consumption/")
+    {
         metrics
             .send_metric(MetricsMessage::HTTPLatency((
                 metrics_path,

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -41,20 +41,23 @@ pub async fn run_console() -> app::AppResult<()> {
         tokio::select! {
             received = rx.recv() => {
                 if let Some(v) = received {
-                    app.req_per_sec(v.total_requests);
+                    app.req_per_sec(v.total_requests, &v.paths_data_vec);
                     app.set_metrics(v);
                 };
             }
             // Handle events.
             event = tui.events.next() => { match event?{
                     Event::Tick => app.tick(),
-                    Event::Key(key_event) => handle_key_events(key_event, &mut app)?,
+                    Event::Key(key_event) => handle_key_events(key_event, &mut app).await?,
                 }
             }
         }
 
         // Render the user interface.
         tui.draw(&mut app)?;
+        // if app.state != "main" {
+        //     app.set_path_data(app.state.clone()).await;
+        // }
     }
 
     // Exit the user interface.

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -55,9 +55,6 @@ pub async fn run_console() -> app::AppResult<()> {
 
         // Render the user interface.
         tui.draw(&mut app)?;
-        // if app.state != "main" {
-        //     app.set_path_data(app.state.clone()).await;
-        // }
     }
 
     // Exit the user interface.

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -75,6 +75,7 @@ impl App {
     pub fn req_per_sec(&mut self, new_total_requests: f64, path_metrics: &Vec<PathMetricsData>) {
         self.requests_per_sec = new_total_requests - self.total_requests;
 
+        // Initializes variables and vec for each path in summary to keep unwraps in ui.rs safe
         for path in &self.summary {
             if !self.path_requests_per_sec.contains_key(&path.path) {
                 self.path_requests_per_sec

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -91,9 +91,7 @@ impl App {
                 self.requests_per_sec_vec
                     .insert(path.path.clone(), vec![0; 150]);
             }
-        }
 
-        for path in &self.summary {
             for item in path_metrics {
                 if item.path == path.path {
                     self.path_requests_per_sec

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -6,9 +6,14 @@ use std::{collections::HashMap, error};
 
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 
+pub enum State {
+    Main(),
+    PathDetails(String),
+}
+
 pub struct App {
     pub viewport: Rect,
-    pub state: String,
+    pub state: State,
     pub running: bool,
     pub average: f64,
     pub requests_per_sec: f64,
@@ -24,7 +29,7 @@ impl Default for App {
     fn default() -> Self {
         Self {
             viewport: Rect::new(0, 0, 0, 0),
-            state: "main".to_string(),
+            state: State::Main(),
             running: true,
             average: 0.0,
             requests_per_sec: 0.0,
@@ -108,7 +113,7 @@ impl App {
         }
     }
 
-    pub fn set_state(&mut self, state: String) {
+    pub fn set_state(&mut self, state: State) {
         self.state = state;
     }
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -1,12 +1,15 @@
 use prometheus_parse::HistogramCount;
+use ratatui::layout::Rect;
 
 use super::client::{parsing_histogram_data, ParsedMetricsData, PathMetricsData};
-use std::error;
+use std::{collections::HashMap, error};
 
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 pub struct App {
+    pub viewport: Rect,
     pub state: String,
+    pub view: String,
     pub running: bool,
     pub average: f64,
     pub requests_per_sec: f64,
@@ -14,13 +17,16 @@ pub struct App {
     pub summary: Vec<PathMetricsData>,
     pub starting_row: usize,
     pub path_detailed_data: Option<Vec<HistogramCount>>,
-    pub path_requests_per_sec: f64,
+    pub path_requests_per_sec: HashMap<String, f64>,
+    pub requests_per_sec_vec: HashMap<String, Vec<u64>>,
 }
 
 impl Default for App {
     fn default() -> Self {
         Self {
+            viewport: Rect::new(0, 0, 0, 0),
             state: "main".to_string(),
+            view: "main".to_string(),
             running: true,
             average: 0.0,
             requests_per_sec: 0.0,
@@ -28,7 +34,8 @@ impl Default for App {
             summary: vec![],
             starting_row: 0,
             path_detailed_data: vec![].into(),
-            path_requests_per_sec: 0.0,
+            path_requests_per_sec: HashMap::new(),
+            requests_per_sec_vec: HashMap::new(),
         }
     }
 }
@@ -48,10 +55,12 @@ impl App {
         self.average = parsed_data.average_latency;
         self.total_requests = parsed_data.total_requests;
         self.summary = parsed_data.paths_data_vec;
-        self.path_detailed_data = parsing_histogram_data(
-            self.summary[self.starting_row].path.clone(),
-            parsed_data.histogram_vec,
-        )
+        if !self.summary.is_empty() {
+            self.path_detailed_data = parsing_histogram_data(
+                self.summary[self.starting_row].path.clone(),
+                parsed_data.histogram_vec,
+            )
+        }
     }
 
     pub fn down(&mut self) {
@@ -67,10 +76,35 @@ impl App {
 
     pub fn req_per_sec(&mut self, new_total_requests: f64, path_metrics: &Vec<PathMetricsData>) {
         self.requests_per_sec = new_total_requests - self.total_requests;
-        for value in path_metrics {
-            if value.path == self.state {
-                self.path_requests_per_sec =
-                    value.request_count - self.summary[self.starting_row].request_count;
+
+        for path in &self.summary {
+            if !self.path_requests_per_sec.contains_key(&path.path) {
+                self.path_requests_per_sec
+                    .insert(path.path.clone(), path.request_count);
+            }
+
+            if !self.requests_per_sec_vec.contains_key(&path.path) {
+                self.requests_per_sec_vec
+                    .insert(path.path.clone(), vec![0; 150]);
+            }
+        }
+
+        for path in &self.summary {
+            for item in path_metrics {
+                if item.path == path.path {
+                    self.path_requests_per_sec
+                        .insert(path.path.clone(), item.request_count - path.request_count);
+                }
+            }
+            self.requests_per_sec_vec
+                .get_mut(&path.path)
+                .unwrap()
+                .push(*self.path_requests_per_sec.get(&path.path).unwrap() as u64);
+            while self.requests_per_sec_vec.get(&path.path).unwrap().len() > 150 {
+                self.requests_per_sec_vec
+                    .get_mut(&path.path)
+                    .unwrap()
+                    .remove(0);
             }
         }
     }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -1,26 +1,34 @@
-use super::client::{ParsedMetricsData, PathMetricsData};
+use prometheus_parse::HistogramCount;
+
+use super::client::{parsing_histogram_data, ParsedMetricsData, PathMetricsData};
 use std::error;
 
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 pub struct App {
+    pub state: String,
     pub running: bool,
     pub average: f64,
     pub requests_per_sec: f64,
     pub total_requests: f64,
     pub summary: Vec<PathMetricsData>,
     pub starting_row: usize,
+    pub path_detailed_data: Option<Vec<HistogramCount>>,
+    pub path_requests_per_sec: f64,
 }
 
 impl Default for App {
     fn default() -> Self {
         Self {
+            state: "main".to_string(),
             running: true,
             average: 0.0,
             requests_per_sec: 0.0,
             total_requests: 0.0,
             summary: vec![],
             starting_row: 0,
+            path_detailed_data: vec![].into(),
+            path_requests_per_sec: 0.0,
         }
     }
 }
@@ -40,6 +48,10 @@ impl App {
         self.average = parsed_data.average_latency;
         self.total_requests = parsed_data.total_requests;
         self.summary = parsed_data.paths_data_vec;
+        self.path_detailed_data = parsing_histogram_data(
+            self.summary[self.starting_row].path.clone(),
+            parsed_data.histogram_vec,
+        )
     }
 
     pub fn down(&mut self) {
@@ -53,7 +65,17 @@ impl App {
         }
     }
 
-    pub fn req_per_sec(&mut self, new_total_requests: f64) {
+    pub fn req_per_sec(&mut self, new_total_requests: f64, path_metrics: &Vec<PathMetricsData>) {
         self.requests_per_sec = new_total_requests - self.total_requests;
+        for value in path_metrics {
+            if value.path == self.state {
+                self.path_requests_per_sec =
+                    value.request_count - self.summary[self.starting_row].request_count;
+            }
+        }
+    }
+
+    pub fn set_state(&mut self, state: String) {
+        self.state = state;
     }
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -9,7 +9,6 @@ pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 pub struct App {
     pub viewport: Rect,
     pub state: String,
-    pub view: String,
     pub running: bool,
     pub average: f64,
     pub requests_per_sec: f64,
@@ -26,7 +25,6 @@ impl Default for App {
         Self {
             viewport: Rect::new(0, 0, 0, 0),
             state: "main".to_string(),
-            view: "main".to_string(),
             running: true,
             average: 0.0,
             requests_per_sec: 0.0,

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -26,9 +26,15 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<
         KeyCode::Esc => {
             if app.state == "main" {
                 app.quit();
+            } else if app.view != "main" {
+                app.view = "main".to_string();
             } else {
                 app.set_state("main".to_string());
             }
+        }
+
+        KeyCode::Char('g') => {
+            app.view = "graphs".to_string();
         }
         _ => {}
     }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -1,3 +1,4 @@
+use crate::cli::routines::metrics_console::run_console::app::State;
 use crate::cli::routines::metrics_console::run_console::app::{App, AppResult};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -21,15 +22,18 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<
         }
 
         KeyCode::Enter => {
-            app.set_state(app.summary[app.starting_row].path.to_string());
+            app.set_state(State::PathDetails(
+                app.summary[app.starting_row].path.to_string(),
+            ));
         }
-        KeyCode::Esc => {
-            if app.state == "main" {
+        KeyCode::Esc => match app.state {
+            State::Main() => {
                 app.quit();
-            } else {
-                app.set_state("main".to_string());
             }
-        }
+            State::PathDetails(_) => {
+                app.set_state(State::Main());
+            }
+        },
         _ => {}
     }
     Ok(())

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -22,9 +22,11 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<
         }
 
         KeyCode::Enter => {
-            app.set_state(State::PathDetails(
-                app.summary[app.starting_row].path.to_string(),
-            ));
+            if !app.summary.is_empty() {
+                app.set_state(State::PathDetails(
+                    app.summary[app.starting_row].path.to_string(),
+                ));
+            }
         }
         KeyCode::Esc => match app.state {
             State::Main() => {

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -1,7 +1,7 @@
 use crate::cli::routines::metrics_console::run_console::app::{App, AppResult};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
+pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
     match key_event.code {
         KeyCode::Char('q') => {
             app.quit();
@@ -18,6 +18,17 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
 
         KeyCode::Up => {
             app.up();
+        }
+
+        KeyCode::Enter => {
+            app.set_state(app.summary[app.starting_row].path.to_string());
+        }
+        KeyCode::Esc => {
+            if app.state == "main" {
+                app.quit();
+            } else {
+                app.set_state("main".to_string());
+            }
         }
         _ => {}
     }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -26,15 +26,9 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<
         KeyCode::Esc => {
             if app.state == "main" {
                 app.quit();
-            } else if app.view != "main" {
-                app.view = "main".to_string();
             } else {
                 app.set_state("main".to_string());
             }
-        }
-
-        KeyCode::Char('g') => {
-            app.view = "graphs".to_string();
         }
         _ => {}
     }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/tui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/tui.rs
@@ -51,7 +51,10 @@ impl<B: Backend> Tui<B> {
     /// [`Draw`]: ratatui::Terminal::draw
     /// [`rendering`]: crate::ui::render
     pub fn draw(&mut self, app: &mut App) -> AppResult<()> {
-        self.terminal.draw(|frame| ui::render(app, frame))?;
+        self.terminal.draw(|frame| {
+            app.viewport = frame.size();
+            ui::render(app, frame)
+        })?;
         Ok(())
     }
 

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -207,11 +207,10 @@ fn render_main_page_details(frame: &mut Frame, layout: &Rc<[Rect]>) {
 
 fn render_path_overview_data(app: &App, frame: &mut Frame, layout: &Rc<[Rect]>, state: &String) {
     let average_latency_block = Block::new()
-        // This unwrap is safe because we know the key exists
         .title(format!(
             "Average Latency: {}ms ",
-            (((app.summary.get(app.starting_row).unwrap().latency_sum
-                / app.summary.get(app.starting_row).unwrap().request_count)
+            (((app.summary[app.starting_row].latency_sum
+                / app.summary[app.starting_row].request_count)
                 * 1000000.0)
                 .round())
                 / 1000.0
@@ -222,10 +221,9 @@ fn render_path_overview_data(app: &App, frame: &mut Frame, layout: &Rc<[Rect]>, 
         .white();
 
     let request_count_block = Block::new()
-        // This unwrap is safe because we know the key exists
         .title(format!(
             "Number of Requests: {}",
-            (app.summary.get(app.starting_row).unwrap().request_count)
+            (app.summary[app.starting_row].request_count)
         ))
         .title_alignment(Alignment::Center)
         .bold()
@@ -233,7 +231,6 @@ fn render_path_overview_data(app: &App, frame: &mut Frame, layout: &Rc<[Rect]>, 
         .white();
 
     let path_req_per_sec_block = Block::new()
-        // This unwrap is safe because we know the key exists
         .title(format!(
             "Requests Per Second: {}",
             (app.path_requests_per_sec.get(state).unwrap_or(&0.0))
@@ -338,51 +335,56 @@ fn render_sparkline_chart(
                         (app.viewport.width as f64 * 0.48) as usize
                     )),
             )
-            .data(
-                &app.requests_per_sec_vec.get(state).unwrap()
-                    [app // This unwrap is safe because we know the key exists
+            .data(match &app.requests_per_sec_vec.get(state) {
+                Some(v) => {
+                    &v[app // This unwrap is safe because we know the key exists
                         .requests_per_sec_vec
                         .get(state)
-                        .unwrap()
+                        .unwrap_or(&vec![0; 0])
                         .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..],
-            )
+                        - (app.viewport.width as f64 * 0.48) as usize..]
+                }
+                None => &[],
+            })
             .style(Style::default().fg(Color::Green));
 
-        // This unwrap is safe because we know the key exists
         top_paragraph = Paragraph::new(
             Line::from(format!(
                 "<-{}",
-                &app.requests_per_sec_vec.get(state).unwrap()
-                    [app // This unwrap is safe because we know the key exists
+                match &app.requests_per_sec_vec.get(state) {
+                    Some(v) => v[app
                         .requests_per_sec_vec
                         .get(state)
-                        .unwrap()
+                        .unwrap_or(&vec![0; 0])
                         .len()
                         - (app.viewport.width as f64 * 0.48) as usize..]
-                    .iter()
-                    .max()
-                    .unwrap_or(&0)
+                        .iter()
+                        .max()
+                        .unwrap_or(&0),
+                    None => &0,
+                }
             ))
             .green(),
         )
         .left_aligned();
 
-        // This unwrap is safe because we know the key exists
         middle_paragraph = Paragraph::new(
             Line::from(format!(
                 "<-{}",
-                *app.requests_per_sec_vec.get(state).unwrap()
-                    [app // This unwrap is safe because we know the key exists
-                        .requests_per_sec_vec
-                        .get(state)
-                        .unwrap()
-                        .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..]
-                    .iter()
-                    .max()
-                    .unwrap_or(&0)
-                    / 2
+                match &app.requests_per_sec_vec.get(state) {
+                    Some(v) =>
+                        v[app
+                            .requests_per_sec_vec
+                            .get(state)
+                            .unwrap_or(&vec![0; 0])
+                            .len()
+                            - (app.viewport.width as f64 * 0.48) as usize..]
+                            .iter()
+                            .max()
+                            .unwrap_or(&0)
+                            / 2,
+                    None => 0,
+                }
             ))
             .green(),
         )

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -57,21 +57,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     ])
                     .bold()
                     .magenta()
-                } else if x.path.contains("ingest/") || x.path.contains("consumption/") {
-                    Row::new(vec![
-                        format!("{}", x.path.to_string()),
-                        format!(
-                            "{}",
-                            ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                / 1000.0)
-                                .to_string()
-                        ),
-                        format!(
-                            "{}",
-                            (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                        ),
-                    ])
-                    .not_bold()
                 } else {
                     Row::new(vec![
                         format!("{}", x.path.to_string()),
@@ -86,7 +71,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                             (((x.request_count * 1000.0).round()) / 1000.0).to_string()
                         ),
                     ])
-                    .cyan()
+                    .green()
                     .not_bold()
                 },
             )

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -170,6 +170,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             .green();
 
         let average_latency_block = Block::new()
+            // This unwrap is safe because we know the key exists
             .title(format!(
                 "Average Latency: {}",
                 (((app.summary.get(app.starting_row).unwrap().latency_sum
@@ -184,6 +185,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             .white();
 
         let request_count_block = Block::new()
+            // This unwrap is safe because we know the key exists
             .title(format!(
                 "Number of Requests: {}",
                 (app.summary.get(app.starting_row).unwrap().request_count)
@@ -194,6 +196,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             .white();
 
         let path_req_per_sec_block = Block::new()
+            // This unwrap is safe because we know the key exists
             .title(format!(
                 "Requests Per Second: {}",
                 (app.path_requests_per_sec.get(&app.state).unwrap_or(&0.0))
@@ -288,6 +291,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                 .data(&[0])
                 .style(Style::default().fg(Color::Green));
         } else {
+            // This unwrap is safe because we know the key exists
             chart = Sparkline::default()
                 .block(
                     Block::new()
@@ -298,24 +302,27 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                         )),
                 )
                 .data(
-                    &app.requests_per_sec_vec.get(&app.state).unwrap()[app
-                        .requests_per_sec_vec
-                        .get(&app.state)
-                        .unwrap()
-                        .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..],
+                    &app.requests_per_sec_vec.get(&app.state).unwrap()
+                        [app // This unwrap is safe because we know the key exists
+                            .requests_per_sec_vec
+                            .get(&app.state)
+                            .unwrap()
+                            .len()
+                            - (app.viewport.width as f64 * 0.48) as usize..],
                 )
                 .style(Style::default().fg(Color::Green));
 
+            // This unwrap is safe because we know the key exists
             top_paragraph = Paragraph::new(
                 Line::from(format!(
                     "<-{}",
-                    &app.requests_per_sec_vec.get(&app.state).unwrap()[app
-                        .requests_per_sec_vec
-                        .get(&app.state)
-                        .unwrap()
-                        .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..]
+                    &app.requests_per_sec_vec.get(&app.state).unwrap()
+                        [app // This unwrap is safe because we know the key exists
+                            .requests_per_sec_vec
+                            .get(&app.state)
+                            .unwrap()
+                            .len()
+                            - (app.viewport.width as f64 * 0.48) as usize..]
                         .iter()
                         .max()
                         .unwrap_or(&0)
@@ -324,15 +331,17 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             )
             .left_aligned();
 
+            // This unwrap is safe because we know the key exists
             middle_paragraph = Paragraph::new(
                 Line::from(format!(
                     "<-{}",
-                    *app.requests_per_sec_vec.get(&app.state).unwrap()[app
-                        .requests_per_sec_vec
-                        .get(&app.state)
-                        .unwrap()
-                        .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..]
+                    *app.requests_per_sec_vec.get(&app.state).unwrap()
+                        [app // This unwrap is safe because we know the key exists
+                            .requests_per_sec_vec
+                            .get(&app.state)
+                            .unwrap()
+                            .len()
+                            - (app.viewport.width as f64 * 0.48) as usize..]
                         .iter()
                         .max()
                         .unwrap_or(&0)

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -12,112 +12,223 @@ const INFO_TEXT: &str = "(q) quit | (↑) move up | (↓) move down";
 
 /// Renders the user interface widgets.
 pub fn render(app: &mut App, frame: &mut Frame) {
-    let outer_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(vec![
-            Constraint::Max(2),
-            Constraint::Max(2),
-            Constraint::Fill(80),
-            Constraint::Max(3),
-        ])
-        .split(frame.size());
-
-    let paragraph_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(vec![Constraint::Max(30)])
-        .split(outer_layout[1]);
-
-    let inner_layout = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints(vec![
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-        ])
-        .split(paragraph_layout[0]);
-
-    let mut rows: Vec<Row> = vec![];
-
-    for x in &app.summary {
-        rows.push(
-            Row::new(vec![
-                format!("{}", x.path.to_string()),
-                format!(
-                    "{}",
-                    ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
-                        .to_string()
-                ),
-                format!(
-                    "{}",
-                    (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                ),
+    if app.state == "main" {
+        let outer_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Max(2),
+                Constraint::Max(2),
+                Constraint::Fill(80),
+                Constraint::Max(3),
             ])
-            .not_bold(),
-        )
+            .split(frame.size());
+
+        let paragraph_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Max(30)])
+            .split(outer_layout[1]);
+
+        let inner_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+            ])
+            .split(paragraph_layout[0]);
+
+        let mut rows: Vec<Row> = vec![];
+
+        for x in &app.summary {
+            rows.push(
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                ])
+                .not_bold(),
+            )
+        }
+        let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
+        let mut table_state = TableState::default();
+        table_state.select(Some(app.starting_row));
+
+        let table = Table::new(rows, widths)
+            .widths(widths)
+            .column_spacing(1)
+            .style(Style::new().green())
+            .header(
+                Row::new(vec!["Path", "Latency (ms)", "Number of Requests"])
+                    .style(Style::new().bold())
+                    .bottom_margin(1)
+                    .underlined(),
+            )
+            .block(Block::bordered().title("Endpoint Metrics Table").bold())
+            .highlight_style(Style::new().reversed())
+            .highlight_symbol(">>");
+
+        let info_footer = Paragraph::new(Line::from(INFO_TEXT).green())
+            .centered()
+            .block(
+                Block::bordered()
+                    .border_type(BorderType::Double)
+                    .border_style(Style::new().fg(Color::Green)),
+            );
+
+        let block = Block::new()
+            .title("Metrics Console")
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::TOP)
+            .green();
+        let average_lat = Block::new()
+            .title(format!(
+                "Average Latency: \n {}",
+                (app.average * 1000.0).round() / 1000.0
+            ))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .white()
+            .padding(Padding::top(50));
+        let total_req = Block::new()
+            .title(format!(
+                "Total Number of Requests: \n\n {}",
+                app.total_requests
+            ))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .white();
+
+        let req_per_sec = Block::new()
+            .title(format!(
+                "Requests Per Second: \n\n {}",
+                app.requests_per_sec
+            ))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .white();
+
+        frame.render_widget(block, outer_layout[0]);
+        frame.render_widget(average_lat, inner_layout[0]);
+        frame.render_widget(total_req, inner_layout[1]);
+        frame.render_widget(req_per_sec, inner_layout[2]);
+        frame.render_widget(info_footer, outer_layout[3]);
+        frame.render_stateful_widget(table, outer_layout[2], &mut table_state);
+    } else {
+        let outer_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Max(2),
+                Constraint::Max(2),
+                Constraint::Fill(93),
+                Constraint::Max(3),
+            ])
+            .split(frame.size());
+
+        let title = Block::new()
+            .title(app.state.clone())
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::TOP)
+            .green();
+
+        let average_latency_block = Block::new()
+            .title(format!(
+                "Average Latency: {}",
+                (((app.summary.get(app.starting_row).unwrap().latency_sum
+                    / app.summary.get(app.starting_row).unwrap().request_count)
+                    * 1000000.0)
+                    .round())
+                    / 1000.0
+            ))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::NONE)
+            .white();
+
+        let request_count_block = Block::new()
+            .title(format!(
+                "Number of Requests: {}",
+                (app.summary.get(app.starting_row).unwrap().request_count)
+            ))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::NONE)
+            .white();
+
+        let path_req_per_sec_block = Block::new()
+            .title(format!(
+                "Requests Per Second: {}",
+                (app.path_requests_per_sec)
+            ))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::NONE)
+            .white();
+
+        let data_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+            ])
+            .split(outer_layout[1]);
+
+        let info_footer = Paragraph::new(Line::from("(esc) exit detailed view | (q) quit").green())
+            .centered()
+            .block(
+                Block::bordered()
+                    .border_type(BorderType::Double)
+                    .border_style(Style::new().fg(Color::Green)),
+            );
+
+        frame.render_widget(average_latency_block, data_layout[0]);
+        frame.render_widget(request_count_block, data_layout[1]);
+        frame.render_widget(path_req_per_sec_block, data_layout[2]);
+        frame.render_widget(title, outer_layout[0]);
+        frame.render_widget(info_footer, outer_layout[3]);
+
+        let mut chart_data_vec: Vec<Bar> = vec![];
+        let bucket_data = app.path_detailed_data.clone().unwrap();
+
+        for each in bucket_data {
+            if each.count > 0.0 {
+                chart_data_vec.push(
+                    Bar::default()
+                        .value(each.count as u64)
+                        .label((each.less_than.to_string() + " ms").into()),
+                );
+            } else {
+                chart_data_vec.push(
+                    Bar::default()
+                        .value(0)
+                        .label(each.less_than.to_string().into()),
+                );
+            }
+        }
+
+        let bar_group = BarGroup::default().bars(&chart_data_vec);
+
+        let bar_chart = BarChart::default()
+            .block(
+                Block::bordered()
+                    .title("Number of Requests With Latency Under _ ms")
+                    .bold(),
+            )
+            .data(bar_group)
+            .bar_width(1)
+            .direction(Direction::Horizontal)
+            .bar_style(Style::default().fg(Color::Green))
+            .value_style(Style::default().black().on_green().bold());
+
+        frame.render_widget(bar_chart, outer_layout[2]);
     }
-    let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
-    let mut table_state = TableState::default();
-    table_state.select(Some(app.starting_row));
-
-    let table = Table::new(rows, widths)
-        .widths(widths)
-        .column_spacing(1)
-        .style(Style::new().green())
-        .header(
-            Row::new(vec!["Path", "Latency (ms)", "Number of Requests"])
-                .style(Style::new().bold())
-                .bottom_margin(1)
-                .underlined(),
-        )
-        .block(Block::bordered().title("Endpoint Metrics Table").bold())
-        .highlight_style(Style::new().reversed())
-        .highlight_symbol(">>");
-
-    let info_footer = Paragraph::new(Line::from(INFO_TEXT).green())
-        .centered()
-        .block(
-            Block::bordered()
-                .border_type(BorderType::Double)
-                .border_style(Style::new().fg(Color::Green)),
-        );
-
-    let block = Block::new()
-        .title("Metrics Console")
-        .title_alignment(Alignment::Center)
-        .bold()
-        .borders(Borders::TOP)
-        .green();
-    let average_lat = Block::new()
-        .title(format!(
-            "Average Latency: \n {}",
-            (app.average * 1000.0).round() / 1000.0
-        ))
-        .title_alignment(Alignment::Center)
-        .bold()
-        .white()
-        .padding(Padding::top(50));
-    let total_req = Block::new()
-        .title(format!(
-            "Total Number of Requests: \n\n {}",
-            app.total_requests
-        ))
-        .title_alignment(Alignment::Center)
-        .bold()
-        .white();
-
-    let req_per_sec = Block::new()
-        .title(format!(
-            "Requests Per Second: \n\n {}",
-            app.requests_per_sec
-        ))
-        .title_alignment(Alignment::Center)
-        .bold()
-        .white();
-
-    frame.render_widget(block, outer_layout[0]);
-    frame.render_widget(average_lat, inner_layout[0]);
-    frame.render_widget(total_req, inner_layout[1]);
-    frame.render_widget(req_per_sec, inner_layout[2]);
-    frame.render_widget(info_footer, outer_layout[3]);
-    frame.render_stateful_widget(table, outer_layout[2], &mut table_state);
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -56,22 +56,40 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                         ),
                     ])
                     .bold()
-                    .white()
+                    .magenta()
                 } else {
-                    Row::new(vec![
-                        format!("{}", x.path.to_string()),
-                        format!(
-                            "{}",
-                            ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                / 1000.0)
-                                .to_string()
-                        ),
-                        format!(
-                            "{}",
-                            (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                        ),
-                    ])
-                    .not_bold()
+                    if x.path.contains("ingest/") || x.path.contains("consumption/") {
+                        Row::new(vec![
+                            format!("{}", x.path.to_string()),
+                            format!(
+                                "{}",
+                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                    / 1000.0)
+                                    .to_string()
+                            ),
+                            format!(
+                                "{}",
+                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                            ),
+                        ])
+                        .not_bold()
+                    } else {
+                        Row::new(vec![
+                            format!("{}", x.path.to_string()),
+                            format!(
+                                "{}",
+                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                    / 1000.0)
+                                    .to_string()
+                            ),
+                            format!(
+                                "{}",
+                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                            ),
+                        ])
+                        .cyan()
+                        .not_bold()
+                    }
                 },
             )
         }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use ratatui::{
     layout::Alignment,
     style::{Color, Style, Stylize},
@@ -37,111 +39,9 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             ])
             .split(paragraph_layout[0]);
 
-        let mut rows: Vec<Row> = vec![];
-
-        for x in &app.summary {
-            rows.push(
-                if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
-                    Row::new(vec![
-                        format!("{}", x.path.to_string()),
-                        format!(
-                            "{}",
-                            ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                / 1000.0)
-                                .to_string()
-                        ),
-                        format!(
-                            "{}",
-                            (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                        ),
-                    ])
-                    .bold()
-                    .magenta()
-                } else {
-                    Row::new(vec![
-                        format!("{}", x.path.to_string()),
-                        format!(
-                            "{}",
-                            ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                / 1000.0)
-                                .to_string()
-                        ),
-                        format!(
-                            "{}",
-                            (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                        ),
-                    ])
-                    .green()
-                    .not_bold()
-                },
-            )
-        }
-
-        let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
-        let mut table_state = TableState::default();
-        table_state.select(Some(app.starting_row));
-
-        let table = Table::new(rows, widths)
-            .widths(widths)
-            .column_spacing(1)
-            .style(Style::new().green())
-            .header(
-                Row::new(vec!["Path", "Latency (ms)", "Number of Requests"])
-                    .style(Style::new().bold())
-                    .bottom_margin(1)
-                    .underlined(),
-            )
-            .block(Block::bordered().title("Endpoint Metrics Table").bold())
-            .highlight_style(Style::new().reversed())
-            .highlight_symbol(">>");
-
-        let info_footer = Paragraph::new(Line::from(INFO_TEXT).green())
-            .centered()
-            .block(
-                Block::bordered()
-                    .border_type(BorderType::Double)
-                    .border_style(Style::new().fg(Color::Green)),
-            );
-
-        let block = Block::new()
-            .title("Metrics Console")
-            .title_alignment(Alignment::Center)
-            .bold()
-            .borders(Borders::TOP)
-            .green();
-        let average_lat = Block::new()
-            .title(format!(
-                "Average Latency: \n {}",
-                (app.average * 1000.0).round() / 1000.0
-            ))
-            .title_alignment(Alignment::Center)
-            .bold()
-            .white()
-            .padding(Padding::top(50));
-        let total_req = Block::new()
-            .title(format!(
-                "Total Number of Requests: \n\n {}",
-                app.total_requests
-            ))
-            .title_alignment(Alignment::Center)
-            .bold()
-            .white();
-
-        let req_per_sec = Block::new()
-            .title(format!(
-                "Requests Per Second: \n\n {}",
-                app.requests_per_sec
-            ))
-            .title_alignment(Alignment::Center)
-            .bold()
-            .white();
-
-        frame.render_widget(block, outer_layout[0]);
-        frame.render_widget(average_lat, inner_layout[0]);
-        frame.render_widget(total_req, inner_layout[1]);
-        frame.render_widget(req_per_sec, inner_layout[2]);
-        frame.render_widget(info_footer, outer_layout[3]);
-        frame.render_stateful_widget(table, outer_layout[2], &mut table_state);
+        render_main_page_details(frame, &outer_layout);
+        render_overview_metrics(app, frame, &inner_layout);
+        render_table(app, frame, outer_layout[2]);
     } else {
         let outer_layout = Layout::default()
             .direction(Direction::Vertical)
@@ -162,50 +62,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             ])
             .split(outer_layout[2]);
 
-        let title = Block::new()
-            .title(app.state.clone())
-            .title_alignment(Alignment::Center)
-            .bold()
-            .borders(Borders::TOP)
-            .green();
-
-        let average_latency_block = Block::new()
-            // This unwrap is safe because we know the key exists
-            .title(format!(
-                "Average Latency: {}",
-                (((app.summary.get(app.starting_row).unwrap().latency_sum
-                    / app.summary.get(app.starting_row).unwrap().request_count)
-                    * 1000000.0)
-                    .round())
-                    / 1000.0
-            ))
-            .title_alignment(Alignment::Center)
-            .bold()
-            .borders(Borders::NONE)
-            .white();
-
-        let request_count_block = Block::new()
-            // This unwrap is safe because we know the key exists
-            .title(format!(
-                "Number of Requests: {}",
-                (app.summary.get(app.starting_row).unwrap().request_count)
-            ))
-            .title_alignment(Alignment::Center)
-            .bold()
-            .borders(Borders::NONE)
-            .white();
-
-        let path_req_per_sec_block = Block::new()
-            // This unwrap is safe because we know the key exists
-            .title(format!(
-                "Requests Per Second: {}",
-                (app.path_requests_per_sec.get(&app.state).unwrap_or(&0.0))
-            ))
-            .title_alignment(Alignment::Center)
-            .bold()
-            .borders(Borders::NONE)
-            .white();
-
         let data_layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(vec![
@@ -215,52 +71,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             ])
             .split(outer_layout[1]);
 
-        let info_footer = Paragraph::new(Line::from("(esc) exit detailed view | (q) quit").green())
-            .centered()
-            .block(
-                Block::bordered()
-                    .border_type(BorderType::Double)
-                    .border_style(Style::new().fg(Color::Green)),
-            );
-
-        frame.render_widget(average_latency_block, data_layout[0]);
-        frame.render_widget(request_count_block, data_layout[1]);
-        frame.render_widget(path_req_per_sec_block, data_layout[2]);
-        frame.render_widget(title, outer_layout[0]);
-        frame.render_widget(info_footer, outer_layout[3]);
-
-        let mut chart_data_vec: Vec<Bar> = vec![];
-        let bucket_data = app.path_detailed_data.clone().unwrap();
-
-        for each in bucket_data {
-            if each.count > 0.0 {
-                chart_data_vec.push(
-                    Bar::default()
-                        .value(each.count as u64)
-                        .label((each.less_than.to_string() + " s").into()),
-                );
-            } else {
-                chart_data_vec.push(
-                    Bar::default()
-                        .value(0)
-                        .label(each.less_than.to_string().into()),
-                );
-            }
-        }
-
-        let bar_group = BarGroup::default().bars(&chart_data_vec);
-
-        let bar_chart = BarChart::default()
-            .block(
-                Block::bordered()
-                    .title("Number of Requests With Latency Under _ ms")
-                    .bold(),
-            )
-            .data(bar_group)
-            .bar_width(1)
-            .direction(Direction::Horizontal)
-            .bar_style(Style::default().fg(Color::Green))
-            .value_style(Style::default().black().on_green().bold());
+        render_path_overview_data(app, frame, &data_layout);
+        render_path_page_details(app, frame, &outer_layout);
 
         let scale_layout = Layout::default()
             .direction(Direction::Vertical)
@@ -273,92 +85,311 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             ])
             .split(body_layout[2]);
 
-        let chart: Sparkline;
-        let mut top_paragraph: Paragraph = Paragraph::new("<-0");
-        let mut middle_paragraph: Paragraph = Paragraph::new("<-0");
-        let mut bottom_paragraph: Paragraph = Paragraph::new("<-0");
-
-        if !app.requests_per_sec_vec.contains_key(&app.state) {
-            chart = Sparkline::default()
-                .block(
-                    Block::new()
-                        .borders(Borders::LEFT | Borders::RIGHT)
-                        .title(format!(
-                            "Requests Per Second Over the Past {} sec",
-                            (app.viewport.width as f64 * 0.48) as usize
-                        )),
-                )
-                .data(&[0])
-                .style(Style::default().fg(Color::Green));
-        } else {
-            // This unwrap is safe because we know the key exists
-            chart = Sparkline::default()
-                .block(
-                    Block::new()
-                        .borders(Borders::LEFT | Borders::RIGHT)
-                        .title(format!(
-                            "Requests Per Second Over the Past {} sec",
-                            (app.viewport.width as f64 * 0.48) as usize
-                        )),
-                )
-                .data(
-                    &app.requests_per_sec_vec.get(&app.state).unwrap()
-                        [app // This unwrap is safe because we know the key exists
-                            .requests_per_sec_vec
-                            .get(&app.state)
-                            .unwrap()
-                            .len()
-                            - (app.viewport.width as f64 * 0.48) as usize..],
-                )
-                .style(Style::default().fg(Color::Green));
-
-            // This unwrap is safe because we know the key exists
-            top_paragraph = Paragraph::new(
-                Line::from(format!(
-                    "<-{}",
-                    &app.requests_per_sec_vec.get(&app.state).unwrap()
-                        [app // This unwrap is safe because we know the key exists
-                            .requests_per_sec_vec
-                            .get(&app.state)
-                            .unwrap()
-                            .len()
-                            - (app.viewport.width as f64 * 0.48) as usize..]
-                        .iter()
-                        .max()
-                        .unwrap_or(&0)
-                ))
-                .green(),
-            )
-            .left_aligned();
-
-            // This unwrap is safe because we know the key exists
-            middle_paragraph = Paragraph::new(
-                Line::from(format!(
-                    "<-{}",
-                    *app.requests_per_sec_vec.get(&app.state).unwrap()
-                        [app // This unwrap is safe because we know the key exists
-                            .requests_per_sec_vec
-                            .get(&app.state)
-                            .unwrap()
-                            .len()
-                            - (app.viewport.width as f64 * 0.48) as usize..]
-                        .iter()
-                        .max()
-                        .unwrap_or(&0)
-                        / 2
-                ))
-                .green(),
-            )
-            .left_aligned();
-
-            bottom_paragraph = Paragraph::new(Line::from("<-0").green()).left_aligned();
-        }
-
-        frame.render_widget(chart, body_layout[1]);
-        frame.render_widget(top_paragraph, scale_layout[0]);
-        frame.render_widget(middle_paragraph, scale_layout[2]);
-        frame.render_widget(bottom_paragraph, scale_layout[4]);
-
-        frame.render_widget(bar_chart, body_layout[0]);
+        render_sparkline_chart(app, frame, &body_layout, &scale_layout);
+        render_bar_chart(app, frame, &body_layout);
     }
+}
+
+fn render_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+    let mut rows: Vec<Row> = vec![];
+
+    for x in &app.summary {
+        rows.push(
+            if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                ])
+                .bold()
+                .magenta()
+            } else {
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                ])
+                .green()
+                .not_bold()
+            },
+        )
+    }
+
+    let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
+    let mut table_state = TableState::default();
+    table_state.select(Some(app.starting_row));
+
+    let table = Table::new(rows, widths)
+        .widths(widths)
+        .column_spacing(1)
+        .style(Style::new().green())
+        .header(
+            Row::new(vec!["Path", "Latency (ms)", "Number of Requests"])
+                .style(Style::new().bold())
+                .bottom_margin(1)
+                .underlined(),
+        )
+        .block(Block::bordered().title("Endpoint Metrics Table").bold())
+        .highlight_style(Style::new().reversed())
+        .highlight_symbol(">>");
+
+    frame.render_stateful_widget(table, layout, &mut table_state)
+}
+
+fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
+    let average_lat = Block::new()
+        .title(format!(
+            "Average Latency: \n {}",
+            (app.average * 1000.0).round() / 1000.0
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white()
+        .padding(Padding::top(50));
+    let total_req = Block::new()
+        .title(format!(
+            "Total Number of Requests: \n\n {}",
+            app.total_requests
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white();
+
+    let req_per_sec = Block::new()
+        .title(format!(
+            "Requests Per Second: \n\n {}",
+            app.requests_per_sec
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white();
+
+    frame.render_widget(average_lat, layout[0]);
+    frame.render_widget(total_req, layout[1]);
+    frame.render_widget(req_per_sec, layout[2]);
+}
+
+fn render_main_page_details(frame: &mut Frame, layout: &Rc<[Rect]>) {
+    let info_footer = Paragraph::new(Line::from(INFO_TEXT).green())
+        .centered()
+        .block(
+            Block::bordered()
+                .border_type(BorderType::Double)
+                .border_style(Style::new().fg(Color::Green)),
+        );
+
+    let block = Block::new()
+        .title("Metrics Console")
+        .title_alignment(Alignment::Center)
+        .bold()
+        .borders(Borders::TOP)
+        .green();
+
+    frame.render_widget(block, layout[0]);
+    frame.render_widget(info_footer, layout[3]);
+}
+
+fn render_path_overview_data(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
+    let average_latency_block = Block::new()
+        // This unwrap is safe because we know the key exists
+        .title(format!(
+            "Average Latency: {}",
+            (((app.summary.get(app.starting_row).unwrap().latency_sum
+                / app.summary.get(app.starting_row).unwrap().request_count)
+                * 1000000.0)
+                .round())
+                / 1000.0
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .borders(Borders::NONE)
+        .white();
+
+    let request_count_block = Block::new()
+        // This unwrap is safe because we know the key exists
+        .title(format!(
+            "Number of Requests: {}",
+            (app.summary.get(app.starting_row).unwrap().request_count)
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .borders(Borders::NONE)
+        .white();
+
+    let path_req_per_sec_block = Block::new()
+        // This unwrap is safe because we know the key exists
+        .title(format!(
+            "Requests Per Second: {}",
+            (app.path_requests_per_sec.get(&app.state).unwrap_or(&0.0))
+        ))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .borders(Borders::NONE)
+        .white();
+
+    frame.render_widget(average_latency_block, layout[0]);
+    frame.render_widget(request_count_block, layout[1]);
+    frame.render_widget(path_req_per_sec_block, layout[2]);
+}
+
+fn render_path_page_details(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
+    let title = Block::new()
+        .title(app.state.clone())
+        .title_alignment(Alignment::Center)
+        .bold()
+        .borders(Borders::TOP)
+        .green();
+
+    let info_footer = Paragraph::new(Line::from("(esc) exit detailed view | (q) quit").green())
+        .centered()
+        .block(
+            Block::bordered()
+                .border_type(BorderType::Double)
+                .border_style(Style::new().fg(Color::Green)),
+        );
+
+    frame.render_widget(title, layout[0]);
+    frame.render_widget(info_footer, layout[3]);
+}
+
+fn render_bar_chart(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
+    let mut chart_data_vec: Vec<Bar> = vec![];
+    let bucket_data = app.path_detailed_data.clone().unwrap();
+
+    for each in bucket_data {
+        if each.count > 0.0 {
+            chart_data_vec.push(
+                Bar::default()
+                    .value(each.count as u64)
+                    .label((each.less_than.to_string() + " s").into()),
+            );
+        } else {
+            chart_data_vec.push(
+                Bar::default()
+                    .value(0)
+                    .label(each.less_than.to_string().into()),
+            );
+        }
+    }
+
+    let bar_group = BarGroup::default().bars(&chart_data_vec);
+
+    let bar_chart = BarChart::default()
+        .block(
+            Block::bordered()
+                .title("Number of Requests With Latency Under _ ms")
+                .bold(),
+        )
+        .data(bar_group)
+        .bar_width(1)
+        .direction(Direction::Horizontal)
+        .bar_style(Style::default().fg(Color::Green))
+        .value_style(Style::default().black().on_green().bold());
+
+    frame.render_widget(bar_chart, layout[0]);
+}
+fn render_sparkline_chart(
+    app: &mut App,
+    frame: &mut Frame,
+    chart_layout: &Rc<[Rect]>,
+    scale_layout: &Rc<[Rect]>,
+) {
+    let chart: Sparkline;
+    let mut top_paragraph: Paragraph = Paragraph::new("<-0");
+    let mut middle_paragraph: Paragraph = Paragraph::new("<-0");
+    let mut bottom_paragraph: Paragraph = Paragraph::new("<-0");
+    if !app.requests_per_sec_vec.contains_key(&app.state) {
+        chart = Sparkline::default()
+            .block(
+                Block::new()
+                    .borders(Borders::LEFT | Borders::RIGHT)
+                    .title(format!(
+                        "Requests Per Second Over the Past {} sec",
+                        (app.viewport.width as f64 * 0.48) as usize
+                    )),
+            )
+            .data(&[0])
+            .style(Style::default().fg(Color::Green));
+    } else {
+        // This unwrap is safe because we know the key exists
+        chart = Sparkline::default()
+            .block(
+                Block::new()
+                    .borders(Borders::LEFT | Borders::RIGHT)
+                    .title(format!(
+                        "Requests Per Second Over the Past {} sec",
+                        (app.viewport.width as f64 * 0.48) as usize
+                    )),
+            )
+            .data(
+                &app.requests_per_sec_vec.get(&app.state).unwrap()
+                    [app // This unwrap is safe because we know the key exists
+                        .requests_per_sec_vec
+                        .get(&app.state)
+                        .unwrap()
+                        .len()
+                        - (app.viewport.width as f64 * 0.48) as usize..],
+            )
+            .style(Style::default().fg(Color::Green));
+
+        // This unwrap is safe because we know the key exists
+        top_paragraph = Paragraph::new(
+            Line::from(format!(
+                "<-{}",
+                &app.requests_per_sec_vec.get(&app.state).unwrap()
+                    [app // This unwrap is safe because we know the key exists
+                        .requests_per_sec_vec
+                        .get(&app.state)
+                        .unwrap()
+                        .len()
+                        - (app.viewport.width as f64 * 0.48) as usize..]
+                    .iter()
+                    .max()
+                    .unwrap_or(&0)
+            ))
+            .green(),
+        )
+        .left_aligned();
+
+        // This unwrap is safe because we know the key exists
+        middle_paragraph = Paragraph::new(
+            Line::from(format!(
+                "<-{}",
+                *app.requests_per_sec_vec.get(&app.state).unwrap()
+                    [app // This unwrap is safe because we know the key exists
+                        .requests_per_sec_vec
+                        .get(&app.state)
+                        .unwrap()
+                        .len()
+                        - (app.viewport.width as f64 * 0.48) as usize..]
+                    .iter()
+                    .max()
+                    .unwrap_or(&0)
+                    / 2
+            ))
+            .green(),
+        )
+        .left_aligned();
+
+        bottom_paragraph = Paragraph::new(Line::from("<-0").green()).left_aligned();
+    }
+
+    frame.render_widget(chart, chart_layout[1]);
+    frame.render_widget(top_paragraph, scale_layout[0]);
+    frame.render_widget(middle_paragraph, scale_layout[2]);
+    frame.render_widget(bottom_paragraph, scale_layout[4]);
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{prelude::*, widgets::*};
 
 use crate::cli::routines::metrics_console::run_console::app::App;
 
-const INFO_TEXT: &str = "(q) quit | (↑) move up | (↓) move down";
+const INFO_TEXT: &str = "(q) quit | (↑) move up | (↓) move down | (enter) view endpoint details";
 
 /// Renders the user interface widgets.
 pub fn render(app: &mut App, frame: &mut Frame) {

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -57,42 +57,41 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     ])
                     .bold()
                     .magenta()
+                } else if x.path.contains("ingest/") || x.path.contains("consumption/") {
+                    Row::new(vec![
+                        format!("{}", x.path.to_string()),
+                        format!(
+                            "{}",
+                            ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                / 1000.0)
+                                .to_string()
+                        ),
+                        format!(
+                            "{}",
+                            (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                        ),
+                    ])
+                    .not_bold()
                 } else {
-                    if x.path.contains("ingest/") || x.path.contains("consumption/") {
-                        Row::new(vec![
-                            format!("{}", x.path.to_string()),
-                            format!(
-                                "{}",
-                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                    / 1000.0)
-                                    .to_string()
-                            ),
-                            format!(
-                                "{}",
-                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                            ),
-                        ])
-                        .not_bold()
-                    } else {
-                        Row::new(vec![
-                            format!("{}", x.path.to_string()),
-                            format!(
-                                "{}",
-                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                    / 1000.0)
-                                    .to_string()
-                            ),
-                            format!(
-                                "{}",
-                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                            ),
-                        ])
-                        .cyan()
-                        .not_bold()
-                    }
+                    Row::new(vec![
+                        format!("{}", x.path.to_string()),
+                        format!(
+                            "{}",
+                            ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                / 1000.0)
+                                .to_string()
+                        ),
+                        format!(
+                            "{}",
+                            (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                        ),
+                    ])
+                    .cyan()
+                    .not_bold()
                 },
             )
         }
+
         let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
         let mut table_state = TableState::default();
         table_state.select(Some(app.starting_row));


### PR DESCRIPTION
Each http endpoint now has a detailed view which the user can access by navigating to the endpoint they want on the table and then clicking enter. In the detailed view there is metrics specific to that endpoint and a bar chart showing the number of requests under X latency in ms. There is also a sparkline graph chart that shows the number of requests per second over the past ___ seconds. The user can view a longer timeframe by expanding the console window horizontally. In the main view all endpoints currently receiving requests are colored purple, ingest and consumption endpoints colored green (not getting requests), and other endpoints colored cyan (not getting requests).

Detailed view UI:

In iterm code terminal:
![image](https://github.com/user-attachments/assets/cec26bd6-8cc1-4a5b-b550-fc841d1aa48a)

In normal mac terminal:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d888d851-24b3-4432-83e3-acda442be65b">

Example of highlighted endpoints
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/19b2de06-6c97-47fc-9278-e87b29c2729c">

