### PR TITLE
Update ingest-sdk.mdx

### DIFF
--- a/apps/framework-docs/src/pages/ingest-data/ingest-sdk.mdx
+++ b/apps/framework-docs/src/pages/ingest-data/ingest-sdk.mdx
@@ -21,12 +21,6 @@ moose-cli generate sdk [OPTIONS]
 
 #### Options
 
-**`-l, --language <LANGUAGE>`**
-
-- **Description:** Specify the language of the SDK to be generated.
-- **Default:** `ts`
-- **Possible Values:** `ts` (TypeScript), `python` (Python)
-
 **`-d, --destination <DESTINATION>`**
 
 - **Description:** Specify the directory where the SDK files should be written.


### PR DESCRIPTION
We don't support python SDK generation yet, at least per my test and @callicles's understanding.