### PR TITLE
feat: add version logging statement when moose prod starts

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -551,6 +551,8 @@ async fn top_command_handler(
         },
         Commands::Prod {} => {
             info!("Running prod command");
+            info!("Moose Version: {}", CLI_VERSION);
+
             let mut project = load_project()?;
 
             project.set_is_production_env(true);


### PR DESCRIPTION
This pull request includes a small change to the `apps/framework-cli/src/cli.rs` file. The change adds a log statement to display the Moose version when the `prod` command is executed.

* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dR554-R555): Added a log statement to display the Moose version in the `top_command_handler` function when the `prod` command is executed.