### PR TITLE
global variable to pause kafka clickhouse sync

### DIFF
--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -359,7 +359,8 @@ async fn watch(
         sleep(Duration::from_secs(1)).await;
         let bucketed_events = receiver_ack.send_replace(EventBuckets::default());
         rx.mark_unchanged();
-        // so that updates done between receiver_ack.send_replace and rx.mark_unchanged is not lost
+        // so that updates done between receiver_ack.send_replace and rx.mark_unchanged
+        // can be picked up the next rx.changed call
         if !rx.borrow().is_empty() {
             rx.mark_changed();
         }

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
@@ -3,6 +3,7 @@ use crate::infrastructure::olap::clickhouse::model::ClickHouseRecord;
 use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
+use crate::infrastructure::processes::kafka_clickhouse_sync;
 use log::{debug, error};
 use rdkafka::error::KafkaError;
 use std::sync::Arc;
@@ -102,8 +103,13 @@ impl<C: ClickHouseClientTrait + 'static> Inserter<C> {
         commit_callback: OffsetCommitCallback,
     ) {
         let mut interval = time::interval(Duration::from_secs(self.flush_interval));
+        let mut pause_receiver = kafka_clickhouse_sync::clickhouse_writing_pause_listener();
 
         loop {
+            if *pause_receiver.borrow() {
+                pause_receiver.changed().await.unwrap();
+                continue;
+            }
             interval.tick().await;
             let mut queue = self.queue.lock().await;
 

--- a/apps/framework-cli/src/infrastructure/redis/redis_client.rs
+++ b/apps/framework-cli/src/infrastructure/redis/redis_client.rs
@@ -247,7 +247,7 @@ impl RedisClient {
                 .await
                 .context("Failed to check lock")?;
 
-            Ok(value == Some(self.instance_id.clone()))
+            Ok(value.is_some_and(|id| id == self.instance_id))
         } else {
             Err(anyhow::anyhow!("Lock not registered"))
         }
@@ -393,7 +393,7 @@ impl RedisClient {
             .push(Arc::new(move |message: String| {
                 let callback = Arc::clone(&callback);
                 Box::pin(async move {
-                    (callback)(message);
+                    callback(message);
                 }) as Pin<Box<dyn Future<Output = ()> + Send>>
             }));
     }


### PR DESCRIPTION
next is somehow to make leader know all followers have stopped syncing and migration is now safe to perform

---

`iterate_subscriber` was a premature abstraction. `select` has to be used to jump out of the `recv` call in one but not the other.