### PR TITLE
fix: enable replacing merge tree to be setup on a brand new table

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
@@ -7,7 +7,7 @@ use log::{debug, info};
 use mapper::{std_column_to_clickhouse_column, std_table_to_clickhouse_table};
 use queries::{
     basic_field_type_to_string, create_table_query, create_view_query, drop_table_query,
-    drop_view_query, update_view_query, ClickhouseEngine,
+    drop_view_query, update_view_query,
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -60,8 +60,7 @@ pub async fn execute_changes(
                 log::info!("Creating table: {:?}", table.id());
 
                 let clickhouse_table = std_table_to_clickhouse_table(table)?;
-                let create_data_table_query =
-                    create_table_query(db_name, clickhouse_table, ClickhouseEngine::MergeTree)?;
+                let create_data_table_query = create_table_query(db_name, clickhouse_table)?;
                 run_query(&create_data_table_query, &configured_client).await?;
             }
             OlapChange::Table(TableChange::Removed(table)) => {
@@ -90,15 +89,7 @@ pub async fn execute_changes(
                     run_query(&drop_query, &configured_client).await?;
 
                     let clickhouse_table = std_table_to_clickhouse_table(after)?;
-                    let create_data_table_query = create_table_query(
-                        db_name,
-                        clickhouse_table,
-                        if after.deduplicate {
-                            ClickhouseEngine::ReplacingMergeTree
-                        } else {
-                            ClickhouseEngine::MergeTree
-                        },
-                    )?;
+                    let create_data_table_query = create_table_query(db_name, clickhouse_table)?;
                     run_query(&create_data_table_query, &configured_client).await?;
                 } else {
                     log::info!("Updating table: {:?}", name);

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mapper.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mapper.rs
@@ -6,6 +6,7 @@ use crate::infrastructure::olap::clickhouse::model::{
 
 use super::errors::ClickhouseError;
 use super::model::sanitize_column_name;
+use super::queries::ClickhouseEngine;
 
 pub fn std_column_to_clickhouse_column(
     column: Column,
@@ -81,10 +82,18 @@ pub fn std_columns_to_clickhouse_columns(
 
 pub fn std_table_to_clickhouse_table(table: &Table) -> Result<ClickHouseTable, ClickhouseError> {
     let columns = std_columns_to_clickhouse_columns(&table.columns)?;
+
+    let clickhouse_engine = if table.deduplicate {
+        ClickhouseEngine::ReplacingMergeTree
+    } else {
+        ClickhouseEngine::MergeTree
+    };
+
     Ok(ClickHouseTable {
         name: table.name.clone(),
         version: table.version.clone(),
         columns,
         order_by: table.order_by.clone(),
+        engine: clickhouse_engine,
     })
 }

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/model.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/model.rs
@@ -378,11 +378,12 @@ pub struct ClickHouseTable {
     pub version: Version,
     pub columns: Vec<ClickHouseColumn>,
     pub order_by: Vec<String>,
+    pub engine: ClickhouseEngine,
 }
 
 impl ClickHouseTable {
     pub fn create_data_table_query(&self, db_name: &str) -> Result<String, ClickhouseError> {
-        create_table_query(db_name, self.clone(), ClickhouseEngine::MergeTree)
+        create_table_query(db_name, self.clone())
     }
 
     pub fn drop_data_table_query(&self, db_name: &str) -> Result<String, ClickhouseError> {


### PR DESCRIPTION
For some reason I did not put in the implementation for creating a table with ReplacingMergeTree from the get go.
This fixes that issue