### PR TITLE
Update leadership lock handling

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -373,11 +373,14 @@ async fn manage_leadership_lock(
     if has_lock && is_new_acquisition {
         info!("<RedisClient> Obtained leadership lock, performing leadership tasks");
 
+        IS_RUNNING_LEADERSHIP_TASKS.store(true, Ordering::SeqCst);
+
         let project_clone = project.clone();
         let cron_registry: CronRegistry = cron_registry.clone();
         tokio::spawn(async move {
             if let Err(e) = leadership_tasks(project_clone, cron_registry).await {
                 error!("<RedisClient> Error executing leadership tasks: {}", e);
+                IS_RUNNING_LEADERSHIP_TASKS.store(false, Ordering::SeqCst);
             }
         });
 

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -492,14 +492,6 @@ pub async fn start_development_mode(
         .start(route_table, consumption_apis, infra_map, project, metrics)
         .await;
 
-    // Only stop CronRegistry if we're the leader
-    let has_lock = redis_client.lock().await.has_lock("leadership").await?;
-    if has_lock {
-        if let Err(e) = CronRegistry::new().await?.stop().await {
-            error!("Failed to stop CronRegistry: {}", e);
-        }
-    }
-
     {
         let mut redis_client = redis_client.lock().await;
         let _ = redis_client.stop_periodic_tasks();
@@ -585,14 +577,6 @@ pub async fn start_production_mode(
     web_server
         .start(route_table, consumption_apis, infra_map, project, metrics)
         .await;
-
-    // Only stop CronRegistry if we're the leader
-    let has_lock = redis_client.lock().await.has_lock("leadership").await?;
-    if has_lock {
-        if let Err(e) = CronRegistry::new().await?.stop().await {
-            error!("Failed to stop CronRegistry: {}", e);
-        }
-    }
 
     {
         let mut redis_client = redis_client.lock().await;

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -389,8 +389,7 @@ async fn manage_leadership_lock(
             );
         }
     } else if IS_RUNNING_LEADERSHIP_TASKS.load(Ordering::SeqCst) {
-        // Stop the CronRegistry first
-        if let Err(e) = CronRegistry::new().await?.stop().await {
+        if let Err(e) = cron_registry.stop().await {
             error!("<RedisClient> Failed to stop CronRegistry: {}", e);
         }
         // Then mark leadership tasks as not running

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -384,10 +384,8 @@ async fn manage_leadership_lock(
                 e
             );
         }
-    } else {
-        if IS_RUNNING_LEADERSHIP_TASKS.load(Ordering::SeqCst) {
-            IS_RUNNING_LEADERSHIP_TASKS.store(false, Ordering::SeqCst);
-        }
+    } else if IS_RUNNING_LEADERSHIP_TASKS.load(Ordering::SeqCst) {
+        IS_RUNNING_LEADERSHIP_TASKS.store(false, Ordering::SeqCst);
     }
     Ok(())
 }

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -378,10 +378,11 @@ async fn manage_leadership_lock(
         let project_clone = project.clone();
         let cron_registry: CronRegistry = cron_registry.clone();
         tokio::spawn(async move {
-            if let Err(e) = leadership_tasks(project_clone, cron_registry).await {
+            let result = leadership_tasks(project_clone, cron_registry).await;
+            if let Err(e) = result {
                 error!("<RedisClient> Error executing leadership tasks: {}", e);
-                IS_RUNNING_LEADERSHIP_TASKS.store(false, Ordering::SeqCst);
             }
+            IS_RUNNING_LEADERSHIP_TASKS.store(false, Ordering::SeqCst);
         });
 
         let mut client = redis_client.lock().await;


### PR DESCRIPTION
- Extend leadership lock interval
- If same instance of moose was the leader and lost leaderhip then if it renewal leadership it should not register cron jobs.