### PR TITLE
Multi-moose data migration increment

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -375,6 +375,7 @@ pub async fn start_development_mode(
             api_changes_channel,
             metrics.clone(),
             &mut client,
+            &redis_client,
         )
         .await?;
         // TODO - need to add a lock on the table to prevent concurrent updates as migrations are going through.
@@ -580,6 +581,7 @@ pub async fn start_production_mode(
             api_changes_channel,
             metrics.clone(),
             &mut client,
+            &redis_client,
         )
         .await?;
         // TODO - need to add a lock on the table to prevent concurrent updates as migrations are going through.

--- a/apps/framework-cli/src/framework/core/execute.rs
+++ b/apps/framework-cli/src/framework/core/execute.rs
@@ -70,20 +70,20 @@ pub async fn execute_initial_infra_change(
     );
     let mut process_registries = ProcessRegistries::new(project);
 
-    processes::execute_changes(
-        &mut syncing_processes_registry,
-        &mut process_registries,
-        &plan.target_infra_map.init_processes(),
-        metrics,
-    )
-    .await?;
-
     // Check if this process instance has the "leadership" lock
     if redis_client
         .has_lock("leadership")
         .await
         .map_err(ExecutionError::LeadershipCheckFailed)?
     {
+        processes::execute_changes(
+            &mut syncing_processes_registry,
+            &mut process_registries,
+            &plan.target_infra_map.init_processes(),
+            metrics,
+        )
+        .await?;
+
         // Execute migration changes only if we have the leadership lock
         migration::execute_changes(project, &plan.changes.initial_data_loads, clickhouse_client)
             .await


### PR DESCRIPTION
This PR explores using the Redis-based leadership lock to ensure that only one moose instance in a multi-moose cluster can execute an initial migration. The `execute_initial_infra_change` seems like a good place to explore this approach.

However, it seems that the entire concept of how "plans" are handled needs to be considered in the multi-moose scenario. So, in this regard, this initial PR is arguably incomplete. I wanted to float this by you guys to get your take on the general approach/direction.
