### PR TITLE
Moose cron fixes

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -308,12 +308,12 @@ async fn manage_leadership_lock(
             // We don't have the lock, try to acquire it
             if redis_client.attempt_lock("leadership").await? {
                 info!("Obtained leadership lock, performing leadership tasks");
-                // Call leadership_tasks immediately when the lock is first acquired
-                if let Err(e) = leadership_tasks(project.clone()).await {
-                    error!("Error executing leadership tasks: {}", e);
-                }
-                // Continue to spawn the task for periodic execution
-                tokio::spawn(leadership_tasks(project.clone()));
+                let project_clone = project.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = leadership_tasks(project_clone).await {
+                        error!("Error executing leadership tasks: {}", e);
+                    }
+                });
             } else {
                 debug!("Failed to obtain leadership lock");
             }

--- a/apps/framework-cli/src/infrastructure/processes/cron_registry.rs
+++ b/apps/framework-cli/src/infrastructure/processes/cron_registry.rs
@@ -1,4 +1,5 @@
 use crate::project::Project;
+use crate::utilities::constants::TSCONFIG_JSON;
 use anyhow::{anyhow, Result};
 use log::{error, info};
 use reqwest;
@@ -109,8 +110,11 @@ impl CronRegistry {
                                 path,
                                 project_path_clone.to_str().unwrap()
                             );
+                            let ts_script_path =
+                                project_path_clone.join(script_path.as_ref().unwrap());
                             Command::new("moose-exec")
-                                .arg(path)
+                                .arg(ts_script_path.to_str().unwrap())
+                                .env("TS_NODE_PROJECT", project_path_clone.join(TSCONFIG_JSON))
                                 .env("PATH", bin_path)
                                 .output()
                         }

--- a/packages/ts-moose-lib/src/moose-exec.ts
+++ b/packages/ts-moose-lib/src/moose-exec.ts
@@ -2,44 +2,25 @@
 
 import { register } from "ts-node";
 
-import fs from "fs";
-import path from "path";
-import * as vm from "vm";
-
 // Register ts-node to interpret TypeScript code
 register({
   esm: true,
-  experimentalTsImportSpecifiers: true,
+  experimentalSpecifierResolution: "node",
 });
 
 // Get the script path from the command line arguments
-const scriptPath = process.argv[2];
-
+let scriptPath = process.argv[2];
 if (!scriptPath) {
-  console.error("No script path provided.");
+  console.error("moose-exec: No script path provided.");
   process.exit(1);
 }
 
-// Read the TypeScript file
-const tsCode = fs.readFileSync(scriptPath, "utf-8");
+scriptPath = scriptPath.substring(0, scriptPath.length - 3);
 
-// Compile and execute the TypeScript code
-const script = new vm.Script(tsCode, {
-  filename: path.basename(scriptPath),
-});
-
-const context = vm.createContext({
-  require,
-  module,
-  __filename: scriptPath,
-  __dirname: path.dirname(scriptPath),
-  console,
-  process,
-  Buffer,
-  setTimeout,
-  setInterval,
-  clearTimeout,
-  clearInterval,
-});
-
-script.runInContext(context);
+// Use dynamic import to load and execute the TypeScript file
+try {
+  require(scriptPath);
+} catch (e) {
+  console.error("moose-exec: Error executing the script:", e);
+  process.exit(1);
+}


### PR DESCRIPTION
Fixes:
* Fix for moose-exec and moose cron path setup for typescript execution
* Fix for moose cron duplicate cron registration during startup
* Defensive programming in cron_registry.rs to avoid duplicate jobs.
