### PR TITLE
add retry & timeout in workflow run cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ dependencies = [
  "prometheus-client",
  "prometheus-parse",
  "prost-types",
+ "prost-wkt-types",
  "protobuf 3.7.1",
  "protobuf-codegen",
  "ratatui",

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -108,6 +108,7 @@ tonic = { version = "0.12", features = ["transport", "prost", "codegen"] }
 url = "2.5.4"
 tempfile = "3.15.0"
 http = "1.2.0"
+prost-wkt-types = "0.6.0"
 
 [dev-dependencies]
 clickhouse = { version = "0.11.5", features = ["uuid", "test-util"] }

--- a/apps/framework-cli/src/framework/python/wrappers/consumption_runner.py
+++ b/apps/framework-cli/src/framework/python/wrappers/consumption_runner.py
@@ -158,6 +158,7 @@ class WorkflowClient:
             }
     
     async def _start_workflow_async(self, name: str, input_data: Any):
+        # TODO: add retry & timeout
         await self.temporal_client.start_workflow(
             "ScriptWorkflow",
             args=[f"{os.getcwd()}/app/scripts/{name}", input_data],

--- a/apps/framework-cli/src/framework/scripts/config.rs
+++ b/apps/framework-cli/src/framework/scripts/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct WorkflowConfig {
     // Basic workflow configuration
     pub name: String,
@@ -38,6 +38,12 @@ impl WorkflowConfig {
         let content = toml::to_string_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         std::fs::write(path, content)
+    }
+
+    pub fn from_file(path: PathBuf) -> Result<Self, anyhow::Error> {
+        let content = std::fs::read_to_string(path)?;
+        let config: WorkflowConfig = toml::from_str(&content)?;
+        Ok(config)
     }
 }
 

--- a/apps/framework-cli/src/framework/scripts/executor.rs
+++ b/apps/framework-cli/src/framework/scripts/executor.rs
@@ -36,8 +36,7 @@ pub(crate) async fn execute_workflow(
     match language {
         SupportedLanguages::Python => {
             let run_id =
-                execute_python_workflow(workflow_id, execution_path, Some(config.schedule), input)
-                    .await?;
+                execute_python_workflow(workflow_id, execution_path, &config, input).await?;
             Ok(run_id)
         }
         _ => Err(WorkflowExecutionError::ConfigError(format!(

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -12,6 +12,7 @@ pub const SETUP_PY: &str = "setup.py";
 pub const OLD_PROJECT_CONFIG_FILE: &str = "project.toml";
 pub const PROJECT_CONFIG_FILE: &str = "moose.config.toml";
 pub const OPENAPI_FILE: &str = "openapi.yaml";
+pub const WORKFLOW_CONFIGS: &str = "workflow_configs.json";
 pub const PROJECT_NAME_ALLOW_PATTERN: &str = r"^[a-zA-Z0-9_-]+$";
 
 pub const CLI_CONFIG_FILE: &str = "config.toml";


### PR DESCRIPTION
For example, a config like this:

```
name = 'testretry'
schedule = ''
retries = 3
timeout = '1m'
steps = ['step1']
```

would give each workflow 1 minute for each of the 3 retries.