### PR TITLE
stop overriding clickhouse version

### DIFF
--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -169,7 +169,6 @@ pub fn start_containers(project: &Project) -> anyhow::Result<()> {
             "CLICKHOUSE_HOST_PORT",
             project.clickhouse_config.host_port.to_string(),
         )
-        .env("CLICKHOUSE_VERSION", "24.1.3") // https://github.com/ClickHouse/ClickHouse/issues/60020
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;


### PR DESCRIPTION
`docker pull docker.io/clickhouse/clickhouse-server:latest` to force an update