### PR TITLE
chore: default metrics instrumentation

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -313,8 +313,7 @@ async fn top_command_handler(
             );
 
             let (metrics, rx) = Metrics::new(TelemetryMetadata {
-                anonymous_telemetry_enabled: settings.telemetry.enabled
-                    && settings.features.telemetry_metrics,
+                anonymous_telemetry_enabled: settings.telemetry.enabled,
                 machine_id: settings.telemetry.machine_id.clone(),
                 is_moose_developer: settings.telemetry.is_moose_developer,
                 is_production: project_arc.is_production,
@@ -465,8 +464,7 @@ async fn top_command_handler(
             let project_arc = Arc::new(project);
 
             let (metrics, rx) = Metrics::new(TelemetryMetadata {
-                anonymous_telemetry_enabled: settings.telemetry.enabled
-                    && settings.features.telemetry_metrics,
+                anonymous_telemetry_enabled: settings.telemetry.enabled,
                 machine_id: settings.telemetry.machine_id.clone(),
                 is_moose_developer: settings.telemetry.is_moose_developer,
                 is_production: project_arc.is_production,

--- a/apps/framework-cli/src/cli/settings.rs
+++ b/apps/framework-cli/src/cli/settings.rs
@@ -44,8 +44,6 @@ impl Default for Telemetry {
 pub struct Features {
     #[serde(default)]
     pub core_v2: bool,
-    #[serde(default)]
-    pub telemetry_metrics: bool,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Tested by turning the flag on - it works.
This activates it as a default

![Screenshot 2024-08-02 at 4 48 26 PM](https://github.com/user-attachments/assets/35052455-61a7-4e83-9bf7-cf3bf3a021ad)

