### PR TITLE
Support jwt in python consumption api

### DIFF
--- a/apps/framework-cli/src/framework/python/consumption.rs
+++ b/apps/framework-cli/src/framework/python/consumption.rs
@@ -18,14 +18,21 @@ pub fn run(
         .as_ref()
         .map(|jwt| jwt.secret.clone())
         .unwrap_or("".to_string());
+
     let jwt_issuer = jwt_config
         .as_ref()
         .map(|jwt| jwt.issuer.clone())
         .unwrap_or("".to_string());
+
     let jwt_audience = jwt_config
         .as_ref()
         .map(|jwt| jwt.audience.clone())
         .unwrap_or("".to_string());
+
+    let enforce_on_all_consumptions_apis = jwt_config
+        .as_ref()
+        .map(|jwt| jwt.enforce_on_all_consumptions_apis.to_string())
+        .unwrap_or("false".to_string());
 
     let args = vec![
         consumption_path.to_str().unwrap().to_string(),
@@ -38,6 +45,7 @@ pub fn run(
         jwt_secret,
         jwt_issuer,
         jwt_audience,
+        enforce_on_all_consumptions_apis,
     ];
 
     let mut aggregation_process =

--- a/apps/framework-cli/src/framework/python/consumption.rs
+++ b/apps/framework-cli/src/framework/python/consumption.rs
@@ -5,13 +5,28 @@ use tokio::process::Child;
 
 use crate::infrastructure::olap::clickhouse::config::ClickHouseConfig;
 use crate::infrastructure::processes::consumption_registry::ConsumptionError;
+use crate::project::JwtConfig;
 
 use super::executor;
 
 pub fn run(
     clickhouse_config: ClickHouseConfig,
+    jwt_config: Option<JwtConfig>,
     consumption_path: &Path,
 ) -> Result<Child, ConsumptionError> {
+    let jwt_secret = jwt_config
+        .as_ref()
+        .map(|jwt| jwt.secret.clone())
+        .unwrap_or("".to_string());
+    let jwt_issuer = jwt_config
+        .as_ref()
+        .map(|jwt| jwt.issuer.clone())
+        .unwrap_or("".to_string());
+    let jwt_audience = jwt_config
+        .as_ref()
+        .map(|jwt| jwt.audience.clone())
+        .unwrap_or("".to_string());
+
     let args = vec![
         consumption_path.to_str().unwrap().to_string(),
         clickhouse_config.db_name,
@@ -20,6 +35,9 @@ pub fn run(
         clickhouse_config.user,
         clickhouse_config.password,
         clickhouse_config.use_ssl.to_string(),
+        jwt_secret,
+        jwt_issuer,
+        jwt_audience,
     ];
 
     let mut aggregation_process =

--- a/apps/framework-cli/src/framework/python/scripts/consumption_runner.py
+++ b/apps/framework-cli/src/framework/python/scripts/consumption_runner.py
@@ -12,6 +12,10 @@ import os
 import sys
 import json
 
+import jwt
+from jwt import InvalidTokenError
+from typing import Optional, Dict, Any
+
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 
@@ -28,6 +32,9 @@ parser.add_argument('clickhouse_username', type=str,
 parser.add_argument('clickhouse_password', type=str,
                     help='Clickhouse password')
 parser.add_argument('clickhouse_use_ssl', type=str, help='Clickhouse use SSL')
+parser.add_argument('jwt_secret', type=str, help='JWT secret')
+parser.add_argument('jwt_issuer', type=str, help='JWT issuer')
+parser.add_argument('jwt_audience', type=str, help='JWT audience')
 
 
 args = parser.parse_args()
@@ -39,6 +46,10 @@ db = args.clickhouse_db
 user = args.clickhouse_username
 password = args.clickhouse_password
 consumption_dir_path = args.consumption_dir_path
+
+jwt_secret = args.jwt_secret
+jwt_issuer = args.jwt_issuer
+jwt_audience = args.jwt_audience
 
 sys.path.append(consumption_dir_path)
 
@@ -87,6 +98,13 @@ class MooseClient:
 
         return list(val.named_results())
 
+def verify_jwt(token: str) -> Optional[Dict[str, Any]]:
+    try:
+        payload = jwt.decode(token, jwt_secret, algorithms=["RS256"], audience=jwt_audience, issuer=jwt_issuer)
+        return payload
+    except InvalidTokenError as e:
+        print("JWT verification failed:", str(e))
+        return None
 
 def handler_with_client(ch_client):
     class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -97,10 +115,18 @@ def handler_with_client(ch_client):
                 module = import_module(module_name)
                 # get the flow definition
                 print(module_name)
+
+                jwt_payload: Optional[Dict[str, Any]] = None
+                auth_header = self.headers.get('Authorization')
+                if auth_header:
+                    # Bearer <token>
+                    token = auth_header.split(" ")[1] if " " in auth_header else None
+                    if token:
+                        jwt_payload = verify_jwt(token)
                 
                 query_params = parse_qs(parsed_path.query)
 
-                response = module.run(ch_client, query_params)
+                response = module.run(ch_client, query_params, jwt_payload)
                 response_message = bytes(json.dumps(response, cls=EnhancedJSONEncoder), 'utf-8')
                 self.send_response(200)
                 self.end_headers()

--- a/apps/framework-cli/src/framework/python/scripts/consumption_runner.py
+++ b/apps/framework-cli/src/framework/python/scripts/consumption_runner.py
@@ -104,7 +104,7 @@ def verify_jwt(token: str) -> Optional[Dict[str, Any]]:
     try:
         payload = jwt.decode(token, jwt_secret, algorithms=["RS256"], audience=jwt_audience, issuer=jwt_issuer)
         return payload
-    except InvalidTokenError as e:
+    except Exception as e:
         print("JWT verification failed:", str(e))
         return None
 

--- a/apps/framework-cli/src/infrastructure/processes/consumption_registry.rs
+++ b/apps/framework-cli/src/infrastructure/processes/consumption_registry.rs
@@ -51,9 +51,11 @@ impl ConsumptionProcessRegistry {
         info!("Starting consumption API...");
 
         let child = match self.language {
-            SupportedLanguages::Python => {
-                python::consumption::run(self.clickhouse_config.clone(), &self.dir)
-            }
+            SupportedLanguages::Python => python::consumption::run(
+                self.clickhouse_config.clone(),
+                self.jwt_config.clone(),
+                &self.dir,
+            ),
             SupportedLanguages::Typescript => typescript::consumption::run(
                 self.clickhouse_config.clone(),
                 self.jwt_config.clone(),

--- a/packages/py-moose-lib/moose_lib/main.py
+++ b/packages/py-moose-lib/moose_lib/main.py
@@ -2,7 +2,7 @@ from clickhouse_connect.driver.client import Client
 from dataclasses import dataclass, asdict
 from enum import Enum
 from string import Formatter
-from typing import Callable, Dict, Generic, Optional, TypeVar, Union, Any, overload
+from typing import Any, Callable, Dict, Generic, Optional, TypeVar, Union, overload
 import sys
 import os
 import json
@@ -88,7 +88,7 @@ def moose_data_model(arg: Any = None) -> Any:
 JWTPayload = Dict[str, Any]
 
 @dataclass
-class QueryResult:
+class ConsumptionApiResult:
     status: int
     body: Any
 

--- a/packages/py-moose-lib/moose_lib/main.py
+++ b/packages/py-moose-lib/moose_lib/main.py
@@ -87,6 +87,11 @@ def moose_data_model(arg: Any = None) -> Any:
 
 JWTPayload = Dict[str, Any]
 
+@dataclass
+class QueryResult:
+    status: int
+    body: Any
+
 class MooseClient:
     def __init__(self, ch_client: Client):
         self.ch_client = ch_client

--- a/packages/py-moose-lib/moose_lib/main.py
+++ b/packages/py-moose-lib/moose_lib/main.py
@@ -2,7 +2,7 @@ from clickhouse_connect.driver.client import Client
 from dataclasses import dataclass, asdict
 from enum import Enum
 from string import Formatter
-from typing import Callable, Generic, Optional, TypeVar, Union, overload, Any
+from typing import Callable, Dict, Generic, Optional, TypeVar, Union, Any, overload
 import sys
 import os
 import json
@@ -84,6 +84,8 @@ def moose_data_model(arg: Any = None) -> Any:
         return moose_data_model(None)(arg)
     return decorator
 
+
+JWTPayload = Dict[str, Any]
 
 class MooseClient:
     def __init__(self, ch_client: Client):

--- a/packages/py-moose-lib/setup.py
+++ b/packages/py-moose-lib/setup.py
@@ -12,5 +12,7 @@ setup(
     name='moose_lib',
     version=version,
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        'pyjwt[crypto]==2.9.0',
+    ],
 )

--- a/packages/ts-moose-lib/package.json
+++ b/packages/ts-moose-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@514labs/moose-lib",
-  "version": "0.0.2-rc",
+  "version": "0.0.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/ts-moose-lib/package.json
+++ b/packages/ts-moose-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@514labs/moose-lib",
-  "version": "0.0.2",
+  "version": "0.0.2-rc",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Example:

```
from moose_lib import cli_log, CliLogData, ConsumptionApiResult, JWTPayload, MooseClient, ConsumptionApiResult
from typing import Optional, Any

# curl -X GET -i "http://localhost:4000/consumption/userActivity?limit=1" -H "Authorization: Bearer <token>"

def run(client: MooseClient, params: Any, jwt: Optional[JWTPayload]):
    # Do something with the JWT payload
    cli_log(CliLogData(action="UserActivity", message=f"JWT payload: {jwt}", message_type="Info"))    
    
    limit = int(params.get('limit', [10])[0])

    # Can also just return the query result directly
    query_result = client.query(
        '''SELECT *
        FROM UserActivity_0_0
        LIMIT {limit}''',
        {
            "limit": limit
        }
    )
    
    return ConsumptionApiResult(status=200, body=query_result)
```