### PR TITLE
Kafka instrumentation and displaying metrics

### DIFF
--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console.rs
@@ -41,7 +41,7 @@ pub async fn run_console() -> app::AppResult<()> {
         tokio::select! {
             received = rx.recv() => {
                 if let Some(v) = received {
-                    app.per_sec_metrics(v.total_requests, &v.paths_data_vec, &v.paths_bytes_hashmap, &v.total_bytes_in, &v.total_bytes_out);
+                    app.per_sec_metrics(v.total_requests, &v.paths_data_vec, &v.paths_bytes_hashmap, &v.total_bytes_in, &v.total_bytes_out, &v.kafka_messages_out_total);
                     app.set_metrics(v);
                 };
             }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/handler.rs
@@ -2,6 +2,8 @@ use crate::cli::routines::metrics_console::run_console::app::State;
 use crate::cli::routines::metrics_console::run_console::app::{App, AppResult};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use super::app::TableState;
+
 pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
     match key_event.code {
         KeyCode::Char('q') => {
@@ -13,18 +15,36 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<
             }
         }
 
-        KeyCode::Down => {
-            app.down();
-        }
+        KeyCode::Down => match app.table_state {
+            TableState::Endpoint => {
+                app.endpoint_down();
+            }
+            TableState::Kafka => {
+                app.kafka_down();
+            }
+        },
 
-        KeyCode::Up => {
-            app.up();
-        }
+        KeyCode::Up => match app.table_state {
+            TableState::Endpoint => {
+                app.endpoint_up();
+            }
+            TableState::Kafka => {
+                app.kafka_up();
+            }
+        },
+        KeyCode::Tab => match app.table_state {
+            TableState::Endpoint => {
+                app.table_state = TableState::Kafka;
+            }
+            TableState::Kafka => {
+                app.table_state = TableState::Endpoint;
+            }
+        },
 
         KeyCode::Enter => {
-            if !app.summary.is_empty() {
+            if !app.summary.is_empty() && matches!(app.table_state, TableState::Endpoint) {
                 app.set_state(State::PathDetails(
-                    app.summary[app.starting_row].path.to_string(),
+                    app.summary[app.endpoint_starting_row].path.to_string(),
                 ));
             }
         }

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -325,7 +325,7 @@ fn render_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) 
             table_state.select(Some(app.kafka_starting_row));
 
             let table = Table::new(rows, widths)
-                .widths(&widths)
+                .widths(widths)
                 .column_spacing(1)
                 .style(Style::new().green())
                 .header(
@@ -380,7 +380,7 @@ fn render_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) 
             ];
 
             let table = Table::new(rows, widths)
-                .widths(&widths)
+                .widths(widths)
                 .column_spacing(1)
                 .style(Style::new().white())
                 .header(
@@ -402,12 +402,8 @@ fn render_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) 
 fn table_equals_path(path: String, table: String) -> bool {
     let mut path_vec: Vec<&str> = path.split(['/', '.']).collect();
     path_vec.remove(0);
-    let table_vec: Vec<&str> = table.split("_").collect();
-    if table_vec == path_vec {
-        return true;
-    } else {
-        return false;
-    }
+    let table_vec: Vec<&str> = table.split('_').collect();
+    table_vec == path_vec
 }
 
 fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -7,9 +7,10 @@ use ratatui::{
 };
 use ratatui::{prelude::*, widgets::*};
 
-use crate::cli::routines::metrics_console::run_console::app::{App, State};
+use crate::cli::routines::metrics_console::run_console::app::{App, State, TableState};
 
-const INFO_TEXT: &str = "(q) quit | (↑) move up | (↓) move down | (enter) view endpoint details";
+const INFO_TEXT: &str =
+    "(q) quit | (↑) move up | (↓) move down | (tab) switch table | (enter) view endpoint details";
 
 /// Renders the user interface widgets.
 pub fn render(app: &mut App, frame: &mut Frame) {
@@ -21,7 +22,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     Constraint::Max(2),
                     Constraint::Max(2),
                     Constraint::Max(2),
-                    Constraint::Fill(80),
+                    Constraint::Fill(40),
+                    Constraint::Fill(40),
                     Constraint::Max(3),
                 ])
                 .split(frame.size());
@@ -51,7 +53,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             render_main_page_details(frame, &outer_layout);
             render_overview_metrics(app, frame, &inner_layout);
             render_overview_bytes_data(app, frame, &bytes_overview_layout);
-            render_table(app, frame, outer_layout[3]);
+            render_endpoint_table(app, frame, outer_layout[3]);
+            render_clickhouse_sync_table(app, frame, outer_layout[4])
         }
         State::PathDetails(state) => {
             let outer_layout = Layout::default()
@@ -104,64 +107,307 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     }
 }
 
