### PR TITLE
Bug fix for duplicate service_name entries

### DIFF
--- a/apps/framework-cli/src/infrastructure/redis/redis_client.rs
+++ b/apps/framework-cli/src/infrastructure/redis/redis_client.rs
@@ -164,7 +164,7 @@ impl RedisClient {
     }
 
     pub async fn register_lock(&mut self, name: &str, ttl: i64) -> Result<()> {
-        let lock_key = self.service_prefix(&[&self.service_name, "lock"]);
+        let lock_key = self.service_prefix(&["lock"]);
         let lock = RedisLock { key: lock_key, ttl };
         self.locks.insert(name.to_string(), lock);
         Ok(())


### PR DESCRIPTION
This PR fixes a bug that is causing the service_name to be duplicated in the Redis resource lock key.