### PR TITLE
fix handling after unknown field

### DIFF
--- a/apps/framework-cli/src/utilities/validate_passthrough.rs
+++ b/apps/framework-cli/src/utilities/validate_passthrough.rs
@@ -351,6 +351,8 @@ impl DataModelVisitor {
                     required: column.required,
                 };
                 map.next_value_seed(&mut visitor)?;
+            } else {
+                map.next_value::<serde::de::IgnoredAny>()?;
             }
         }
         let mut missing_fields: Vec<&str> = Vec::new();


### PR DESCRIPTION
without calling `next_value` it expects a new key in JSON when the next tokens are `:` and the value