-fn render_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+fn render_endpoint_table(app: &mut App, frame: &mut Frame, layout: Rect) {
     let mut rows: Vec<Row> = vec![];
 
-    for x in &app.summary {
-        rows.push(
-            if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
-                Row::new(vec![
-                    format!("{}", x.path.to_string()),
-                    format!(
-                        "{}",
-                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
-                            .to_string()
-                    ),
-                    format!(
-                        "{}",
-                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                    ),
-                ])
-                .bold()
-                .magenta()
-            } else {
-                Row::new(vec![
-                    format!("{}", x.path.to_string()),
-                    format!(
-                        "{}",
-                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
-                            .to_string()
-                    ),
-                    format!(
-                        "{}",
-                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                    ),
-                ])
-                .green()
-                .not_bold()
-            },
-        )
+    match &app.table_state {
+        TableState::Endpoint => {
+            for x in &app.summary {
+                rows.push(
+                    if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
+                        Row::new(vec![
+                            format!("{}", x.path.to_string()),
+                            format!(
+                                "{}",
+                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                    / 1000.0)
+                                    .to_string()
+                            ),
+                            format!(
+                                "{}",
+                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                            ),
+                            format!(
+                                "{}",
+                                app.kafka_messages_in_total
+                                    .get(&x.path)
+                                    .unwrap_or(&("".to_string(), 0.0))
+                                    .1
+                            ),
+                        ])
+                        .bold()
+                        .magenta()
+                    } else {
+                        Row::new(vec![
+                            format!("{}", x.path.to_string()),
+                            format!(
+                                "{}",
+                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                    / 1000.0)
+                                    .to_string()
+                            ),
+                            format!(
+                                "{}",
+                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                            ),
+                            format!(
+                                "{}",
+                                app.kafka_messages_in_total
+                                    .get(&x.path)
+                                    .unwrap_or(&("".to_string(), 0.0))
+                                    .1
+                            ),
+                        ])
+                        .green()
+                        .not_bold()
+                    },
+                )
+            }
+
+            let widths = [
+                Constraint::Fill(22),
+                Constraint::Fill(20),
+                Constraint::Fill(20),
+                Constraint::Fill(20),
+            ];
+            let mut table_state = ratatui::widgets::TableState::default();
+            table_state.select(Some(app.endpoint_starting_row));
+
+            let table = Table::new(rows, widths)
+                .widths(widths)
+                .column_spacing(1)
+                .style(Style::new().green())
+                .header(
+                    Row::new(vec![
+                        "Path",
+                        "Latency (ms)",
+                        "Number of Requests",
+                        "Kafka Messages Sent",
+                    ])
+                    .style(Style::new().bold())
+                    .bottom_margin(1)
+                    .underlined(),
+                )
+                .block(Block::bordered().title("Endpoint Metrics Table").bold())
+                .highlight_style(Style::new().reversed())
+                .highlight_symbol(">>");
+
+            frame.render_stateful_widget(table, layout, &mut table_state)
+        }
+
+        TableState::Kafka => {
+            for x in &app.summary {
+                rows.push(
+                    if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
+                        Row::new(vec![
+                            format!("{}", x.path.to_string()),
+                            format!(
+                                "{}",
+                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                    / 1000.0)
+                                    .to_string()
+                            ),
+                            format!(
+                                "{}",
+                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                            ),
+                            format!(
+                                "{}",
+                                app.kafka_messages_in_total
+                                    .get(&x.path)
+                                    .unwrap_or(&("".to_string(), 0.0))
+                                    .1
+                            ),
+                        ])
+                        .bold()
+                        .magenta()
+                    } else {
+                        Row::new(vec![
+                            format!("{}", x.path.to_string()),
+                            format!(
+                                "{}",
+                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
+                                    / 1000.0)
+                                    .to_string()
+                            ),
+                            format!(
+                                "{}",
+                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                            ),
+                            format!(
+                                "{}",
+                                app.kafka_messages_in_total
+                                    .get(&x.path)
+                                    .unwrap_or(&("".to_string(), 0.0))
+                                    .1
+                            ),
+                        ])
+                        .white()
+                        .not_bold()
+                    },
+                )
+            }
+
+            let widths = [
+                Constraint::Fill(22),
+                Constraint::Fill(20),
+                Constraint::Fill(20),
+                Constraint::Fill(20),
+            ];
+            let mut table_state = ratatui::widgets::TableState::default();
+            table_state.select(Some(app.endpoint_starting_row));
+
+            let table = Table::new(rows, widths)
+                .widths(widths)
+                .column_spacing(1)
+                .style(Style::new().white())
+                .header(
+                    Row::new(vec![
+                        "Path",
+                        "Latency (ms)",
+                        "Number of Requests",
+                        "Kafka Messages Sent",
+                    ])
+                    .style(Style::new().bold())
+                    .bottom_margin(1)
+                    .underlined(),
+                )
+                .block(Block::bordered().title("Endpoint Metrics Table").bold());
+
+            frame.render_widget(table, layout)
+        }
     }
+}
 
-    let widths = [Constraint::Min(1), Constraint::Min(1), Constraint::Min(1)];
-    let mut table_state = TableState::default();
-    table_state.select(Some(app.starting_row));
+fn render_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+    let mut rows: Vec<Row> = vec![];
 
-    let table = Table::new(rows, widths)
-        .widths(widths)
-        .column_spacing(1)
-        .style(Style::new().green())
-        .header(
-            Row::new(vec!["Path", "Latency (ms)", "Number of Requests"])
-                .style(Style::new().bold())
-                .bottom_margin(1)
-                .underlined(),
-        )
-        .block(Block::bordered().title("Endpoint Metrics Table").bold())
-        .highlight_style(Style::new().reversed())
-        .highlight_symbol(">>");
+    let mut sorted_messages: Vec<_> = app.kafka_messages_out_total.iter().collect();
+    sorted_messages.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
 
