### PR TITLE
openapi + egress in redis inframap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "serde_yaml",
  "serial_test",
  "sha2",
  "spinners",
@@ -3159,6 +3160,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +3924,12 @@ dependencies = [
  "phf_codegen",
  "rand",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -100,6 +100,7 @@ opentelemetry-otlp = { version = "0.27.0", default-features = false, features = 
 ] }
 opentelemetry-http = { version = "0.27.0", features = ["reqwest"] }
 prometheus-client = "0.22.2"
+serde_yaml = "0.9.34"
 
 [dev-dependencies]
 clickhouse = { version = "0.11.5", features = ["uuid", "test-util"] }

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -54,6 +54,7 @@ use log::Level::{Debug, Trace};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::env::VarError;
+use std::fs;
 use std::future::Future;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
@@ -224,6 +225,7 @@ struct ManagementService<I: InfraMapProvider + Clone> {
     is_prod: bool,
     metrics: Arc<Metrics>,
     infra_map: I,
+    openapi_path: Option<PathBuf>,
 }
 
 impl Service<Request<Incoming>> for RouteService {
@@ -263,6 +265,7 @@ impl<I: InfraMapProvider + Clone + Send + 'static> Service<Request<Incoming>>
             self.metrics.clone(),
             // here we're either cloning the reference or the RwLock
             self.infra_map.clone(),
+            self.openapi_path.clone(),
             req,
         ))
     }
@@ -352,6 +355,39 @@ async fn metrics_route(metrics: Arc<Metrics>) -> Result<Response<Full<Bytes>>, h
         .unwrap();
 
     Ok(response)
+}
+
+async fn openapi_route(
+    is_prod: bool,
+    openapi_path: Option<PathBuf>,
+) -> Result<Response<Full<Bytes>>, hyper::http::Error> {
+    if is_prod {
+        return Ok(Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Full::new(Bytes::from(
+                "OpenAPI spec not available in production",
+            )))
+            .unwrap());
+    }
+
+    if let Some(path) = openapi_path {
+        match fs::read_to_string(path) {
+            Ok(contents) => Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/yaml")
+                .body(Full::new(Bytes::from(contents)))
+                .unwrap()),
+            Err(_) => Ok(Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Full::new(Bytes::from("Failed to read OpenAPI spec file")))
+                .unwrap()),
+        }
+    } else {
+        Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::new(Bytes::from("OpenAPI spec file not found")))
+            .unwrap())
+    }
 }
 
 fn bad_json_response(e: serde_json::Error) -> Response<Full<Bytes>> {
@@ -774,6 +810,7 @@ async fn management_router<I: InfraMapProvider>(
     is_prod: bool,
     metrics: Arc<Metrics>,
     infra_map: I,
+    openapi_path: Option<PathBuf>,
     req: Request<Incoming>,
 ) -> Result<Response<Full<Bytes>>, hyper::http::Error> {
     let level = if req.uri().path().ends_with(METRICS_LOGS_PATH) {
@@ -804,6 +841,7 @@ async fn management_router<I: InfraMapProvider>(
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(Full::new(Bytes::from(res)))
         }
+        (&hyper::Method::GET, "openapi.yaml") => openapi_route(is_prod, openapi_path).await,
         _ => route_not_found_response(),
     };
 
@@ -870,7 +908,7 @@ impl Webserver {
                                     },
                                 );
                             }
