### PR TITLE
Allow RedisClient to update the CONTEXT

### DIFF
--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -57,6 +57,7 @@ pub const VSCODE_EXT_FILE: &str = "extensions.json";
 pub const VSCODE_SETTINGS_FILE: &str = "settings.json";
 
 pub const CTX_SESSION_ID: &str = "session_id";
+pub const CTX_IS_LEADER: &str = "is_leader";
 
 pub const PYTHON_FILE_EXTENSION: &str = "py";
 pub const TYPESCRIPT_FILE_EXTENSION: &str = "ts";


### PR DESCRIPTION
Allow RedisClient to update the CONTEXT when a moose instance becomes the leader or loses leadership

This will allow other application areas to determine whether they are the leader.