### PR TITLE
fix: remove stop gap for compilation

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -225,8 +225,6 @@ jobs:
           target: ${{ matrix.build.TARGET }}
           args: --release --features rdkafka/cmake-build --locked --target ${{ matrix.build.TARGET }} --out dist
           sccache: "true"
-          # https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655
-          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || '' }}
           working-directory: ./apps/framework-cli
 
       - name: Upload wheels
@@ -266,6 +264,7 @@ jobs:
     if: ${{ !inputs.dry-run }}
     steps:
       - uses: actions/download-artifact@v4
+
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
Trying to see if that fixes the publishing of the python wheel