### PR TITLE
Attempt to use the docker container ID

### DIFF
--- a/apps/framework-cli/src/infrastructure/redis/redis_client.rs
+++ b/apps/framework-cli/src/infrastructure/redis/redis_client.rs
@@ -90,7 +90,7 @@ impl RedisClient {
             .await
             .context("Failed to establish Redis pub/sub connection")?;
 
-        let instance_id = Uuid::new_v4().to_string();
+        let instance_id = std::env::var("HOSTNAME").unwrap_or_else(|_| Uuid::new_v4().to_string());
 
         info!(
             "Initializing Redis client for {} with instance ID: {}",


### PR DESCRIPTION
Docker containers include a HOSTNAME environment variable that contains the short ID of the docker container.  This PR introduces a one-line change:

```rust
let instance_id = std::env::var("HOSTNAME").unwrap_or_else(|_| Uuid::new_v4().to_string());
```

which will use the HOSTNAME if present; else, default to a UUID.

The reason for using this approach rather than our existing config crate and moose.config.toml is because we expect moose environment variables to be prefixed with `MOOSE_` and the docker HOSTNAME environment variable, if present, will not have that prefix.

The usefulness of this approach is that we'll be able to tie moose usage of Redis keys to exact containers. 