### PR TITLE
fix: attempt release fix 2

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -226,7 +226,7 @@ jobs:
           args: --release --features rdkafka/cmake-build --locked --target ${{ matrix.build.TARGET }} --out dist
           sccache: "true"
           # https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655
-          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || '' }}
+          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || '2014' }}
           working-directory: ./apps/framework-cli
 
       - name: Upload wheels

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -225,6 +225,8 @@ jobs:
           target: ${{ matrix.build.TARGET }}
           args: --release --features rdkafka/cmake-build --locked --target ${{ matrix.build.TARGET }} --out dist
           sccache: "true"
+          # https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655
+          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || 'auto' }}
           working-directory: ./apps/framework-cli
 
       - name: Upload wheels
@@ -258,13 +260,12 @@ jobs:
             ./target/${{ matrix.build.TARGET }}/release/moose-cli-${{ matrix.build.TARGET }}
 
   release-python:
-    name: Release
+    name: Release Python Wheels
     runs-on: ubuntu-latest
     needs: [build-and-publish-binaries]
     if: ${{ !inputs.dry-run }}
     steps:
       - uses: actions/download-artifact@v4
-
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -226,7 +226,7 @@ jobs:
           args: --release --features rdkafka/cmake-build --locked --target ${{ matrix.build.TARGET }} --out dist
           sccache: "true"
           # https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655
-          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || 'auto' }}
+          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || '' }}
           working-directory: ./apps/framework-cli
 
       - name: Upload wheels

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -225,6 +225,8 @@ jobs:
           target: ${{ matrix.build.TARGET }}
           args: --release --features rdkafka/cmake-build --locked --target ${{ matrix.build.TARGET }} --out dist
           sccache: "true"
+          # https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655
+          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || 'auto' }}
           working-directory: ./apps/framework-cli
 
       - name: Upload wheels

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -225,8 +225,6 @@ jobs:
           target: ${{ matrix.build.TARGET }}
           args: --release --features rdkafka/cmake-build --locked --target ${{ matrix.build.TARGET }} --out dist
           sccache: "true"
-          # https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655
-          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || '2014' }}
           working-directory: ./apps/framework-cli
 
       - name: Upload wheels

--- a/apps/framework-cli/pyproject.toml
+++ b/apps/framework-cli/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==1.46.0"]
+requires = ["maturin==1.8.1"]
 build-backend = "maturin"
 
 [project]

--- a/apps/framework-cli/pyproject.toml
+++ b/apps/framework-cli/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==1.7.0"]
+requires = ["maturin==1.46.0"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/release-cli.yaml` file to improve the build and release process for the CLI application. The most important changes are related to the configuration of the build target and the naming of the release job.

Improvements to build configuration:

* Added a conditional configuration for `manylinux` targeting `aarch64-unknown-linux-gnu` to address an issue with the `ring` crate. (`.github/workflows/release-cli.yaml`, [.github/workflows/release-cli.yamlR228-R229](diffhunk://#diff-499c73a2f13eb6f53b0606fab451145e22009c29aac1e2834c960009e4641dc1R228-R229))

Improvements to job naming:

* Renamed the `release-python` job to `Release Python Wheels` for better clarity. (`.github/workflows/release-cli.yaml`, [.github/workflows/release-cli.yamlL261-L267](diffhunk://#diff-499c73a2f13eb6f53b0606fab451145e22009c29aac1e2834c960009e4641dc1L261-L267))