### PR TITLE
wait for in-flight reqs to finish

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -999,15 +999,23 @@ impl Webserver {
                         with_spinner("Stopping containers", || {
                              let _ = docker::stop_containers(&project);
                         }, true);
+                    } else {
+                        log::info!("Received sigint, waiting for in-flight requests to complete");
+                        tokio::time::sleep(Duration::from_secs(30)).await;
                     }
+
                     std::process::exit(0);
                 }
                 _ = sigterm.recv() => {
                     if !project.is_production {
                         with_spinner("Stopping containers", || {
                             let _ = docker::stop_containers(&project);
-                       }, true);
+                        }, true);
+                    } else {
+                        log::info!("Received sigterm, waiting for in-flight requests to complete");
+                        tokio::time::sleep(Duration::from_secs(30)).await;
                     }
+
                     std::process::exit(0);
                 }
                 listener_result = listener.accept() => {


### PR DESCRIPTION
1. New pod starts up. Default RollingUpdate strategy allows it to co-exist with old pod
2. Health check for new pod succeeds
3. Traffic is routed to new pod
4. No new traffic is routed to old pod. Old pod gets a sigterm. 

Default `terminationGracePeriodSeconds` is 30 seconds. So we wait for in-flight reqs to finish instead of killing the server immediately.