### PR TITLE
Metrics console docs update

### DIFF
--- a/apps/framework-docs/src/pages/_meta.json
+++ b/apps/framework-docs/src/pages/_meta.json
@@ -9,6 +9,7 @@
   "building": "Developing your App",
   "deploying": "Deploying your App",
   "moose-cli": "Moose CLI",
+  "metrics-console": "Metrics Console",
   "quick-reference": "Quick Reference",
   "faqs": "FAQs",
   "usage-data": "Privacy"

--- a/apps/framework-docs/src/pages/metrics-console.mdx
+++ b/apps/framework-docs/src/pages/metrics-console.mdx
@@ -1,0 +1,27 @@
+# Metrics Console
+
+The metrics console lets you view live metrics from your Moose application all within your terminal
+
+To view metrics, run the following command:
+
+```txt filename="Terminal" copy
+moose metrics
+```
+
+## HTTP Endpoint Metrics
+
+In the metrics console you can view how many http requests per second and total requests are being send to each ingest and consumption endpoint.
+You can also view how many bytes per second are being sent to each endpoint. Using your arrow keys you can move up and down rows in the endpoint table and then press enter to view more details about that endpoint.
+In the detailed view you can see more detailed metrics and graphs.
+
+## Kafka To Clickhouse Sync Process Metrics
+
+The metrics console provide metrics to view the status of the Kafka Clickhouse sync process.
+You can view the number of messages that have been sent from the ingest point to kafka and how many have been received by the Clickhouse consumer.
+There are also metrics to show the lag of the consumer and the number of messages received per second and the number of bytes and per second that are being sent to Clickhouse.
+
+## Streaming Functions Metrics
+
+The metrics console provide metrics to view the status of the streaming functions.
+You can see the total number of messages that have been sent to the streaming function and the number of messages that have been received by the streaming function.
+There are metrics that show the number of messages in per seconds, messages out per second, and bytes out per second.


### PR DESCRIPTION
Added a new page in the docs to give a more detailed explanation of what metrics moose tracks and where they come from.