### PR TITLE
chore: harden docker images

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -21,8 +21,9 @@ FROM node:20-bookworm-slim
 RUN npm config set update-notifier false
 "#;
 
+// Python and node 'slim' term is flipped
 static PY_BASE_DOCKER_FILE: &str = r#"
-FROM python:3.12-bookworm
+FROM python:3.12-slim-bookworm
 "#;
 
 static DOCKER_FILE_COMMON: &str = r#"


### PR DESCRIPTION
* Changes user pattern to not run as root user
* Use base node image instead of making our own
* Change order of instructions to maximize caching

Build is now 30s 

![Screenshot 2024-08-21 at 4 32 38 PM](https://github.com/user-attachments/assets/27b120c7-0026-4ccf-b897-bfd75aef016a)
