### PR TITLE
fix: deactivate the update notifier from npm

### DIFF
--- a/apps/framework-cli/src/framework/typescript/parser.rs
+++ b/apps/framework-cli/src/framework/typescript/parser.rs
@@ -63,6 +63,7 @@ pub fn extract_data_model_from_file(
         .arg("tspc")
         .arg("--project")
         .arg(".moose/tsconfig.json")
+        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
         .current_dir(&project.project_location)
         .spawn()?
         .wait()

--- a/apps/framework-cli/src/framework/typescript/ts_node.rs
+++ b/apps/framework-cli/src/framework/typescript/ts_node.rs
@@ -15,6 +15,7 @@ pub fn run(script: &str, args: &[&str]) -> Result<Child, std::io::Error> {
     let mut command = Command::new("npx");
 
     command
+        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
         .arg("--yes")
         .arg("ts-node")
         .arg("-e")


### PR DESCRIPTION
This was breaking the deployment in boreal since the notice is on the `stderr` channel