### PR TITLE
Updated workflow status

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -1021,8 +1021,8 @@ async fn top_command_handler(
                 }
                 Some(WorkflowCommands::Pause { name }) => pause_workflow(&project, name).await,
                 Some(WorkflowCommands::Unpause { name }) => unpause_workflow(&project, name).await,
-                Some(WorkflowCommands::Status { name, id }) => {
-                    get_workflow_status(&project, name, id.clone()).await
+                Some(WorkflowCommands::Status { name, id, verbose }) => {
+                    get_workflow_status(&project, name, id.clone(), *verbose).await
                 }
                 None => Err(RoutineFailure::error(Message {
                     action: "Workflow".to_string(),

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -310,5 +310,9 @@ pub enum WorkflowCommands {
         /// Optional run ID (defaults to most recent)
         #[arg(long)]
         id: Option<String>,
+
+        /// Verbose output
+        #[arg(long)]
+        verbose: bool,
     },
 }

--- a/apps/framework-cli/src/cli/routines/scripts.rs
+++ b/apps/framework-cli/src/cli/routines/scripts.rs
@@ -189,6 +189,7 @@ pub async fn list_workflows(
             if let Some(execution_info) = execution.execution {
                 table_data.push(vec![
                     execution_info.workflow_id,
+                    execution_info.run_id,
                     status,
                     execution.start_time.map_or("-".to_string(), |t| {
                         chrono::DateTime::from_timestamp(t.seconds, t.nanos as u32)
@@ -203,6 +204,7 @@ pub async fn list_workflows(
     show_table(
         vec![
             "Workflow Name".to_string(),
+            "Run ID".to_string(),
             "Status".to_string(),
             "Started At".to_string(),
         ],


### PR DESCRIPTION
This pull request introduces a new verbose flag to the workflow status command and enhances the workflow status output with detailed history information when the verbose flag is set. Additionally, it includes minor improvements to the workflow listing command.

Key changes include:

### Enhancements to Workflow Status Command:
* Added a `verbose` flag to the `WorkflowCommands::Status` variant in the `WorkflowCommands` enum.
* Updated `get_workflow_status` function to accept the `verbose` flag and fetch detailed workflow history if the flag is set. [[1]](diffhunk://#diff-b94c433325c41b11008825090270a283db040c41a0cf1bb843866098ed068629R364) [[2]](diffhunk://#diff-b94c433325c41b11008825090270a283db040c41a0cf1bb843866098ed068629L447-R543)
* Modified the `top_command_handler` to pass the `verbose` flag to the `get_workflow_status` function.

### Improvements to Workflow Listing:
* Included `run_id` in the workflow listing output to provide more detailed information about each workflow. [[1]](diffhunk://#diff-b94c433325c41b11008825090270a283db040c41a0cf1bb843866098ed068629R194) [[2]](diffhunk://#diff-b94c433325c41b11008825090270a283db040c41a0cf1bb843866098ed068629R209)

### Dependency Updates:
* Added `WorkflowExecution` import to support the new functionality in the `get_workflow_status` function.