### PR TITLE
feat: add the ability to leverage clickhouse deduplicating merge tree to remove duplicates

### DIFF
--- a/apps/framework-cli/src/cli/display.rs
+++ b/apps/framework-cli/src/cli/display.rs
@@ -308,11 +308,18 @@ pub fn show_changes(infra_plan: &InfraPlan) {
                 name,
                 column_changes,
                 order_by_change,
+                before,
+                after,
             }) => {
-                infra_updated(&format!(
-                    "Table {} with colume changes: {:?} and order by changes: {:?}",
-                    name, column_changes, order_by_change
-                ));
+                if after.deduplicate != before.deduplicate {
+                    infra_removed(&before.expanded_display());
+                    infra_added(&after.expanded_display());
+                } else {
+                    infra_updated(&format!(
+                        "Table {} with colume changes: {:?} and order by changes: {:?}",
+                        name, column_changes, order_by_change
+                    ));
+                }
             }
             OlapChange::View(Change::Added(infra)) => {
                 infra_added(&infra.expanded_display());

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -377,7 +377,7 @@ async fn watch(
                             info!("Plan Changes: {:?}", plan_result.changes);
 
                             display::show_changes(&plan_result);
-                            framework::core::execute::execute_online_change(
+                            match framework::core::execute::execute_online_change(
                                 &project,
                                 &plan_result,
                                 route_update_channel.clone(),
@@ -385,28 +385,39 @@ async fn watch(
                                 project_registries,
                                 metrics.clone(),
                             )
-                            .await?;
+                            .await
+                            {
+                                Ok(_) => {
+                                    store_infrastructure_map(
+                                        &mut clickhouse_client_v2,
+                                        &project.clickhouse_config,
+                                        &plan_result.target_infra_map,
+                                    )
+                                    .await?;
 
-                            store_infrastructure_map(
-                                &mut clickhouse_client_v2,
-                                &project.clickhouse_config,
-                                &plan_result.target_infra_map,
-                            )
-                            .await?;
+                                    plan_result
+                                        .target_infra_map
+                                        .store_in_redis(&*redis_client.lock().await)
+                                        .await?;
 
-                            plan_result
-                                .target_infra_map
-                                .store_in_redis(&*redis_client.lock().await)
-                                .await?;
-
-                            let mut infra_ptr = infrastructure_map.write().await;
-                            *infra_ptr = plan_result.target_infra_map
+                                    let mut infra_ptr = infrastructure_map.write().await;
+                                    *infra_ptr = plan_result.target_infra_map
+                                }
+                                Err(e) => {
+                                    show_message!(MessageType::Error, {
+                                        Message {
+                                            action: "\nFailed".to_string(),
+                                            details: format!("Executing changes to the infrastructure failed:\n {}", e),
+                                        }
+                                    });
+                                }
+                            }
                         }
                         Err(e) => {
                             show_message!(MessageType::Error, {
                                 Message {
                                     action: "\nFailed".to_string(),
-                                    details: format!("\n {}", e),
+                                    details: format!("Planning changes to the infrastructure failed:\n {}", e),
                                 }
                             });
                         }

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -404,20 +404,22 @@ async fn watch(
                                     *infra_ptr = plan_result.target_infra_map
                                 }
                                 Err(e) => {
+                                    let error: anyhow::Error = e.into();
                                     show_message!(MessageType::Error, {
                                         Message {
                                             action: "\nFailed".to_string(),
-                                            details: format!("Executing changes to the infrastructure failed:\n {}", e),
+                                            details: format!("Executing changes to the infrastructure failed:\n{:?}", error) 
                                         }
                                     });
                                 }
                             }
                         }
                         Err(e) => {
+                            let error: anyhow::Error = e.into();
                             show_message!(MessageType::Error, {
                                 Message {
                                     action: "\nFailed".to_string(),
-                                    details: format!("Planning changes to the infrastructure failed:\n {}", e),
+                                    details: format!("Planning changes to the infrastructure failed:\n{:?}", error),
                                 }
                             });
                         }

--- a/apps/framework-cli/src/framework/core/infrastructure/table.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/table.rs
@@ -15,6 +15,8 @@ pub struct Table {
     pub name: String,
     pub columns: Vec<Column>,
     pub order_by: Vec<String>,
+    #[serde(default)]
+    pub deduplicate: bool,
 
     pub version: String,
     pub source_primitive: PrimitiveSignature,
@@ -29,7 +31,7 @@ impl Table {
 
     pub fn expanded_display(&self) -> String {
         format!(
-            "Table: {} Version {} - {} - {}",
+            "Table: {} Version {} - {} - {} - deduplicate: {}",
             self.name,
             self.version,
             self.columns
@@ -37,7 +39,8 @@ impl Table {
                 .map(|c| format!("{}: {}", c.name, c.data_type))
                 .collect::<Vec<String>>()
                 .join(", "),
-            self.order_by.join(",")
+            self.order_by.join(","),
+            self.deduplicate
         )
     }
 

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -78,6 +78,8 @@ pub enum TableChange {
         name: String,
         column_changes: Vec<ColumnChange>,
         order_by_change: OrderByChange,
+        before: Table,
+        after: Table,
     },
 }
 
@@ -466,6 +468,8 @@ impl InfrastructureMap {
                                 before: table.order_by.clone(),
                                 after: target_table.order_by.clone(),
                             },
+                            before: table.clone(),
+                            after: target_table.clone(),
                         }));
                 }
             } else {
@@ -986,6 +990,7 @@ mod tests {
     fn test_compute_table_diff() {
         let before = Table {
             name: "test_table".to_string(),
+            deduplicate: false,
             columns: vec![
                 Column {
                     name: "id".to_string(),
@@ -1022,6 +1027,7 @@ mod tests {
 
         let after = Table {
             name: "test_table".to_string(),
+            deduplicate: false,
             columns: vec![
                 Column {
                     name: "id".to_string(),

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -71,6 +71,7 @@ pub struct OrderByChange {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum TableChange {
     Added(Table),
     Removed(Table),
@@ -100,6 +101,7 @@ pub enum InfraChange {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum OlapChange {
     Table(TableChange),
     View(Change<View>),

--- a/apps/framework-cli/src/framework/data_model/config.rs
+++ b/apps/framework-cli/src/framework/data_model/config.rs
@@ -1,13 +1,12 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{absolute, Path};
+use std::path::Path;
 
+use crate::framework::python::datamodel_config::execute_python_model_file_for_config;
 use crate::framework::typescript::export_collectors::get_data_model_configs;
 use log::info;
 use serde::Deserialize;
 use serde::Serialize;
 use std::ffi::OsStr;
-
-use crate::framework::python::executor::run_python_file;
 
 pub type ConfigIdentifier = String;
 
@@ -38,6 +37,8 @@ pub struct StorageConfig {
     pub enabled: bool,
     #[serde(default)]
     pub order_by_fields: Vec<String>,
+    #[serde(default)]
+    pub deduplicate: bool,
 }
 const fn _true() -> bool {
     true
@@ -48,6 +49,7 @@ impl Default for StorageConfig {
         Self {
             enabled: true,
             order_by_fields: vec![],
+            deduplicate: false,
         }
     }
 }
@@ -67,49 +69,6 @@ pub enum ModelConfigurationError {
     TypescriptRunner(#[from] crate::framework::typescript::export_collectors::ExportCollectorError),
     #[error("Failed to get the Data Model configuration with Python\n{0}")]
     PythonRunner(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default, Hash)]
-pub struct PythonDataModelConfig {
-    #[serde(default)]
-    pub class_name: String,
-    #[serde(default)]
-    pub config: DataModelConfig,
-}
-
-async fn execute_python_model_file_for_config(
-    path: &Path,
-) -> Result<HashMap<ConfigIdentifier, DataModelConfig>, ModelConfigurationError> {
-    let abs_path = path.canonicalize().or_else(|_| absolute(path));
-    let path_str = abs_path.as_deref().unwrap_or(path).to_string_lossy();
-    let process = run_python_file(path, &[("MOOSE_PYTHON_DM_DUMP", &*path_str)])
-        .await
-        .map_err(|e| ModelConfigurationError::PythonRunner(e.to_string()))?;
-
-    let output = process
-        .wait_with_output()
-        .await
-        .map_err(|e| ModelConfigurationError::PythonRunner(e.to_string()))?;
-
-    if !output.status.success() {
-        return Err(ModelConfigurationError::PythonRunner(
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        ));
-    }
-
-    let raw_string_stdout = String::from_utf8_lossy(&output.stdout);
-
-    let configs: HashMap<ConfigIdentifier, DataModelConfig> = raw_string_stdout
-        .split("___DATAMODELCONFIG___")
-        .filter_map(|entry| {
-            let config = serde_json::from_str::<PythonDataModelConfig>(entry).ok()?;
-            Some((config.class_name, config.config))
-        })
-        .collect();
-
-    info!("Data Model configuration for {:?}: {:?}", path, configs);
-
-    Ok(configs)
 }
 
 pub async fn get(

--- a/apps/framework-cli/src/framework/data_model/model.rs
+++ b/apps/framework-cli/src/framework/data_model/model.rs
@@ -30,6 +30,7 @@ impl DataModel {
             name: format!("{}_{}", self.name, self.version.replace('.', "_")),
             columns: self.columns.clone(),
             order_by: self.config.storage.order_by_fields.clone(),
+            deduplicate: self.config.storage.deduplicate,
             version: self.version.clone(),
             source_primitive: PrimitiveSignature {
                 name: self.name.clone(),

--- a/apps/framework-cli/src/framework/python.rs
+++ b/apps/framework-cli/src/framework/python.rs
@@ -1,6 +1,7 @@
 pub mod aggregation;
 pub mod checker;
 pub mod consumption;
+pub mod datamodel_config;
 pub mod executor;
 pub mod parser;
 pub mod streaming;

--- a/apps/framework-cli/src/framework/python/datamodel_config.rs
+++ b/apps/framework-cli/src/framework/python/datamodel_config.rs
@@ -1,0 +1,55 @@
+use log::info;
+use serde::Deserialize;
+use serde::Serialize;
+use std::{
+    collections::HashMap,
+    path::{absolute, Path},
+};
+
+use crate::framework::{
+    data_model::config::{ConfigIdentifier, DataModelConfig, ModelConfigurationError},
+    python::executor::run_python_file,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default, Hash)]
+pub struct PythonDataModelConfig {
+    #[serde(default)]
+    pub class_name: String,
+    #[serde(default)]
+    pub config: DataModelConfig,
+}
+
+pub async fn execute_python_model_file_for_config(
+    path: &Path,
+) -> Result<HashMap<ConfigIdentifier, DataModelConfig>, ModelConfigurationError> {
+    let abs_path = path.canonicalize().or_else(|_| absolute(path));
+    let path_str = abs_path.as_deref().unwrap_or(path).to_string_lossy();
+    let process = run_python_file(path, &[("MOOSE_PYTHON_DM_DUMP", &*path_str)])
+        .await
+        .map_err(|e| ModelConfigurationError::PythonRunner(e.to_string()))?;
+
+    let output = process
+        .wait_with_output()
+        .await
+        .map_err(|e| ModelConfigurationError::PythonRunner(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(ModelConfigurationError::PythonRunner(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+
+    let raw_string_stdout = String::from_utf8_lossy(&output.stdout);
+
+    let configs: HashMap<ConfigIdentifier, DataModelConfig> = raw_string_stdout
+        .split("___DATAMODELCONFIG___")
+        .filter_map(|entry| {
+            let config = serde_json::from_str::<PythonDataModelConfig>(entry).ok()?;
+            Some((config.class_name, config.config))
+        })
+        .collect();
+
+    info!("Data Model configuration for {:?}: {:?}", path, configs);
+
+    Ok(configs)
+}

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/errors.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/errors.rs
@@ -6,5 +6,9 @@ pub enum ClickhouseError {
     UnsupportedDataType {
         type_name: String,
     },
+    #[error("Clickhouse - Invalid parameters: {message}")]
+    InvalidParameters {
+        message: String,
+    },
     QueryRender(#[from] handlebars::RenderError),
 }

--- a/packages/py-moose-lib/moose_lib/main.py
+++ b/packages/py-moose-lib/moose_lib/main.py
@@ -35,6 +35,7 @@ class IngestionConfig:
 class StorageConfig:
     enabled: Optional[bool] = None
     order_by_fields: Optional[list[str]] = None
+    deduplicate: Optional[bool] = None
 
 
 @dataclass

--- a/packages/ts-moose-lib/src/index.ts
+++ b/packages/ts-moose-lib/src/index.ts
@@ -29,6 +29,7 @@ export type DataModelConfig<T> = Partial<{
   storage: {
     enabled?: boolean;
     order_by_fields?: (keyof T)[];
+    deduplicate?: boolean;
   };
 }>;
 


### PR DESCRIPTION
* Adds the 'deduplicate' field in the data model storage configuration
* Handle errors during watch to not crash
* Move Python data config loading to the python module
* Added some create table tests