-    frame.render_stateful_widget(table, layout, &mut table_state)
+    match app.table_state {
+        TableState::Kafka => {
+            for item in &sorted_messages {
+                rows.push(
+                    Row::new(vec![
+                        format!("{}", item.0.to_string()),
+                        format!("{}", item.2),
+                        format!("{}", {
+                            let mut lag = 10.0;
+                            for value in &app.kafka_messages_in_total {
+                                if table_equals_path(value.0.clone(), item.0.clone()) {
+                                    lag = value.1 .1 - item.2;
+                                    break;
+                                }
+                            }
+                            lag
+                        }),
+                        format!(
+                            "{}",
+                            app.kafka_messages_out_per_sec
+                                .get(&item.0)
+                                .unwrap_or(&("".to_string(), 0.0))
+                                .1
+                        ),
+                    ])
+                    .bold()
+                    .green(),
+                )
+            }
+
+            let widths = [
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ];
+            let mut table_state = ratatui::widgets::TableState::default();
+            table_state.select(Some(app.kafka_starting_row));
+
+            let table = Table::new(rows, widths)
+                .widths(&widths)
+                .column_spacing(1)
+                .style(Style::new().green())
+                .header(
+                    Row::new(vec!["Data Model", "Messages Read", "Lag", "Messages/sec"])
+                        .style(Style::new().bold())
+                        .bottom_margin(1),
+                )
+                .block(
+                    Block::bordered()
+                        .title("Kafka to Table Sync Process")
+                        .bold(),
+                )
+                .highlight_style(Style::new().reversed())
+                .highlight_symbol(">>");
+
+            frame.render_stateful_widget(table, layout, &mut table_state)
+        }
+        TableState::Endpoint => {
+            for item in &sorted_messages {
+                rows.push(
+                    Row::new(vec![
+                        format!("{}", item.0.to_string()),
+                        format!("{}", item.2),
+                        format!("{}", {
+                            let mut lag = 10.0;
+                            for value in &app.kafka_messages_in_total {
+                                if table_equals_path(value.0.clone(), item.0.clone()) {
+                                    lag = value.1 .1 - item.2;
+                                    break;
+                                }
+                            }
+                            lag
+                        }),
+                        format!(
+                            "{}",
+                            app.kafka_messages_out_per_sec
+                                .get(&item.0)
+                                .unwrap_or(&("".to_string(), 0.0))
+                                .1
+                        ),
+                    ])
+                    .bold()
+                    .white(),
+                )
+            }
+
+            let widths = [
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ];
+
+            let table = Table::new(rows, widths)
+                .widths(&widths)
+                .column_spacing(1)
+                .style(Style::new().white())
+                .header(
+                    Row::new(vec!["Data Model", "Messages Read", "Lag", "Messages/sec"])
+                        .style(Style::new().bold())
+                        .bottom_margin(1),
+                )
+                .block(
+                    Block::bordered()
+                        .title("Kafka to Table Sync Process")
+                        .bold(),
+                );
+
+            frame.render_widget(table, layout)
+        }
+    }
+}
+
+fn table_equals_path(path: String, table: String) -> bool {
+    let mut path_vec: Vec<&str> = path.split(['/', '.']).collect();
+    path_vec.remove(0);
+    let table_vec: Vec<&str> = table.split("_").collect();
+    if table_vec == path_vec {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>) {
@@ -181,10 +427,7 @@ fn render_overview_metrics(app: &mut App, frame: &mut Frame, layout: &Rc<[Rect]>
         .white();
 
     let req_per_sec = Block::new()
-        .title(format!(
-            "Requests Per Second: {}",
-            app.main_bytes_data.bytes_out_per_sec
-        ))
+        .title(format!("Requests Per Second: {}", app.requests_per_sec))
         .title_alignment(Alignment::Center)
         .bold()
         .white();
@@ -234,7 +477,7 @@ fn render_main_page_details(frame: &mut Frame, layout: &Rc<[Rect]>) {
         .green();
 
     frame.render_widget(block, layout[0]);
-    frame.render_widget(info_footer, layout[4]);
+    frame.render_widget(info_footer, layout[5]);
 }
 
 fn render_path_overview_data(
@@ -247,8 +490,8 @@ fn render_path_overview_data(
     let average_latency_block = Block::new()
         .title(format!(
             "Average Latency: {}ms ",
-            (((app.summary[app.starting_row].latency_sum
-                / app.summary[app.starting_row].request_count)
+            (((app.summary[app.endpoint_starting_row].latency_sum
+                / app.summary[app.endpoint_starting_row].request_count)
                 * 1000000.0)
                 .round())
                 / 1000.0
@@ -261,7 +504,7 @@ fn render_path_overview_data(
     let request_count_block = Block::new()
         .title(format!(
             "Number of Requests: {}",
-            (app.summary[app.starting_row].request_count)
+            (app.summary[app.endpoint_starting_row].request_count)
         ))
         .title_alignment(Alignment::Center)
         .bold()

--- a/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
+++ b/apps/framework-cli/src/cli/routines/metrics_console/run_console/ui.rs
@@ -108,295 +108,312 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 }
 
 fn render_endpoint_table(app: &mut App, frame: &mut Frame, layout: Rect) {
-    let mut rows: Vec<Row> = vec![];
-
     match &app.table_state {
-        TableState::Endpoint => {
-            for x in &app.summary {
-                rows.push(
-                    if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
-                        Row::new(vec![
-                            format!("{}", x.path.to_string()),
-                            format!(
-                                "{}",
-                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                    / 1000.0)
-                                    .to_string()
-                            ),
-                            format!(
-                                "{}",
-                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                            ),
-                            format!(
-                                "{}",
-                                app.kafka_messages_in_total
-                                    .get(&x.path)
-                                    .unwrap_or(&("".to_string(), 0.0))
-                                    .1
-                            ),
-                        ])
-                        .bold()
-                        .magenta()
-                    } else {
-                        Row::new(vec![
-                            format!("{}", x.path.to_string()),
-                            format!(
-                                "{}",
-                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                    / 1000.0)
-                                    .to_string()
-                            ),
-                            format!(
-                                "{}",
-                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                            ),
-                            format!(
-                                "{}",
-                                app.kafka_messages_in_total
-                                    .get(&x.path)
-                                    .unwrap_or(&("".to_string(), 0.0))
-                                    .1
-                            ),
-                        ])
-                        .green()
-                        .not_bold()
-                    },
-                )
-            }
+        TableState::Endpoint => render_active_endpoint_table(app, frame, layout),
 
-            let widths = [
-                Constraint::Fill(22),
-                Constraint::Fill(20),
-                Constraint::Fill(20),
-                Constraint::Fill(20),
-            ];
-            let mut table_state = ratatui::widgets::TableState::default();
-            table_state.select(Some(app.endpoint_starting_row));
-
-            let table = Table::new(rows, widths)
-                .widths(widths)
-                .column_spacing(1)
-                .style(Style::new().green())
-                .header(
-                    Row::new(vec![
-                        "Path",
-                        "Latency (ms)",
-                        "Number of Requests",
-                        "Kafka Messages Sent",
-                    ])
-                    .style(Style::new().bold())
-                    .bottom_margin(1)
-                    .underlined(),
-                )
-                .block(Block::bordered().title("Endpoint Metrics Table").bold())
-                .highlight_style(Style::new().reversed())
-                .highlight_symbol(">>");
-
-            frame.render_stateful_widget(table, layout, &mut table_state)
-        }
-
-        TableState::Kafka => {
-            for x in &app.summary {
-                rows.push(
-                    if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
-                        Row::new(vec![
-                            format!("{}", x.path.to_string()),
-                            format!(
-                                "{}",
-                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                    / 1000.0)
-                                    .to_string()
-                            ),
-                            format!(
-                                "{}",
-                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                            ),
-                            format!(
-                                "{}",
-                                app.kafka_messages_in_total
-                                    .get(&x.path)
-                                    .unwrap_or(&("".to_string(), 0.0))
-                                    .1
-                            ),
-                        ])
-                        .bold()
-                        .magenta()
-                    } else {
-                        Row::new(vec![
-                            format!("{}", x.path.to_string()),
-                            format!(
-                                "{}",
-                                ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round()
-                                    / 1000.0)
-                                    .to_string()
-                            ),
-                            format!(
-                                "{}",
-                                (((x.request_count * 1000.0).round()) / 1000.0).to_string()
-                            ),
-                            format!(
-                                "{}",
-                                app.kafka_messages_in_total
-                                    .get(&x.path)
-                                    .unwrap_or(&("".to_string(), 0.0))
-                                    .1
-                            ),
-                        ])
-                        .white()
-                        .not_bold()
-                    },
-                )
-            }
-
-            let widths = [
-                Constraint::Fill(22),
-                Constraint::Fill(20),
-                Constraint::Fill(20),
-                Constraint::Fill(20),
-            ];
-            let mut table_state = ratatui::widgets::TableState::default();
-            table_state.select(Some(app.endpoint_starting_row));
-
-            let table = Table::new(rows, widths)
-                .widths(widths)
-                .column_spacing(1)
-                .style(Style::new().white())
-                .header(
-                    Row::new(vec![
-                        "Path",
-                        "Latency (ms)",
-                        "Number of Requests",
-                        "Kafka Messages Sent",
-                    ])
-                    .style(Style::new().bold())
-                    .bottom_margin(1)
-                    .underlined(),
-                )
-                .block(Block::bordered().title("Endpoint Metrics Table").bold());
-
-            frame.render_widget(table, layout)
-        }
+        _ => render_passive_endpoint_table(app, frame, layout),
     }
 }
 
+fn render_active_endpoint_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+    let mut rows: Vec<Row> = vec![];
+
+    for x in &app.summary {
+        rows.push(
+            if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                    format!(
+                        "{}",
+                        app.kafka_messages_in_total
+                            .get(&x.path)
+                            .unwrap_or(&("".to_string(), 0.0))
+                            .1
+                    ),
+                ])
+                .bold()
+                .magenta()
+            } else {
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                    format!(
+                        "{}",
+                        app.kafka_messages_in_total
+                            .get(&x.path)
+                            .unwrap_or(&("".to_string(), 0.0))
+                            .1
+                    ),
+                ])
+                .green()
+                .not_bold()
+            },
+        )
+    }
+
+    let widths = [
+        Constraint::Fill(22),
+        Constraint::Fill(20),
+        Constraint::Fill(20),
+        Constraint::Fill(20),
+    ];
+    let mut table_state = ratatui::widgets::TableState::default();
+    table_state.select(Some(app.endpoint_starting_row));
+
+    let table = Table::new(rows, widths)
+        .widths(widths)
+        .column_spacing(1)
+        .style(Style::new().green())
+        .header(
+            Row::new(vec![
+                "Path",
+                "Latency (ms)",
+                "Number of Requests",
+                "Kafka Messages Sent",
+            ])
+            .style(Style::new().bold())
+            .bottom_margin(1)
+            .underlined(),
+        )
+        .block(Block::bordered().title("Endpoint Metrics Table").bold())
+        .highlight_style(Style::new().reversed())
+        .highlight_symbol(">>");
+
+    frame.render_stateful_widget(table, layout, &mut table_state)
+}
+
+fn render_passive_endpoint_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+    let mut rows: Vec<Row> = vec![];
+
+    for x in &app.summary {
+        rows.push(
+            if *app.path_requests_per_sec.get(&x.path).unwrap_or(&0.0) > 0.0 {
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                    format!(
+                        "{}",
+                        app.kafka_messages_in_total
+                            .get(&x.path)
+                            .unwrap_or(&("".to_string(), 0.0))
+                            .1
+                    ),
+                ])
+                .bold()
+                .magenta()
+            } else {
+                Row::new(vec![
+                    format!("{}", x.path.to_string()),
+                    format!(
+                        "{}",
+                        ((((x.latency_sum / x.request_count) * 1000.0) * 1000.0).round() / 1000.0)
+                            .to_string()
+                    ),
+                    format!(
+                        "{}",
+                        (((x.request_count * 1000.0).round()) / 1000.0).to_string()
+                    ),
+                    format!(
+                        "{}",
+                        app.kafka_messages_in_total
+                            .get(&x.path)
+                            .unwrap_or(&("".to_string(), 0.0))
+                            .1
+                    ),
+                ])
+                .white()
+                .not_bold()
+            },
+        )
+    }
+
+    let widths = [
+        Constraint::Fill(22),
+        Constraint::Fill(20),
+        Constraint::Fill(20),
+        Constraint::Fill(20),
+    ];
+    let mut table_state = ratatui::widgets::TableState::default();
+    table_state.select(Some(app.endpoint_starting_row));
+
+    let table = Table::new(rows, widths)
+        .widths(widths)
+        .column_spacing(1)
+        .style(Style::new().white())
+        .header(
+            Row::new(vec![
+                "Path",
+                "Latency (ms)",
+                "Number of Requests",
+                "Kafka Messages Sent",
+            ])
+            .style(Style::new().bold())
+            .bottom_margin(1)
+            .underlined(),
+        )
+        .block(Block::bordered().title("Endpoint Metrics Table").bold());
+
+    frame.render_widget(table, layout)
+}
+
 fn render_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+    match app.table_state {
+        TableState::Kafka => render_active_clickhouse_sync_table(app, frame, layout),
+        _ => render_passive_clickhouse_sync_table(app, frame, layout),
+    }
+}
+
+fn render_passive_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) {
     let mut rows: Vec<Row> = vec![];
 
     let mut sorted_messages: Vec<_> = app.kafka_messages_out_total.iter().collect();
     sorted_messages.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
 
-    match app.table_state {
-        TableState::Kafka => {
-            for item in &sorted_messages {
-                rows.push(
-                    Row::new(vec![
-                        format!("{}", item.0.to_string()),
-                        format!("{}", item.2),
-                        format!("{}", {
-                            let mut lag = 10.0;
-                            for value in &app.kafka_messages_in_total {
-                                if table_equals_path(value.0.clone(), item.0.clone()) {
-                                    lag = value.1 .1 - item.2;
-                                    break;
-                                }
-                            }
-                            lag
-                        }),
-                        format!(
-                            "{}",
-                            app.kafka_messages_out_per_sec
-                                .get(&item.0)
-                                .unwrap_or(&("".to_string(), 0.0))
-                                .1
-                        ),
-                    ])
-                    .bold()
-                    .green(),
-                )
-            }
-
-            let widths = [
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-            ];
-            let mut table_state = ratatui::widgets::TableState::default();
-            table_state.select(Some(app.kafka_starting_row));
-
-            let table = Table::new(rows, widths)
-                .widths(widths)
-                .column_spacing(1)
-                .style(Style::new().green())
-                .header(
-                    Row::new(vec!["Data Model", "Messages Read", "Lag", "Messages/sec"])
-                        .style(Style::new().bold())
-                        .bottom_margin(1),
-                )
-                .block(
-                    Block::bordered()
-                        .title("Kafka to Table Sync Process")
-                        .bold(),
-                )
-                .highlight_style(Style::new().reversed())
-                .highlight_symbol(">>");
-
-            frame.render_stateful_widget(table, layout, &mut table_state)
-        }
-        TableState::Endpoint => {
-            for item in &sorted_messages {
-                rows.push(
-                    Row::new(vec![
-                        format!("{}", item.0.to_string()),
-                        format!("{}", item.2),
-                        format!("{}", {
-                            let mut lag = 10.0;
-                            for value in &app.kafka_messages_in_total {
-                                if table_equals_path(value.0.clone(), item.0.clone()) {
-                                    lag = value.1 .1 - item.2;
-                                    break;
-                                }
-                            }
-                            lag
-                        }),
-                        format!(
-                            "{}",
-                            app.kafka_messages_out_per_sec
-                                .get(&item.0)
-                                .unwrap_or(&("".to_string(), 0.0))
-                                .1
-                        ),
-                    ])
-                    .bold()
-                    .white(),
-                )
-            }
-
-            let widths = [
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-            ];
-
-            let table = Table::new(rows, widths)
-                .widths(widths)
-                .column_spacing(1)
-                .style(Style::new().white())
-                .header(
-                    Row::new(vec!["Data Model", "Messages Read", "Lag", "Messages/sec"])
-                        .style(Style::new().bold())
-                        .bottom_margin(1),
-                )
-                .block(
-                    Block::bordered()
-                        .title("Kafka to Table Sync Process")
-                        .bold(),
-                );
-
-            frame.render_widget(table, layout)
-        }
+    for item in &sorted_messages {
+        rows.push(
+            Row::new(vec![
+                format!("{}", item.0.to_string()),
+                format!("{}", item.2),
+                format!("{}", {
+                    let mut lag: Option<f64> = None;
+                    for value in &app.kafka_messages_in_total {
+                        if table_equals_path(value.0.clone(), item.0.clone()) {
+                            lag = Some(value.1 .1 - item.2);
+                            break;
+                        }
+                    }
+                    match lag {
+                        Some(value) => value.to_string(),
+                        None => "NA".to_string(),
+                    }
+                }),
+                format!(
+                    "{}",
+                    app.kafka_messages_out_per_sec
+                        .get(&item.0)
+                        .unwrap_or(&("".to_string(), 0.0))
+                        .1
+                ),
+            ])
+            .bold()
+            .white(),
+        )
     }
+
+    let widths = [
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+    ];
+
+    let table = Table::new(rows, widths)
+        .widths(widths)
+        .column_spacing(1)
+        .style(Style::new().white())
+        .header(
+            Row::new(vec!["Data Model", "Messages Read", "Lag", "Messages/sec"])
+                .style(Style::new().bold())
+                .bottom_margin(1),
+        )
+        .block(
+            Block::bordered()
+                .title("Kafka to Table Sync Process")
+                .bold(),
+        );
+
+    frame.render_widget(table, layout)
+}
+
+fn render_active_clickhouse_sync_table(app: &mut App, frame: &mut Frame, layout: Rect) {
+    let mut rows: Vec<Row> = vec![];
+
+    let mut sorted_messages: Vec<_> = app.kafka_messages_out_total.iter().collect();
+    sorted_messages.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+
+    for item in &sorted_messages {
+        rows.push(
+            Row::new(vec![
+                format!("{}", item.0.to_string()),
+                format!("{}", item.2),
+                format!("{}", {
+                    let mut lag: Option<f64> = None;
+                    for value in &app.kafka_messages_in_total {
+                        if table_equals_path(value.0.clone(), item.0.clone()) {
+                            lag = Some(value.1 .1 - item.2);
+                            break;
+                        }
+                    }
+                    match lag {
+                        Some(value) => value.to_string(),
+                        None => "NA".to_string(),
+                    }
+                }),
+                format!(
+                    "{}",
+                    app.kafka_messages_out_per_sec
+                        .get(&item.0)
+                        .unwrap_or(&("".to_string(), 0.0))
+                        .1
+                ),
+            ])
+            .bold()
+            .green(),
+        )
+    }
+
+    let widths = [
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+    ];
+    let mut table_state = ratatui::widgets::TableState::default();
+    table_state.select(Some(app.kafka_starting_row));
+
+    let table = Table::new(rows, widths)
+        .widths(widths)
+        .column_spacing(1)
+        .style(Style::new().green())
+        .header(
+            Row::new(vec!["Data Model", "Messages Read", "Lag", "Messages/sec"])
+                .style(Style::new().bold())
+                .bottom_margin(1),
+        )
+        .block(
+            Block::bordered()
+                .title("Kafka to Table Sync Process")
+                .bold(),
+        )
+        .highlight_style(Style::new().reversed())
+        .highlight_symbol(">>");
+
+    frame.render_stateful_widget(table, layout, &mut table_state)
 }
 
 fn table_equals_path(path: String, table: String) -> bool {

--- a/apps/framework-cli/src/infrastructure/processes.rs
+++ b/apps/framework-cli/src/infrastructure/processes.rs
@@ -1,10 +1,15 @@
+use std::sync::Arc;
+
 use consumption_registry::ConsumptionError;
 use kafka_clickhouse_sync::SyncingProcessesRegistry;
 use process_registry::ProcessRegistries;
 
-use crate::framework::{
-    aggregations::model::AggregationError,
-    core::infrastructure_map::{Change, ProcessChange},
+use crate::{
+    framework::{
+        aggregations::model::AggregationError,
+        core::infrastructure_map::{Change, ProcessChange},
+    },
+    metrics::Metrics,
 };
 
 use super::olap::clickhouse::{errors::ClickhouseError, mapper::std_columns_to_clickhouse_columns};
@@ -36,6 +41,7 @@ pub async fn execute_changes(
     syncing_registry: &mut SyncingProcessesRegistry,
     process_registry: &mut ProcessRegistries,
     changes: &[ProcessChange],
+    metrics: Arc<Metrics>,
 ) -> Result<(), SyncProcessChangesError> {
     for change in changes.iter() {
         match change {
@@ -47,6 +53,7 @@ pub async fn execute_changes(
                     sync.columns.clone(),
                     sync.target_table_id.clone(),
                     target_table_columns,
+                    metrics.clone(),
                 );
             }
             ProcessChange::TopicToTableSyncProcess(Change::Removed(sync)) => {
@@ -64,6 +71,7 @@ pub async fn execute_changes(
                     after.columns.clone(),
                     after.target_table_id.clone(),
                     target_table_columns,
+                    metrics.clone(),
                 );
             }
             ProcessChange::FunctionProcess(Change::Added(function_process)) => {

--- a/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
+++ b/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
@@ -297,8 +297,6 @@ async fn sync_kafka_to_kafka(
     let queue: Mutex<VecDeque<DeliveryFuture>> = Mutex::new(VecDeque::new());
     let target_topic_name = &target_topic_name;
 
-    println!("1: {:#?}", target_topic_name);
-
     iterate_subscriber(
         subscriber,
         source_topic_name,
@@ -331,8 +329,6 @@ async fn sync_kafka_to_clickhouse(
 ) -> anyhow::Result<()> {
     let subscriber: StreamConsumer =
         create_subscriber(&kafka_config, TABLE_SYNC_GROUP_ID, &source_topic_name);
-    println!("2: {:#?}", source_topic_name);
-    println!("2: {:#?}", target_table_name);
 
     let clickhouse_columns = target_table_columns
         .iter()
@@ -401,7 +397,6 @@ async fn iterate_subscriber<'a, F>(
                             "Received message from {}: {}",
                             source_topic_name, payload_str
                         );
-                        //println!("{}", subscriber);
                         metrics
                             .send_metric(MetricsMessage::PutNumberOfMessagesOut(
                                 "clickhouse_sync".to_string(),

--- a/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
+++ b/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
@@ -297,6 +297,8 @@ async fn sync_kafka_to_kafka(
     let queue: Mutex<VecDeque<DeliveryFuture>> = Mutex::new(VecDeque::new());
     let target_topic_name = &target_topic_name;
 
+    println!("1: {:#?}", target_topic_name);
+
     iterate_subscriber(
         subscriber,
         source_topic_name,
@@ -327,7 +329,10 @@ async fn sync_kafka_to_clickhouse(
     target_table_columns: Vec<ClickHouseColumn>,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<()> {
-    let subscriber = create_subscriber(&kafka_config, TABLE_SYNC_GROUP_ID, &source_topic_name);
+    let subscriber: StreamConsumer =
+        create_subscriber(&kafka_config, TABLE_SYNC_GROUP_ID, &source_topic_name);
+    println!("2: {:#?}", source_topic_name);
+    println!("2: {:#?}", target_table_name);
 
     let clickhouse_columns = target_table_columns
         .iter()
@@ -396,6 +401,7 @@ async fn iterate_subscriber<'a, F>(
                             "Received message from {}: {}",
                             source_topic_name, payload_str
                         );
+                        //println!("{}", subscriber);
                         metrics
                             .send_metric(MetricsMessage::PutNumberOfMessagesOut(
                                 "clickhouse_sync".to_string(),

--- a/apps/framework-cli/src/infrastructure/stream/redpanda.rs
+++ b/apps/framework-cli/src/infrastructure/stream/redpanda.rs
@@ -307,6 +307,7 @@ pub fn create_subscriber(config: &RedpandaConfig, group_id: &str, topic: &str) -
         .set("enable.partition.eof", "false")
         .set("enable.auto.commit", "true")
         .set("auto.commit.interval.ms", "1000")
+        // Groupid
         .set("group.id", group_id);
 
     let consumer: StreamConsumer = client_config.create().expect("Failed to create consumer");

--- a/apps/framework-cli/src/infrastructure/stream/redpanda.rs
+++ b/apps/framework-cli/src/infrastructure/stream/redpanda.rs
@@ -301,7 +301,6 @@ pub async fn fetch_topics(
 
 pub fn create_subscriber(config: &RedpandaConfig, group_id: &str, topic: &str) -> StreamConsumer {
     let mut client_config = config_client(config);
-    println!("{}", group_id);
 
     client_config
         .set("session.timeout.ms", "6000")

--- a/apps/framework-cli/src/infrastructure/stream/redpanda.rs
+++ b/apps/framework-cli/src/infrastructure/stream/redpanda.rs
@@ -301,6 +301,7 @@ pub async fn fetch_topics(
 
 pub fn create_subscriber(config: &RedpandaConfig, group_id: &str, topic: &str) -> StreamConsumer {
     let mut client_config = config_client(config);
+    println!("{}", group_id);
 
     client_config
         .set("session.timeout.ms", "6000")

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -112,10 +112,10 @@ impl Metrics {
                 Counter::default()
             }),
             messages_in_family: Family::<MessagesInCounterLabels, Counter>::new_with_constructor(
-                || {Counter::default()}
+                || Counter::default(),
             ),
             messages_out_family: Family::<MessagesOutCounterLabels, Counter>::new_with_constructor(
-                || {Counter::default()}
+                || Counter::default(),
             ),
             registry: Some(Registry::default()),
         };

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -112,10 +112,10 @@ impl Metrics {
                 Counter::default()
             }),
             messages_in_family: Family::<MessagesInCounterLabels, Counter>::new_with_constructor(
-                || Counter::default(),
+                Counter::default,
             ),
             messages_out_family: Family::<MessagesOutCounterLabels, Counter>::new_with_constructor(
-                || Counter::default(),
+                Counter::default,
             ),
             registry: Some(Registry::default()),
         };

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -112,10 +112,10 @@ impl Metrics {
                 Counter::default()
             }),
             messages_in_family: Family::<MessagesInCounterLabels, Counter>::new_with_constructor(
-                || Counter::default(),
+                || {Counter::default()}
             ),
             messages_out_family: Family::<MessagesOutCounterLabels, Counter>::new_with_constructor(
-                || Counter::default(),
+                || {Counter::default()}
             ),
             registry: Some(Registry::default()),
         };

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -19,6 +19,8 @@ pub enum MetricsMessage {
     HTTPLatency((PathBuf, Duration, String)),
     PutNumberOfBytesIn(PathBuf, u64),
     PutNumberOfBytesOut(PathBuf, u64),
+    PutNumberOfMessagesIn(String, String),
+    PutNumberOfMessagesOut(String, String),
 }
 
 #[derive(Clone)]
@@ -29,8 +31,10 @@ pub struct Metrics {
 pub struct Statistics {
     pub total_latency_histogram: Histogram,
     pub histogram_family: Family<HistogramLabels, Histogram>,
-    pub bytes_in_family: Family<CounterLabels, Counter>,
-    pub bytes_out_family: Family<CounterLabels, Counter>,
+    pub bytes_in_family: Family<BytesCounterLabels, Counter>,
+    pub bytes_out_family: Family<BytesCounterLabels, Counter>,
+    pub messages_in_family: Family<MessagesInCounterLabels, Counter>,
+    pub messages_out_family: Family<MessagesOutCounterLabels, Counter>,
     pub registry: Option<Registry>,
 }
 
@@ -41,8 +45,20 @@ pub struct HistogramLabels {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-pub struct CounterLabels {
+pub struct BytesCounterLabels {
     path: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct MessagesInCounterLabels {
+    path: String,
+    topic: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct MessagesOutCounterLabels {
+    consumer_group: String,
+    topic: String,
 }
 
 impl Metrics {
@@ -89,12 +105,18 @@ impl Metrics {
                     .into_iter(),
                 )
             }),
-            bytes_in_family: Family::<CounterLabels, Counter>::new_with_constructor(|| {
+            bytes_in_family: Family::<BytesCounterLabels, Counter>::new_with_constructor(|| {
                 Counter::default()
             }),
-            bytes_out_family: Family::<CounterLabels, Counter>::new_with_constructor(|| {
+            bytes_out_family: Family::<BytesCounterLabels, Counter>::new_with_constructor(|| {
                 Counter::default()
             }),
+            messages_in_family: Family::<MessagesInCounterLabels, Counter>::new_with_constructor(
+                || Counter::default(),
+            ),
+            messages_out_family: Family::<MessagesOutCounterLabels, Counter>::new_with_constructor(
+                || Counter::default(),
+            ),
             registry: Some(Registry::default()),
         };
         let mut new_registry = data.registry.unwrap();
@@ -118,6 +140,16 @@ impl Metrics {
             "Bytes sent out through consumption endpoints",
             data.bytes_out_family.clone(),
         );
+        new_registry.register(
+            "messages_in",
+            "Messages sent to kafka stream",
+            data.messages_in_family.clone(),
+        );
+        new_registry.register(
+            "messages_out",
+            "Messages received from kafka stream",
+            data.messages_out_family.clone(),
+        );
 
         data.registry = Some(new_registry);
 
@@ -138,17 +170,30 @@ impl Metrics {
                     }
                     MetricsMessage::PutNumberOfBytesIn(path, number_of_bytes) => {
                         data.bytes_in_family
-                            .get_or_create(&CounterLabels {
+                            .get_or_create(&BytesCounterLabels {
                                 path: path.clone().into_os_string().to_str().unwrap().to_string(),
                             })
                             .inc_by(number_of_bytes);
                     }
                     MetricsMessage::PutNumberOfBytesOut(path, number_of_bytes) => {
                         data.bytes_out_family
-                            .get_or_create(&CounterLabels {
+                            .get_or_create(&BytesCounterLabels {
                                 path: path.clone().into_os_string().to_str().unwrap().to_string(),
                             })
                             .inc_by(number_of_bytes);
+                    }
+                    MetricsMessage::PutNumberOfMessagesIn(path, topic) => {
+                        data.messages_in_family
+                            .get_or_create(&MessagesInCounterLabels { path, topic })
+                            .inc();
+                    }
+                    MetricsMessage::PutNumberOfMessagesOut(consumer_group, topic) => {
+                        data.messages_out_family
+                            .get_or_create(&MessagesOutCounterLabels {
+                                consumer_group,
+                                topic,
+                            })
+                            .inc();
                     }
                 };
             }


### PR DESCRIPTION
Instruments moose to track the number of messages sent to kafka from each ingest point and the number of messages received from kafka for each data model. Lag and messages per second are also calculated and displayed to the user. The user can also toggle between tables and then use the arrow keys to scroll within the table they have selected

Screen Shot:



<img width="1081" alt="Screenshot 2024-07-19 at 11 26 53 PM" src="https://github.com/user-attachments/assets/b9868d3c-7b31-4af6-9dfd-d2b8f4bf16f3">

