### PR TITLE
speed up temporal health check

### DIFF
--- a/apps/framework-cli/src/utilities/docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/docker-compose.yml.hbs
@@ -117,6 +117,11 @@ services:
         target: /etc/temporal/config/dynamicconfig/development-sql.yaml
     volumes:
       - temporal-data:/etc/temporal/config
+    healthcheck:
+      test: ["CMD-SHELL", "tctl --address temporal:${TEMPORAL_PORT:-7233} workflow list"]
+      interval: 1s
+      retries: 30
+      timeout: 5s
 
   temporal-admin-tools:
     container_name: temporal-admin-tools


### PR DESCRIPTION
Before (~22s on my machine):

https://github.com/user-attachments/assets/0c807ab6-876f-4430-931a-be48558dbe7d


After (< 1s)

https://github.com/user-attachments/assets/b574dd10-04fc-41d0-b8a8-00bc59bc8b27

