### PR TITLE
chore: fix main release build by adding install step to the publish script

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -287,6 +287,10 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
+      - name: Install dependencies
+        shell: bash
+        run: pnpm --filter ...create-moose-app  --filter ...@514labs/moose-cli install
+
       - name: Publish the NPM Moose CLI package
         shell: bash
         run: ./apps/moose-cli-npm/scripts/release-cli.sh ${{ needs.version.outputs.version }}

--- a/apps/create-moose-app/scripts/release.sh
+++ b/apps/create-moose-app/scripts/release.sh
@@ -13,6 +13,6 @@ jq \
     && mv package.json.tmp package.json
 
 cd ../..
-pnpm build --filter create-moose-app
+pnpm build --filter ...create-moose-app
 cd apps/create-moose-app
 pnpm publish --access public --no-git-checks


### PR DESCRIPTION
Looks like we broke main release on Friday by adding some dependencies.

Ref: https://github.com/514-labs/moose/actions/runs/10746946493/job/29808833294