### PR TITLE
workflow status command

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -28,12 +28,10 @@ use routines::ls::{list_db, list_streaming};
 use routines::metrics_console::run_console;
 use routines::plan;
 use routines::ps::show_processes;
-use routines::scripts::init_workflow;
-use routines::scripts::list_workflows;
-use routines::scripts::pause_workflow;
-use routines::scripts::run_workflow;
-use routines::scripts::terminate_workflow;
-use routines::scripts::unpause_workflow;
+use routines::scripts::{
+    get_workflow_status, init_workflow, list_workflows, pause_workflow, run_workflow,
+    terminate_workflow, unpause_workflow,
+};
 
 use settings::{read_settings, Settings};
 use std::cmp::Ordering;
@@ -1023,6 +1021,9 @@ async fn top_command_handler(
                 }
                 Some(WorkflowCommands::Pause { name }) => pause_workflow(&project, name).await,
                 Some(WorkflowCommands::Unpause { name }) => unpause_workflow(&project, name).await,
+                Some(WorkflowCommands::Status { name, id }) => {
+                    get_workflow_status(&project, name, id.clone()).await
+                }
                 None => Err(RoutineFailure::error(Message {
                     action: "Workflow".to_string(),
                     details: "No subcommand provided".to_string(),

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -302,4 +302,13 @@ pub enum WorkflowCommands {
         /// Name of the workflow to unpause
         name: String,
     },
+    /// Get the status of a workflow
+    Status {
+        /// Name of the workflow
+        name: String,
+
+        /// Optional run ID (defaults to most recent)
+        #[arg(long)]
+        id: Option<String>,
+    },
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `framework-cli` application: the ability to get the status of a workflow. The changes include updates to the command handling, new functionality in the workflow routines, and necessary imports.

New feature implementation:

* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL31-R34): Added a new command `Status` to the workflow commands and included the `get_workflow_status` function in the command handler. [[1]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL31-R34) [[2]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dR1024-R1026)
* [`apps/framework-cli/src/cli/commands.rs`](diffhunk://#diff-e7f0aaaa20bae413611601b71b7dcb324e95b5d4bea41ab3c88fcb1efb4ba20fR305-R313): Added a new `Status` variant to the `WorkflowCommands` enum to handle the status retrieval command.

Workflow routines update:

* [`apps/framework-cli/src/cli/routines/scripts.rs`](diffhunk://#diff-b94c433325c41b11008825090270a283db040c41a0cf1bb843866098ed068629R356-R461): Implemented the `get_workflow_status` function to retrieve and format the status of a workflow, including handling for optional run IDs and formatting the output with status emojis.

Necessary imports:

* [`apps/framework-cli/src/cli/routines/scripts.rs`](diffhunk://#diff-b94c433325c41b11008825090270a283db040c41a0cf1bb843866098ed068629R12-R16): Added necessary imports for `DateTime` and `Utc` from `chrono`, and `DescribeWorkflowExecutionRequest` from `temporal_sdk_core_protos`.