-                            APIType::EGRESS => {
+                            APIType::EGRESS { .. } => {
                                 consumption_apis
                                     .write()
                                     .await
@@ -884,7 +922,7 @@ impl Webserver {
                             APIType::INGRESS { .. } => {
                                 route_table.remove(&api_endpoint.path);
                             }
-                            APIType::EGRESS => {
+                            APIType::EGRESS { .. } => {
                                 consumption_apis
                                     .write()
                                     .await
@@ -911,7 +949,7 @@ impl Webserver {
                                     },
                                 );
                             }
-                            APIType::EGRESS => {
+                            APIType::EGRESS { .. } => {
                                 // Nothing to do, we don't need to update the route table
                             }
                         }
@@ -932,6 +970,7 @@ impl Webserver {
         infra_map: I,
         project: Arc<Project>,
         metrics: Arc<Metrics>,
+        openapi_path: Option<PathBuf>,
     ) {
         //! Starts the local webserver
         let socket = self.socket().await;
@@ -990,6 +1029,7 @@ impl Webserver {
             is_prod: project.is_production,
             metrics,
             infra_map,
+            openapi_path,
         };
 
         let graceful = GracefulShutdown::new();

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -89,11 +89,11 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{interval, Duration};
 
-use crate::framework::core::execute::execute_initial_infra_change;
-use crate::framework::core::plan::plan_changes;
-
+use crate::cli::routines::openapi::openapi;
 use crate::framework::controller::RouteMeta;
+use crate::framework::core::execute::execute_initial_infra_change;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
+use crate::framework::core::plan::plan_changes;
 use crate::infrastructure::olap::clickhouse_alt_client::{get_pool, store_infrastructure_map};
 use crate::infrastructure::processes::cron_registry::CronRegistry;
 use crate::infrastructure::processes::kafka_clickhouse_sync::clickhouse_writing_pause_button;
@@ -117,6 +117,7 @@ pub mod logs;
 pub mod ls;
 pub mod metrics_console;
 pub mod migrate;
+pub mod openapi;
 pub mod peek;
 pub mod ps;
 pub mod streaming;
@@ -473,6 +474,8 @@ pub async fn start_development_mode(
     )
     .await?;
 
+    let openapi_file = openapi(&project, &plan.target_infra_map).await?;
+
     plan.target_infra_map
         .store_in_redis(&*redis_client.lock().await)
         .await?;
@@ -493,7 +496,14 @@ pub async fn start_development_mode(
 
     info!("Starting web server...");
     web_server
-        .start(route_table, consumption_apis, infra_map, project, metrics)
+        .start(
+            route_table,
+            consumption_apis,
+            infra_map,
+            project,
+            metrics,
+            Some(openapi_file),
+        )
         .await;
 
     {
@@ -579,7 +589,14 @@ pub async fn start_production_mode(
     let infra_map: &'static InfrastructureMap = Box::leak(Box::new(plan.target_infra_map));
 
     web_server
-        .start(route_table, consumption_apis, infra_map, project, metrics)
+        .start(
+            route_table,
+            consumption_apis,
+            infra_map,
+            project,
+            metrics,
+            None,
+        )
         .await;
 
     {

--- a/apps/framework-cli/src/cli/routines/openapi.rs
+++ b/apps/framework-cli/src/cli/routines/openapi.rs
@@ -1,0 +1,308 @@
+use crate::framework::core::infrastructure::api_endpoint::APIType;
+use crate::framework::core::infrastructure::table::ColumnType;
+use crate::framework::core::infrastructure_map::InfrastructureMap;
+use crate::project::Project;
+use crate::utilities::constants::OPENAPI_FILE;
+
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use serde_yaml;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize)]
+struct OpenAPI {
+    openapi: String,
+    info: Info,
+    servers: Vec<Server>,
+    paths: HashMap<String, PathItem>,
+    components: Components,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Info {
+    title: String,
+    version: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Server {
+    url: String,
+    description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Parameter {
+    name: String,
+    #[serde(rename = "in")]
+    in_: String,
+    required: bool,
+    schema: ParameterSchema,
+    example: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ParameterSchema {
+    #[serde(rename = "type")]
+    schema_type: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PathItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post: Option<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    get: Option<Operation>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Operation {
+    summary: String,
+    parameters: Vec<Parameter>,
+    #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
+    request_body: Option<RequestBody>,
+    responses: HashMap<String, Response>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RequestBody {
+    content: HashMap<String, MediaType>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MediaType {
+    schema: Schema,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Schema {
+    #[serde(rename = "type")]
+    schema_type: String,
+    properties: HashMap<String, Property>,
+    required: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Property {
+    #[serde(rename = "type")]
+    property_type: String,
+    example: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Response {
+    description: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Components {
+    schemas: HashMap<String, Schema>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OpenAPIError {
+    #[error("Failed to save OpenAPI spec to file: {0}")]
+    Save(String),
+}
+
+pub async fn openapi(
+    project: &Arc<Project>,
+    infra_map: &InfrastructureMap,
+) -> Result<PathBuf, OpenAPIError> {
+    let openapi_spec = generate_openapi_spec(project, infra_map);
+    let openapi_file = project.internal_dir().unwrap().join(OPENAPI_FILE);
+    save_openapi_to_file(&openapi_spec, &openapi_file.to_string_lossy())
+        .map_err(|e| OpenAPIError::Save(e.to_string()))?;
+
+    Ok(openapi_file)
+}
+
+fn generate_openapi_spec(project: &Arc<Project>, infra_map: &InfrastructureMap) -> OpenAPI {
+    let mut paths = HashMap::new();
+    let mut schemas = HashMap::new();
+
+    for api_endpoint in infra_map.api_endpoints.values() {
+        match &api_endpoint.api_type {
+            APIType::INGRESS {
+                data_model: Some(data_model),
+                ..
+            } => {
+                let (properties, required) = data_model.columns.iter().fold(
+                    (HashMap::new(), Vec::new()),
+                    |(mut props, mut req), column| {
+                        let (property_type, example) = map_column_type(&column.data_type);
+                        props.insert(
+                            column.name.clone(),
+                            Property {
+                                property_type,
+                                example,
+                            },
+                        );
+                        if column.required {
+                            req.push(column.name.clone());
+                        }
+                        (props, req)
+                    },
+                );
+
+                let schema = Schema {
+                    schema_type: "object".to_string(),
+                    properties,
+                    required,
+                };
+                schemas.insert(data_model.name.clone(), schema.clone());
+
+                let path_item = PathItem {
+                    post: Some(Operation {
+                        summary: format!("Ingress endpoint for {}", api_endpoint.name),
+                        parameters: vec![],
+                        request_body: Some(RequestBody {
+                            content: {
+                                let mut content = HashMap::new();
+                                content
+                                    .insert("application/json".to_string(), MediaType { schema });
+                                content
+                            },
+                        }),
+                        responses: {
+                            let mut responses = HashMap::new();
+                            responses.insert(
+                                "200".to_string(),
+                                Response {
+                                    description: "Successful operation".to_string(),
+                                },
+                            );
+                            responses
+                        },
+                    }),
+                    get: None,
+                };
+
+                paths.insert(
+                    format!("/{}", api_endpoint.path.to_string_lossy()),
+                    path_item,
+                );
+            }
+            APIType::EGRESS { query_params } => {
+                let path_item = PathItem {
+                    post: None,
+                    get: Some(Operation {
+                        summary: format!("Egress endpoint for {}", api_endpoint.name),
+                        parameters: query_params
+                            .iter()
+                            .map(|param| {
+                                let (schema_type, example) = map_query_param_type(&param.data_type);
+                                Parameter {
+                                    name: param.name.clone(),
+                                    in_: "query".to_string(),
+                                    required: param.required,
+                                    schema: ParameterSchema { schema_type },
+                                    example,
+                                }
+                            })
+                            .collect(),
+                        request_body: None,
+                        responses: {
+                            let mut responses = HashMap::new();
+                            responses.insert(
+                                "200".to_string(),
+                                Response {
+                                    description: "Successful operation".to_string(),
+                                },
+                            );
+                            responses
+                        },
+                    }),
+                };
+
+                paths.insert(
+                    format!("/consumption/{}", api_endpoint.path.to_string_lossy()),
+                    path_item,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    OpenAPI {
+        openapi: "3.0.0".to_string(),
+        info: Info {
+            title: format!("{} API", project.name()),
+            version: project.cur_version().to_string(),
+        },
+        servers: vec![Server {
+            url: project.http_server_config.url(),
+            description: Some("Server URL".to_string()),
+        }],
+        paths,
+        components: Components { schemas },
+    }
+}
+
+fn map_column_type(column_type: &ColumnType) -> (String, Option<serde_json::Value>) {
+    match column_type {
+        ColumnType::Boolean => ("boolean".to_string(), Some(serde_json::Value::Bool(true))),
+        ColumnType::Int | ColumnType::BigInt => (
+            "integer".to_string(),
+            Some(serde_json::Value::Number(1.into())),
+        ),
+        ColumnType::Float | ColumnType::Decimal => (
+            "number".to_string(),
+            Some(serde_json::Value::Number(
+                serde_json::Number::from_f64(1.0).unwrap(),
+            )),
+        ),
+        ColumnType::DateTime => (
+            "string".to_string(),
+            Some(serde_json::Value::String(Local::now().to_rfc3339())),
+        ),
+        ColumnType::Array(_) => (
+            "array".to_string(),
+            Some(serde_json::Value::Array(vec![serde_json::Value::String(
+                "add array items here".to_string(),
+            )])),
+        ),
+        ColumnType::Nested(_) => (
+            "object".to_string(),
+            Some(serde_json::Value::Object(serde_json::Map::new())),
+        ),
+        _ => (
+            "string".to_string(),
+            Some(serde_json::Value::String("stringValue".to_string())),
+        ),
+    }
+}
+
+fn map_query_param_type(data_type: &ColumnType) -> (String, Option<serde_json::Value>) {
+    match data_type {
+        ColumnType::Boolean => ("boolean".to_string(), Some(serde_json::Value::Bool(true))),
+        ColumnType::Int | ColumnType::BigInt => (
+            "integer".to_string(),
+            Some(serde_json::Value::Number(1.into())),
+        ),
+        ColumnType::Float | ColumnType::Decimal => (
+            "number".to_string(),
+            Some(serde_json::Value::Number(
+                serde_json::Number::from_f64(1.0).unwrap(),
+            )),
+        ),
+        ColumnType::DateTime => (
+            "string".to_string(),
+            Some(serde_json::Value::String(Local::now().to_rfc3339())),
+        ),
+        _ => (
+            "string".to_string(),
+            Some(serde_json::Value::String("stringValue".to_string())),
+        ),
+    }
+}
+
+fn save_openapi_to_file(openapi_spec: &OpenAPI, file_path: &str) -> std::io::Result<()> {
+    let openapi_yaml = serde_yaml::to_string(openapi_spec).unwrap();
+    let mut file = File::create(file_path)?;
+    file.write_all(openapi_yaml.as_bytes())?;
+    Ok(())
+}

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -16,6 +16,7 @@ use crate::framework::core::infrastructure_map::{ApiChange, InfrastructureMap};
 
 use super::display::{self, with_spinner_async, Message, MessageType};
 
+use crate::cli::routines::openapi::openapi;
 use crate::infrastructure::olap::clickhouse_alt_client::{get_pool, store_infrastructure_map};
 use crate::infrastructure::processes::kafka_clickhouse_sync::SyncingProcessesRegistry;
 use crate::infrastructure::processes::process_registry::ProcessRegistries;
@@ -176,6 +177,9 @@ async fn watch(
                                     .target_infra_map
                                     .store_in_redis(&*redis_client.lock().await)
                                     .await?;
+
+                                let _openapi_file =
+                                    openapi(&project, &plan_result.target_infra_map).await?;
 
                                 let mut infra_ptr = infrastructure_map.write().await;
                                 *infra_ptr = plan_result.target_infra_map

--- a/apps/framework-cli/src/framework/consumption/model.rs
+++ b/apps/framework-cli/src/framework/consumption/model.rs
@@ -1,14 +1,27 @@
 use crate::framework::core::infrastructure::table::ColumnType;
+use crate::proto::infrastructure_map::ConsumptionQueryParam as ProtoConsumptionQueryParam;
 use hex::encode;
-use serde::Deserialize;
+use protobuf::MessageField;
+use serde::{Deserialize, Serialize};
 use sha2::{digest::Output, Sha256};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConsumptionQueryParam {
     pub name: String,
     pub data_type: ColumnType,
     pub required: bool,
+}
+
+impl ConsumptionQueryParam {
+    pub fn to_proto(&self) -> ProtoConsumptionQueryParam {
+        ProtoConsumptionQueryParam {
+            name: self.name.clone(),
+            data_type: MessageField::some(self.data_type.to_proto()),
+            required: self.required,
+            special_fields: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -245,7 +245,7 @@ impl InfrastructureMap {
                     ref mut target_topic,
                     ..
                 } => *target_topic = redpanda_config.prefix_with_namespace(target_topic),
-                APIType::EGRESS => {}
+                APIType::EGRESS { .. } => {}
             }
             self.api_endpoints.insert(api_endpoint.id(), api_endpoint);
         }

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -11,6 +11,7 @@ pub const TSCONFIG_JSON: &str = "tsconfig.json";
 pub const SETUP_PY: &str = "setup.py";
 pub const OLD_PROJECT_CONFIG_FILE: &str = "project.toml";
 pub const PROJECT_CONFIG_FILE: &str = "moose.config.toml";
+pub const OPENAPI_FILE: &str = "openapi.yaml";
 pub const PROJECT_NAME_ALLOW_PATTERN: &str = r"^[a-zA-Z0-9_-]+$";
 
 pub const CLI_CONFIG_FILE: &str = "config.toml";

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -46,7 +46,13 @@ message IngressDetails {
 }
 
 message EgressDetails {
-  // nothing right now
+  repeated ConsumptionQueryParam query_params = 1;
+}
+
+message ConsumptionQueryParam {
+  string name = 1;
+  ColumnType data_type = 2;
+  bool required = 3;
 }
 
 enum EndpointIngestionFormat {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8578,7 +8578,7 @@ snapshots:
       '@aws-sdk/client-sso-oidc': 3.574.0
       '@aws-sdk/client-sts': 3.574.0(@aws-sdk/client-sso-oidc@3.574.0)
       '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0)
+      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))
       '@aws-sdk/middleware-bucket-endpoint': 3.568.0
       '@aws-sdk/middleware-expect-continue': 3.572.0
       '@aws-sdk/middleware-flexible-checksums': 3.572.0
@@ -8639,7 +8639,7 @@ snapshots:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/client-sts': 3.574.0(@aws-sdk/client-sso-oidc@3.574.0)
       '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0)
+      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))
       '@aws-sdk/middleware-host-header': 3.567.0
       '@aws-sdk/middleware-logger': 3.568.0
       '@aws-sdk/middleware-recursion-detection': 3.567.0
@@ -8727,7 +8727,7 @@ snapshots:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/client-sso-oidc': 3.574.0
       '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0)
+      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))
       '@aws-sdk/middleware-host-header': 3.567.0
       '@aws-sdk/middleware-logger': 3.568.0
       '@aws-sdk/middleware-recursion-detection': 3.567.0
@@ -8796,13 +8796,13 @@ snapshots:
       '@smithy/util-stream': 2.2.0
       tslib: 2.6.2
 
-  '@aws-sdk/credential-provider-ini@3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0)':
+  '@aws-sdk/credential-provider-ini@3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))':
     dependencies:
       '@aws-sdk/client-sts': 3.574.0(@aws-sdk/client-sso-oidc@3.574.0)
       '@aws-sdk/credential-provider-env': 3.568.0
       '@aws-sdk/credential-provider-process': 3.572.0
       '@aws-sdk/credential-provider-sso': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)
-      '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.574.0)
+      '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))
       '@aws-sdk/types': 3.567.0
       '@smithy/credential-provider-imds': 2.3.0
       '@smithy/property-provider': 2.2.0
@@ -8813,14 +8813,14 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0)':
+  '@aws-sdk/credential-provider-node@3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.568.0
       '@aws-sdk/credential-provider-http': 3.568.0
-      '@aws-sdk/credential-provider-ini': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0)
+      '@aws-sdk/credential-provider-ini': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))
       '@aws-sdk/credential-provider-process': 3.572.0
       '@aws-sdk/credential-provider-sso': 3.572.0(@aws-sdk/client-sso-oidc@3.574.0)
-      '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.574.0)
+      '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))
       '@aws-sdk/types': 3.567.0
       '@smithy/credential-provider-imds': 2.3.0
       '@smithy/property-provider': 2.2.0
@@ -8853,7 +8853,7 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.568.0(@aws-sdk/client-sts@3.574.0)':
+  '@aws-sdk/credential-provider-web-identity@3.568.0(@aws-sdk/client-sts@3.574.0(@aws-sdk/client-sso-oidc@3.574.0))':
     dependencies:
       '@aws-sdk/client-sts': 3.574.0(@aws-sdk/client-sso-oidc@3.574.0)
       '@aws-sdk/types': 3.567.0


### PR DESCRIPTION
What's new since https://github.com/514-labs/moose/pull/1993:

- Updated moose proto to include consumption query params
- Updated openapi to just use the infra map that's already in memory rather than re-querying
- Tested with released moose-cli to create the infra map as-is, then restarted moose with this change to verify we can deserialize older infra map