### PR TITLE
Bytes in and out metric tracking

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -323,10 +323,7 @@ async fn handle_json_req(
     let parsed: Result<Value, serde_json::Error> = serde_json::from_reader(body);
 
     metrics
-        .send_metric(MetricsMessage::GetNumberOfBytesIn(
-            route,
-            number_of_bytes as u64,
-        ))
+        .send_metric(MetricsMessage::GetNumberOfBytesIn(route, number_of_bytes))
         .await;
     // TODO add check that the payload has the proper schema
 
@@ -377,10 +374,7 @@ async fn handle_json_array_body(
     let parsed: Result<Vec<Value>, serde_json::Error> = serde_json::from_reader(body);
 
     metrics
-        .send_metric(MetricsMessage::GetNumberOfBytesIn(
-            route,
-            number_of_bytes as u64,
-        ))
+        .send_metric(MetricsMessage::GetNumberOfBytesIn(route, number_of_bytes))
         .await;
     if let Err(e) = parsed {
         return bad_json_response(e);

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -318,9 +318,9 @@ async fn handle_json_req(
     // TODO probably a refactor to be done here with the array json but it doesn't seem to be
     // straightforward to do it in a generic way.
     let url = req.uri().to_string();
+    let number_of_bytes = req.body().size_hint().exact().unwrap();
     let body = to_reader(req).await;
     let parsed: Result<Value, serde_json::Error> = serde_json::from_reader(body);
-    let number_of_bytes = req.body().size_hint().exact().unwrap();
 
     metrics
         .send_metric(MetricsMessage::GetNumberOfBytesIn(

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -146,7 +146,7 @@ async fn create_client(
     let res = sender.send_request(req).await?;
     let body = res.collect().await.unwrap().to_bytes().to_vec();
     metrics
-        .send_metric(MetricsMessage::GetNumberOfBytesOut(
+        .send_metric(MetricsMessage::PutNumberOfBytesOut(
             route,
             body.len() as u64,
         ))
@@ -323,7 +323,7 @@ async fn handle_json_req(
     let parsed: Result<Value, serde_json::Error> = serde_json::from_reader(body);
 
     metrics
-        .send_metric(MetricsMessage::GetNumberOfBytesIn(route, number_of_bytes))
+        .send_metric(MetricsMessage::PutNumberOfBytesIn(route, number_of_bytes))
         .await;
     // TODO add check that the payload has the proper schema
 
@@ -374,7 +374,7 @@ async fn handle_json_array_body(
     let parsed: Result<Vec<Value>, serde_json::Error> = serde_json::from_reader(body);
 
     metrics
-        .send_metric(MetricsMessage::GetNumberOfBytesIn(route, number_of_bytes))
+        .send_metric(MetricsMessage::PutNumberOfBytesIn(route, number_of_bytes))
         .await;
     if let Err(e) = parsed {
         return bad_json_response(e);

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -41,7 +41,7 @@ pub async fn run_console() -> app::AppResult<()> {
         tokio::select! {
             received = rx.recv() => {
                 if let Some(v) = received {
-                    app.per_sec_metrics(v.total_requests, &v.paths_data_vec, &v.paths_bytes_in_vec, &v.paths_bytes_out_vec, &v.total_bytes_in, &v.total_bytes_out);
+                    app.per_sec_metrics(v.total_requests, &v.paths_data_vec, &v.paths_bytes_hashmap, &v.total_bytes_in, &v.total_bytes_out);
                     app.set_metrics(v);
                 };
             }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -41,7 +41,7 @@ pub async fn run_console() -> app::AppResult<()> {
         tokio::select! {
             received = rx.recv() => {
                 if let Some(v) = received {
-                    app.req_per_sec(v.total_requests, &v.paths_data_vec);
+                    app.per_sec_metrics(v.total_requests, &v.paths_data_vec, &v.paths_bytes_in_vec, &v.paths_bytes_out_vec, &v.total_bytes_in, &v.total_bytes_out);
                     app.set_metrics(v);
                 };
             }
@@ -52,6 +52,8 @@ pub async fn run_console() -> app::AppResult<()> {
                 }
             }
         }
+
+        //println!("BYTES: {:#?}", app.parsed_bytes_data.path_bytes_in_per_sec_vec);
 
         // Render the user interface.
         tui.draw(&mut app)?;

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -53,8 +53,6 @@ pub async fn run_console() -> app::AppResult<()> {
             }
         }
 
-        //println!("BYTES: {:#?}", app.parsed_bytes_data.path_bytes_in_per_sec_vec);
-
         // Render the user interface.
         tui.draw(&mut app)?;
     }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/app.rs
@@ -184,24 +184,19 @@ impl App {
                             .insert(path.0.clone(), *value - path.1);
                     }
                 }
-                None => {}
+                None => {
+                    if path.0.starts_with("ingest/") {
+                        self.parsed_bytes_data
+                            .path_bytes_in_per_sec_vec
+                            .insert(path.0.clone(), 0);
+                    } else {
+                        self.parsed_bytes_data
+                            .path_bytes_out_per_sec_vec
+                            .insert(path.0.clone(), 0);
+                    }
+                }
             }
-            // if item.path == path.path {
-            //     self.parsed_bytes_data
-            //         .path_bytes_in_per_sec_vec
-            //         .insert(path.path.clone(), item.bytes_data - path.bytes_data);
-            // }
         }
-
-        // for path in &self.parsed_bytes_data.previous_bytes_out {
-        //     for item in path_bytes_out {
-        //         if item.path == path.path {
-        //             self.parsed_bytes_data
-        //                 .path_bytes_out_per_sec_vec
-        //                 .insert(path.path.clone(), item.bytes_data - path.bytes_data);
-        //         }
-        //     }
-        // }
     }
 
     pub fn set_state(&mut self, state: State) {

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -294,7 +294,7 @@ fn render_path_overview_data(
         .borders(Borders::NONE)
         .white();
 
-    if (state.starts_with("ingest")) {
+    if state.starts_with("ingest") {
         let bytes_in_per_sec_block = Block::new()
             .title(format!("Data In: {}", {
                 let bytes = (*app
@@ -445,7 +445,7 @@ fn render_sparkline_chart(
             )
             .data(match &app.requests_per_sec_vec.get(state) {
                 Some(v) => {
-                    &v.get(
+                    v.get(
                         ((app // This unwrap is safe because we know the key exists
                             .requests_per_sec_vec
                             .get(state)

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -20,6 +20,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                 .constraints(vec![
                     Constraint::Max(2),
                     Constraint::Max(2),
+                    Constraint::Max(2),
                     Constraint::Fill(80),
                     Constraint::Max(3),
                 ])
@@ -38,10 +39,19 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     Constraint::Percentage(33),
                 ])
                 .split(paragraph_layout[0]);
+            let bytes_overview_layout = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints(vec![
+                    Constraint::Percentage(33),
+                    Constraint::Percentage(33),
+                    Constraint::Percentage(33),
+                ])
+                .split(outer_layout[2]);
 
             render_main_page_details(frame, &outer_layout);
             render_overview_metrics(app, frame, &inner_layout);
-            render_table(app, frame, outer_layout[2]);
+            render_overview_bytes_data(app, frame, &bytes_overview_layout);
+            render_table(app, frame, outer_layout[3]);
         }
         State::PathDetails(state) => {
             let outer_layout = Layout::default()
@@ -49,7 +59,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                 .constraints(vec![
                     Constraint::Max(2),
                     Constraint::Max(2),
-                    Constraint::Fill(93),
+                    Constraint::Max(2),
+                    Constraint::Fill(91),
                     Constraint::Max(3),
                 ])
                 .split(frame.size());
@@ -61,18 +72,19 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     Constraint::Percentage(50),
                     Constraint::Fill(10),
                 ])
-                .split(outer_layout[2]);
+                .split(outer_layout[3]);
 
-            let data_layout = Layout::default()
+            let top_row_data_layout = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(vec![
-                    Constraint::Percentage(33),
-                    Constraint::Percentage(33),
-                    Constraint::Percentage(33),
-                ])
+                .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(outer_layout[1]);
 
-            render_path_overview_data(&*app, frame, &data_layout, state);
+            let bottom_row_data = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(outer_layout[2]);
+
+            render_path_overview_data(&*app, frame, &top_row_data_layout, &bottom_row_data, state);
             render_path_page_details(frame, &outer_layout, state.clone());
 
             let scale_layout = Layout::default()
@@ -155,7 +167,7 @@ fn render_table(app: &mut App, frame: &mut Frame, layout: Rect) {
 fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
     let average_lat = Block::new()
         .title(format!(
-            "Average Latency: \n {} ms",
+            "Average Latency: {} ms",
             (app.average * 1000.0).round() / 1000.0
         ))
         .title_alignment(Alignment::Center)
@@ -163,18 +175,15 @@ fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>
         .white()
         .padding(Padding::top(50));
     let total_req = Block::new()
-        .title(format!(
-            "Total Number of Requests: \n\n {}",
-            app.total_requests
-        ))
+        .title(format!("Total Number of Requests: {}", app.total_requests))
         .title_alignment(Alignment::Center)
         .bold()
         .white();
 
     let req_per_sec = Block::new()
         .title(format!(
-            "Requests Per Second: \n\n {}",
-            app.requests_per_sec
+            "Requests Per Second: {}",
+            app.main_bytes_data.bytes_out_per_sec
         ))
         .title_alignment(Alignment::Center)
         .bold()
@@ -183,6 +192,45 @@ fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>
     frame.render_widget(average_lat, layout[0]);
     frame.render_widget(total_req, layout[1]);
     frame.render_widget(req_per_sec, layout[2]);
+}
+
+fn render_overview_bytes_data(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
+    let bytes_in_per_sec = Block::new()
+        .title(format!("Data In: {}", {
+            let bytes = app.main_bytes_data.bytes_in_per_sec as f64;
+            if (bytes / 1000000000.0) > 1.0 {
+                format!("{:.3} GB/s", (bytes / 1000000000.0))
+            } else if (bytes / 1000000.0) > 1.0 {
+                format!("{:.3} MB/s", (bytes / 1000000.0))
+            } else if (bytes / 1000.0) > 1.0 {
+                format!("{:.3} KB/s", (bytes / 1000.0))
+            } else {
+                format!("{:3} B/s", bytes)
+            }
+        }))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white();
+
+    let bytes_out_per_sec = Block::new()
+        .title(format!("Data Out: {}", {
+            let bytes = app.main_bytes_data.bytes_out_per_sec as f64;
+            if (bytes / 1000000000.0) > 1.0 {
+                format!("{:.3} GB/s", (bytes / 1000000000.0))
+            } else if (bytes / 1000000.0) > 1.0 {
+                format!("{:.3} MB/s", (bytes / 1000000.0))
+            } else if (bytes / 1000.0) > 1.0 {
+                format!("{:.3} KB/s", (bytes / 1000.0))
+            } else {
+                format!("{:3} B/s", bytes)
+            }
+        }))
+        .title_alignment(Alignment::Center)
+        .bold()
+        .white();
+
+    frame.render_widget(bytes_in_per_sec, layout[0]);
+    frame.render_widget(bytes_out_per_sec, layout[2]);
 }
 
 fn render_main_page_details(frame: &mut Frame, layout: &Rc<[Rect]>) {
@@ -202,10 +250,16 @@ fn render_main_page_details(frame: &mut Frame, layout: &Rc<[Rect]>) {
         .green();
 
     frame.render_widget(block, layout[0]);
-    frame.render_widget(info_footer, layout[3]);
+    frame.render_widget(info_footer, layout[4]);
 }
 
-fn render_path_overview_data(app: &App, frame: &mut Frame, layout: &Rc<[Rect]>, state: &String) {
+fn render_path_overview_data(
+    app: &App,
+    frame: &mut Frame,
+    top_layout: &Rc<[Rect]>,
+    bottom_layout: &Rc<[Rect]>,
+    state: &String,
+) {
     let average_latency_block = Block::new()
         .title(format!(
             "Average Latency: {}ms ",
@@ -240,9 +294,57 @@ fn render_path_overview_data(app: &App, frame: &mut Frame, layout: &Rc<[Rect]>, 
         .borders(Borders::NONE)
         .white();
 
-    frame.render_widget(average_latency_block, layout[0]);
-    frame.render_widget(request_count_block, layout[1]);
-    frame.render_widget(path_req_per_sec_block, layout[2]);
+    if (state.starts_with("ingest")) {
+        let bytes_in_per_sec_block = Block::new()
+            .title(format!("Data In: {}", {
+                let bytes = (*app
+                    .parsed_bytes_data
+                    .path_bytes_in_per_sec_vec
+                    .get(state)
+                    .unwrap_or(&0)) as f64;
+                if (bytes / 1000000000.0) > 1.0 {
+                    format!("{:.3} GB/s", (bytes / 1000000000.0))
+                } else if (bytes / 1000000.0) > 1.0 {
+                    format!("{:.3} MB/s", (bytes / 1000000.0))
+                } else if (bytes / 1000.0) > 1.0 {
+                    format!("{:.3} KB/s", (bytes / 1000.0))
+                } else {
+                    format!("{:3} B/s", bytes)
+                }
+            }))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::NONE)
+            .white();
+        frame.render_widget(bytes_in_per_sec_block, bottom_layout[1]);
+    } else {
+        let bytes_in_per_sec_block = Block::new()
+            .title(format!("Data Out: {}", {
+                let bytes = (*app
+                    .parsed_bytes_data
+                    .path_bytes_out_per_sec_vec
+                    .get(state)
+                    .unwrap_or(&0)) as f64;
+                if (bytes / 1000000000.0) > 1.0 {
+                    format!("{:.3} GB/s", (bytes / 1000000000.0))
+                } else if (bytes / 1000000.0) > 1.0 {
+                    format!("{:.3} MB/s", (bytes / 1000000.0))
+                } else if (bytes / 1000.0) > 1.0 {
+                    format!("{:.3} KB/s", (bytes / 1000.0))
+                } else {
+                    format!("{:3} B/s", bytes)
+                }
+            }))
+            .title_alignment(Alignment::Center)
+            .bold()
+            .borders(Borders::NONE)
+            .white();
+        frame.render_widget(bytes_in_per_sec_block, bottom_layout[1]);
+    }
+
+    frame.render_widget(average_latency_block, top_layout[0]);
+    frame.render_widget(request_count_block, top_layout[1]);
+    frame.render_widget(path_req_per_sec_block, bottom_layout[0]);
 }
 
 fn render_path_page_details(frame: &mut Frame, layout: &Rc<[Rect]>, state: String) {
@@ -262,7 +364,7 @@ fn render_path_page_details(frame: &mut Frame, layout: &Rc<[Rect]>, state: Strin
         );
 
     frame.render_widget(title, layout[0]);
-    frame.render_widget(info_footer, layout[3]);
+    frame.render_widget(info_footer, layout[4]);
 }
 
 fn render_bar_chart(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
@@ -290,7 +392,7 @@ fn render_bar_chart(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
     let bar_chart = BarChart::default()
         .block(
             Block::bordered()
-                .title("Number of Requests With Latency Under _ ms")
+                .title("Number of Requests With Latency Under _ s")
                 .bold(),
         )
         .data(bar_group)
@@ -317,10 +419,13 @@ fn render_sparkline_chart(
             .block(
                 Block::new()
                     .borders(Borders::LEFT | Borders::RIGHT)
-                    .title(format!(
-                        "Requests Per Second Over the Past {} sec",
-                        (app.viewport.width as f64 * 0.48) as usize
-                    )),
+                    .title(format!("Requests Per Second Over the Past {} sec", {
+                        if (app.viewport.width as f64 * 0.48) > 150.0 {
+                            150
+                        } else {
+                            (app.viewport.width as f64 * 0.48) as usize
+                        }
+                    })),
             )
             .data(&[0])
             .style(Style::default().fg(Color::Green));
@@ -330,19 +435,26 @@ fn render_sparkline_chart(
             .block(
                 Block::new()
                     .borders(Borders::LEFT | Borders::RIGHT)
-                    .title(format!(
-                        "Requests Per Second Over the Past {} sec",
-                        (app.viewport.width as f64 * 0.48) as usize
-                    )),
+                    .title(format!("Requests Per Second Over the Past {} sec", {
+                        if (app.viewport.width as f64 * 0.48) > 150.0 {
+                            150
+                        } else {
+                            (app.viewport.width as f64 * 0.48) as usize
+                        }
+                    })),
             )
             .data(match &app.requests_per_sec_vec.get(state) {
                 Some(v) => {
-                    &v[app // This unwrap is safe because we know the key exists
-                        .requests_per_sec_vec
-                        .get(state)
-                        .unwrap_or(&vec![0; 0])
-                        .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..]
+                    &v.get(
+                        ((app // This unwrap is safe because we know the key exists
+                            .requests_per_sec_vec
+                            .get(state)
+                            .unwrap_or(&vec![0; 0])
+                            .len() as f64)
+                            - (app.viewport.width as f64 * 0.48))
+                            as usize..,
+                    )
+                    .unwrap_or(&v[0..])
                 }
                 None => &[],
             })
@@ -352,12 +464,16 @@ fn render_sparkline_chart(
             Line::from(format!(
                 "<-{}",
                 match &app.requests_per_sec_vec.get(state) {
-                    Some(v) => v[app
-                        .requests_per_sec_vec
-                        .get(state)
-                        .unwrap_or(&vec![0; 0])
-                        .len()
-                        - (app.viewport.width as f64 * 0.48) as usize..]
+                    Some(v) => v
+                        .get(
+                            (app.requests_per_sec_vec
+                                .get(state)
+                                .unwrap_or(&vec![0; 0])
+                                .len() as f64
+                                - (app.viewport.width as f64 * 0.48))
+                                as usize..
+                        )
+                        .unwrap_or(&v[0..])
                         .iter()
                         .max()
                         .unwrap_or(&0),
@@ -373,15 +489,18 @@ fn render_sparkline_chart(
                 "<-{}",
                 match &app.requests_per_sec_vec.get(state) {
                     Some(v) =>
-                        v[app
-                            .requests_per_sec_vec
-                            .get(state)
-                            .unwrap_or(&vec![0; 0])
-                            .len()
-                            - (app.viewport.width as f64 * 0.48) as usize..]
-                            .iter()
-                            .max()
-                            .unwrap_or(&0)
+                        v.get(
+                            (app.requests_per_sec_vec
+                                .get(state)
+                                .unwrap_or(&vec![0; 0])
+                                .len() as f64
+                                - (app.viewport.width as f64 * 0.48))
+                                as usize..
+                        )
+                        .unwrap_or(&v[0..])
+                        .iter()
+                        .max()
+                        .unwrap_or(&0)
                             / 2,
                     None => 0,
                 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -196,35 +196,19 @@ fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>
 
 fn render_overview_bytes_data(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
     let bytes_in_per_sec = Block::new()
-        .title(format!("Data In: {}", {
-            let bytes = app.main_bytes_data.bytes_in_per_sec as f64;
-            if (bytes / 1000000000.0) > 1.0 {
-                format!("{:.3} GB/s", (bytes / 1000000000.0))
-            } else if (bytes / 1000000.0) > 1.0 {
-                format!("{:.3} MB/s", (bytes / 1000000.0))
-            } else if (bytes / 1000.0) > 1.0 {
-                format!("{:.3} KB/s", (bytes / 1000.0))
-            } else {
-                format!("{:3} B/s", bytes)
-            }
-        }))
+        .title(format!(
+            "Data In: {}",
+            format_bytes(app.main_bytes_data.bytes_in_per_sec as f64)
+        ))
         .title_alignment(Alignment::Center)
         .bold()
         .white();
 
     let bytes_out_per_sec = Block::new()
-        .title(format!("Data Out: {}", {
-            let bytes = app.main_bytes_data.bytes_out_per_sec as f64;
-            if (bytes / 1000000000.0) > 1.0 {
-                format!("{:.3} GB/s", (bytes / 1000000000.0))
-            } else if (bytes / 1000000.0) > 1.0 {
-                format!("{:.3} MB/s", (bytes / 1000000.0))
-            } else if (bytes / 1000.0) > 1.0 {
-                format!("{:.3} KB/s", (bytes / 1000.0))
-            } else {
-                format!("{:3} B/s", bytes)
-            }
-        }))
+        .title(format!(
+            "Data Out: {}",
+            format_bytes(app.main_bytes_data.bytes_out_per_sec as f64)
+        ))
         .title_alignment(Alignment::Center)
         .bold()
         .white();
@@ -296,22 +280,16 @@ fn render_path_overview_data(
 
     if state.starts_with("ingest") {
         let bytes_in_per_sec_block = Block::new()
-            .title(format!("Data In: {}", {
-                let bytes = (*app
-                    .parsed_bytes_data
-                    .path_bytes_in_per_sec_vec
-                    .get(state)
-                    .unwrap_or(&0)) as f64;
-                if (bytes / 1000000000.0) > 1.0 {
-                    format!("{:.3} GB/s", (bytes / 1000000000.0))
-                } else if (bytes / 1000000.0) > 1.0 {
-                    format!("{:.3} MB/s", (bytes / 1000000.0))
-                } else if (bytes / 1000.0) > 1.0 {
-                    format!("{:.3} KB/s", (bytes / 1000.0))
-                } else {
-                    format!("{:3} B/s", bytes)
-                }
-            }))
+            .title(format!(
+                "Data In: {}",
+                format_bytes(
+                    (*app
+                        .parsed_bytes_data
+                        .path_bytes_in_per_sec_vec
+                        .get(state)
+                        .unwrap_or(&0)) as f64
+                )
+            ))
             .title_alignment(Alignment::Center)
             .bold()
             .borders(Borders::NONE)
@@ -319,22 +297,15 @@ fn render_path_overview_data(
         frame.render_widget(bytes_in_per_sec_block, bottom_layout[1]);
     } else {
         let bytes_in_per_sec_block = Block::new()
-            .title(format!("Data Out: {}", {
-                let bytes = (*app
-                    .parsed_bytes_data
-                    .path_bytes_out_per_sec_vec
-                    .get(state)
-                    .unwrap_or(&0)) as f64;
-                if (bytes / 1000000000.0) > 1.0 {
-                    format!("{:.3} GB/s", (bytes / 1000000000.0))
-                } else if (bytes / 1000000.0) > 1.0 {
-                    format!("{:.3} MB/s", (bytes / 1000000.0))
-                } else if (bytes / 1000.0) > 1.0 {
-                    format!("{:.3} KB/s", (bytes / 1000.0))
-                } else {
-                    format!("{:3} B/s", bytes)
-                }
-            }))
+            .title(format!(
+                "Data Out: {}",
+                format_bytes(
+                    *app.parsed_bytes_data
+                        .path_bytes_out_per_sec_vec
+                        .get(state)
+                        .unwrap_or(&0) as f64
+                )
+            ))
             .title_alignment(Alignment::Center)
             .bold()
             .borders(Borders::NONE)
@@ -516,4 +487,16 @@ fn render_sparkline_chart(
     frame.render_widget(top_paragraph, scale_layout[0]);
     frame.render_widget(middle_paragraph, scale_layout[2]);
     frame.render_widget(bottom_paragraph, scale_layout[4]);
+}
+
+fn format_bytes(bytes: f64) -> String {
+    if (bytes / 1000000000.0) > 1.0 {
+        return format!("{:.3} GB/s", (bytes / 1000000000.0));
+    } else if (bytes / 1000000.0) > 1.0 {
+        return format!("{:.3} MB/s", (bytes / 1000000.0));
+    } else if (bytes / 1000.0) > 1.0 {
+        return format!("{:.3} KB/s", (bytes / 1000.0));
+    } else {
+        return format!("{:3} B/s", bytes);
+    }
 }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -491,12 +491,12 @@ fn render_sparkline_chart(
 
 fn format_bytes(bytes: f64) -> String {
     if (bytes / 1000000000.0) > 1.0 {
-        return format!("{:.3} GB/s", (bytes / 1000000000.0));
+        format!("{:.3} GB/s", (bytes / 1000000000.0))
     } else if (bytes / 1000000.0) > 1.0 {
-        return format!("{:.3} MB/s", (bytes / 1000000.0));
+        format!("{:.3} MB/s", (bytes / 1000000.0))
     } else if (bytes / 1000.0) > 1.0 {
-        return format!("{:.3} KB/s", (bytes / 1000.0));
+        format!("{:.3} KB/s", (bytes / 1000.0))
     } else {
-        return format!("{:3} B/s", bytes);
+        format!("{:3} B/s", bytes)
     }
 }

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -142,14 +142,6 @@ impl Metrics {
                                 path: path.clone().into_os_string().to_str().unwrap().to_string(),
                             })
                             .inc_by(number_of_bytes);
-                        println!(
-                            "bytes in {}",
-                            data.bytes_in_family
-                                .get_or_create(&CounterLabels {
-                                    path: "ingest/Logs/0.0".to_string()
-                                })
-                                .get()
-                        );
                     }
                     MetricsMessage::GetNumberOfBytesOut(path, number_of_bytes) => {
                         data.bytes_out_family
@@ -157,7 +149,6 @@ impl Metrics {
                                 path: path.clone().into_os_string().to_str().unwrap().to_string(),
                             })
                             .inc_by(number_of_bytes);
-                        println!("{} bytes out {}", number_of_bytes, path.to_str().unwrap());
                     }
                 };
             }

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -17,8 +17,8 @@ pub enum MetricsErrors {
 pub enum MetricsMessage {
     GetMetricsRegistryAsString(tokio::sync::oneshot::Sender<String>),
     HTTPLatency((PathBuf, Duration, String)),
-    GetNumberOfBytesIn(PathBuf, u64),
-    GetNumberOfBytesOut(PathBuf, u64),
+    PutNumberOfBytesIn(PathBuf, u64),
+    PutNumberOfBytesOut(PathBuf, u64),
 }
 
 #[derive(Clone)]
@@ -136,14 +136,14 @@ impl Metrics {
                             .observe(duration.as_secs_f64());
                         data.total_latency_histogram.observe(duration.as_secs_f64())
                     }
-                    MetricsMessage::GetNumberOfBytesIn(path, number_of_bytes) => {
+                    MetricsMessage::PutNumberOfBytesIn(path, number_of_bytes) => {
                         data.bytes_in_family
                             .get_or_create(&CounterLabels {
                                 path: path.clone().into_os_string().to_str().unwrap().to_string(),
                             })
                             .inc_by(number_of_bytes);
                     }
-                    MetricsMessage::GetNumberOfBytesOut(path, number_of_bytes) => {
+                    MetricsMessage::PutNumberOfBytesOut(path, number_of_bytes) => {
                         data.bytes_out_family
                             .get_or_create(&CounterLabels {
                                 path: path.clone().into_os_string().to_str().unwrap().to_string(),


### PR DESCRIPTION
Instruments moose using prometheus counter to track bytes in and out per sec. Bytes in and out per sec is displayed in metrics console. There is bytes in/out per sec displayed for the whole app and for each path in the detailed view.

Screenshots:

<img width="919" alt="Screenshot 2024-07-18 at 11 59 26 AM" src="https://github.com/user-attachments/assets/5f65f983-3669-4c59-bc03-89b3684b9dc2">

<img width="913" alt="Screenshot 2024-07-18 at 11 59 39 AM" src="https://github.com/user-attachments/assets/5879171f-08e2-4fdd-b4f2-37f7ad51cf10">
