### PR TITLE
chore: replace flags with pre-built redpanda dev flag

### DIFF
--- a/apps/framework-cli/src/utilities/docker-compose.yml
+++ b/apps/framework-cli/src/utilities/docker-compose.yml
@@ -14,12 +14,10 @@ services:
       - --advertise-kafka-addr=internal://redpanda:9092,external://localhost:19092
       - --pandaproxy-addr=internal://0.0.0.0:8082,external://0.0.0.0:18082
       - --advertise-pandaproxy-addr=internal://redpanda:8082,external://localhost:18082
-      - --overprovisioned
+      - --mode=dev-container
       - --smp=1
       - --memory=2G
-      - --reserve-memory=200M
       - --node-id=0
-      - --check=false
   clickhousedb:
     image: docker.io/clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-latest}
     volumes:


### PR DESCRIPTION
Cleans up docker compose options for redpanda