### PR TITLE
Nicolas/enable docker drop in replacements

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -968,6 +968,7 @@ impl Webserver {
 
     // TODO - when we retire the the old core, we should remove routeTable from the start method and using only
     // the channel to update the routes
+    #[allow(clippy::too_many_arguments)]
     pub async fn start<I: InfraMapProvider + Clone + Send + 'static>(
         &self,
         settings: &Settings,

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1,6 +1,7 @@
 use super::display::Message;
 use super::display::MessageType;
 use super::routines::auth::validate_auth_token;
+use super::settings::Settings;
 use crate::metrics::MetricEvent;
 
 use crate::cli::display::with_spinner;
@@ -11,7 +12,6 @@ use crate::framework::core::infrastructure_map::Change;
 use crate::framework::core::infrastructure_map::{ApiChange, InfrastructureMap};
 use crate::metrics::Metrics;
 use crate::utilities::auth::{get_claims, validate_jwt};
-use crate::utilities::docker;
 
 use crate::framework::data_model::config::EndpointIngestionFormat;
 use crate::infrastructure::stream::redpanda;
@@ -19,6 +19,7 @@ use crate::infrastructure::stream::redpanda::ConfiguredProducer;
 
 use crate::framework::typescript::bin::CliMessage;
 use crate::project::{JwtConfig, Project};
+use crate::utilities::docker::DockerClient;
 use bytes::Buf;
 use chrono::Utc;
 use http_body_util::BodyExt;
@@ -969,6 +970,7 @@ impl Webserver {
     // the channel to update the routes
     pub async fn start<I: InfraMapProvider + Clone + Send + 'static>(
         &self,
+        settings: &Settings,
         route_table: &'static RwLock<HashMap<PathBuf, RouteMeta>>,
         consumption_apis: &'static RwLock<HashSet<String>>,
         infra_map: I,
@@ -1087,7 +1089,7 @@ impl Webserver {
             }
         }
 
-        shutdown(&project, graceful).await;
+        shutdown(settings, &project, graceful).await;
     }
 }
 
@@ -1114,8 +1116,7 @@ fn handle_listener_err(port: u16, e: std::io::Error) -> ! {
         _ => panic!("Failed to listen to port {}: {:?}", port, e),
     }
 }
-
-async fn shutdown(project: &Project, graceful: GracefulShutdown) -> ! {
+async fn shutdown(settings: &Settings, project: &Project, graceful: GracefulShutdown) -> ! {
     tokio::select! {
             _ = graceful.shutdown() => {
                 info!("all connections gracefully closed");
@@ -1126,10 +1127,11 @@ async fn shutdown(project: &Project, graceful: GracefulShutdown) -> ! {
     }
 
     if !project.is_production {
+        let docker = DockerClient::new(settings);
         with_spinner(
             "Stopping containers",
             || {
-                let _ = docker::stop_containers(project);
+                let _ = docker.stop_containers(project);
             },
             true,
         );

--- a/apps/framework-cli/src/cli/routines/clean.rs
+++ b/apps/framework-cli/src/cli/routines/clean.rs
@@ -1,45 +1,35 @@
-use log::error;
-use std::sync::Arc;
-
-use crate::cli::routines::util::ensure_docker_running;
-use crate::utilities::docker;
+use crate::utilities::docker::DockerClient;
 use crate::{cli::display::Message, project::Project};
+use log::error;
 
-use super::{Routine, RoutineFailure, RoutineSuccess};
+use super::util::ensure_docker_running;
+use super::{RoutineFailure, RoutineSuccess};
 
-pub struct CleanProject {
-    project: Arc<Project>,
-}
-impl CleanProject {
-    pub fn new(project: Arc<Project>) -> Self {
-        Self { project }
-    }
-}
+pub fn clean_project(
+    project: &Project,
+    docker_client: &DockerClient,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    ensure_docker_running(docker_client)?;
+    docker_client.stop_containers(project).map_err(|err| {
+        RoutineFailure::new(
+            Message::new("Failed".to_string(), "to stop containers".to_string()),
+            err,
+        )
+    })?;
 
-impl Routine for CleanProject {
-    fn run_silent(&self) -> Result<RoutineSuccess, RoutineFailure> {
-        ensure_docker_running()?;
-        docker::stop_containers(&self.project).map_err(|err| {
-            RoutineFailure::new(
-                Message::new("Failed".to_string(), "to stop containers".to_string()),
-                err,
-            )
-        })?;
+    project.delete_old_versions().map_err(|err| {
+        error!("Failed to remove .moose directory: {:?}", err);
+        RoutineFailure::new(
+            Message::new(
+                "Failed".to_string(),
+                "to remove .moose directory".to_string(),
+            ),
+            err,
+        )
+    })?;
 
-        self.project.delete_old_versions().map_err(|err| {
-            error!("Failed to remove .moose directory: {:?}", err);
-            RoutineFailure::new(
-                Message::new(
-                    "Failed".to_string(),
-                    "to remove .moose directory".to_string(),
-                ),
-                err,
-            )
-        })?;
-
-        Ok(RoutineSuccess::success(Message::new(
-            "Cleaned".to_string(),
-            "project".to_string(),
-        )))
-    }
+    Ok(RoutineSuccess::success(Message::new(
+        "Cleaned".to_string(),
+        "project".to_string(),
+    )))
 }

--- a/apps/framework-cli/src/cli/routines/util.rs
+++ b/apps/framework-cli/src/cli/routines/util.rs
@@ -1,9 +1,9 @@
 use crate::cli::display::Message;
 use crate::cli::routines::RoutineFailure;
-use crate::utilities::docker;
+use crate::utilities::docker::DockerClient;
 
-pub fn ensure_docker_running() -> Result<(), RoutineFailure> {
-    let errors = docker::check_status().map_err(|err| {
+pub fn ensure_docker_running(docker_client: &DockerClient) -> Result<(), RoutineFailure> {
+    let errors = docker_client.check_status().map_err(|err| {
         RoutineFailure::new(
             Message::new("Failed".to_string(), "to run `docker info`".to_string()),
             err,

--- a/apps/framework-cli/src/cli/routines/validate.rs
+++ b/apps/framework-cli/src/cli/routines/validate.rs
@@ -1,15 +1,21 @@
+use log::debug;
+
 use super::{RoutineFailure, RoutineSuccess};
+use crate::cli::display::Message;
 use crate::project::Project;
 use crate::utilities::constants::{
     CLICKHOUSE_CONTAINER_NAME, REDPANDA_CONTAINER_NAME, TEMPORAL_CONTAINER_NAME,
 };
-use crate::utilities::docker::ContainerRow;
-use crate::{cli::display::Message, utilities::docker};
+use crate::utilities::docker::{DockerClient, DockerComposeContainerInfo};
 use std::thread::sleep;
 use std::time::Duration;
 
-fn find_container(project: &Project, container_name: &str) -> Result<ContainerRow, RoutineFailure> {
-    let containers = docker::list_containers(project).map_err(|err| {
+fn find_container(
+    project: &Project,
+    container_name: &str,
+    docker_client: &DockerClient,
+) -> Result<DockerComposeContainerInfo, RoutineFailure> {
+    let containers = docker_client.list_containers(project).map_err(|err| {
         RoutineFailure::new(
             Message::new("Failed".to_string(), "to get the containers".to_string()),
             err,
@@ -18,7 +24,7 @@ fn find_container(project: &Project, container_name: &str) -> Result<ContainerRo
 
     containers
         .into_iter()
-        .find(|container| container.names.contains(container_name))
+        .find(|container| container.name.contains(container_name))
         .ok_or_else(|| {
             RoutineFailure::error(Message::new(
                 "Failed".to_string(),
@@ -31,16 +37,22 @@ fn validate_container_run(
     project: &Project,
     container_name: &str,
     health: Option<&str>,
+    docker_client: &DockerClient,
 ) -> Result<RoutineSuccess, RoutineFailure> {
-    let mut container = find_container(project, container_name)?;
+    let mut container = find_container(project, container_name, docker_client)?;
 
     if let Some(expected) = health {
         for _ in 0..20 {
-            if container.health == expected {
+            if let Some(effective_health) = container.health {
+                if effective_health == expected {
+                    break;
+                }
+            } else {
+                debug!("No health info for container {}", container_name);
                 break;
             }
 
-            container = find_container(project, container_name)?;
+            container = find_container(project, container_name, docker_client)?;
             sleep(Duration::from_secs(1));
         }
     }
@@ -51,28 +63,52 @@ fn validate_container_run(
     )))
 }
 
-pub fn validate_clickhouse_run(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
-    validate_container_run(project, CLICKHOUSE_CONTAINER_NAME, Some("healthy"))
+pub fn validate_clickhouse_run(
+    project: &Project,
+    docker_client: &DockerClient,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    validate_container_run(
+        project,
+        CLICKHOUSE_CONTAINER_NAME,
+        Some("healthy"),
+        docker_client,
+    )
 }
 
-pub fn validate_redpanda_run(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
-    validate_container_run(project, REDPANDA_CONTAINER_NAME, None)
+pub fn validate_redpanda_run(
+    project: &Project,
+    docker_client: &DockerClient,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    validate_container_run(project, REDPANDA_CONTAINER_NAME, None, docker_client)
 }
 
-pub fn validate_temporal_run(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
-    validate_container_run(project, TEMPORAL_CONTAINER_NAME, Some("healthy"))
+pub fn validate_temporal_run(
+    project: &Project,
+    docker_client: &DockerClient,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    validate_container_run(
+        project,
+        TEMPORAL_CONTAINER_NAME,
+        Some("healthy"),
+        docker_client,
+    )
 }
 
-pub fn validate_redpanda_cluster(project_name: String) -> Result<RoutineSuccess, RoutineFailure> {
-    docker::run_rpk_cluster_info(&project_name, 10).map_err(|err| {
-        RoutineFailure::new(
-            Message::new(
-                "Failed".to_string(),
-                format!("to validate red panda cluster, {}", err),
-            ),
-            err,
-        )
-    })?;
+pub fn validate_redpanda_cluster(
+    project_name: String,
+    docker_client: &DockerClient,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    docker_client
+        .run_rpk_cluster_info(&project_name, 10)
+        .map_err(|err| {
+            RoutineFailure::new(
+                Message::new(
+                    "Failed".to_string(),
+                    format!("to validate red panda cluster, {}", err),
+                ),
+                err,
+            )
+        })?;
 
     Ok(RoutineSuccess::success(Message::new(
         "Successfully".to_string(),

--- a/apps/framework-cli/src/cli/settings.rs
+++ b/apps/framework-cli/src/cli/settings.rs
@@ -1,11 +1,34 @@
-/// # Config
-/// Module to handle reading the config file from the user's home directory and configuring the CLI
-///
-/// ## Suggested Improvements
-/// - add a config file option to the CLI
-/// - add a config file generator to the CLI
-/// - add a config file validation and error handling
-///
+//! Settings module for the Moose CLI
+//!
+//! This module handles configuration management for the Moose CLI, including:
+//! - Reading/writing configuration from the user's home directory
+//! - Environment variable overrides
+//! - Default configuration values
+//! - Feature flags and telemetry settings
+//!
+//! # Configuration Sources
+//! Configuration is loaded in the following order (later sources override earlier ones):
+//! 1. Default values
+//! 2. Local configuration file (~/.moose/config.toml)
+//! 3. Environment variables (prefixed with MOOSE_)
+//!
+//! # Environment Variables
+//! Environment variables can override any config value using double underscores as separators:
+//! - `MOOSE_LOGGER__LEVEL=debug`
+//! - `MOOSE_TELEMETRY__ENABLED=false`
+//!
+//! # Example Configuration
+//! ```toml
+//! [telemetry]
+//! enabled = true
+//! machine_id = "uuid-here"
+//! export_metrics = false
+//!
+//! [features]
+//! metrics_v2 = false
+//! scripts = true
+//! ```
+
 use config::{Config, ConfigError, Environment, File};
 use home::home_dir;
 use log::warn;
@@ -20,18 +43,26 @@ use crate::utilities::constants::{CLI_CONFIG_FILE, CLI_USER_DIRECTORY};
 
 const ENVIRONMENT_VARIABLE_PREFIX: &str = "MOOSE";
 
+/// Configuration for metric collection labels and endpoints
 #[derive(Deserialize, Debug, Default)]
 pub struct MetricLabels {
+    /// Custom labels to attach to metrics
     pub labels: Option<String>,
+    /// Custom endpoints for metric submission
     pub endpoints: Option<String>,
 }
 
+/// Telemetry configuration for usage tracking and metrics
 #[derive(Deserialize, Debug)]
 pub struct Telemetry {
+    /// Unique identifier for the machine running Moose
     pub machine_id: String,
+    /// Whether telemetry collection is enabled
     pub enabled: bool,
+    /// Whether to export metrics to external systems
     #[serde(default)]
     pub export_metrics: bool,
+    /// Flag indicating if the user is a Moose developer
     #[serde(default)]
     pub is_moose_developer: bool,
 }
@@ -47,11 +78,14 @@ impl Default for Telemetry {
     }
 }
 
+/// Feature flag configuration for enabling/disabling functionality
 #[derive(Deserialize, Debug, Clone)]
 pub struct Features {
+    /// Whether to use the v2 metrics system
     #[serde(default = "Features::default_metrics_v2")]
     pub metrics_v2: bool,
 
+    /// Whether the scripts feature is enabled
     #[serde(default)]
     pub scripts: bool,
 }
@@ -71,48 +105,71 @@ impl Features {
     }
 }
 
+/// Main settings structure containing all configuration options
 #[derive(Deserialize, Debug)]
 pub struct Settings {
+    /// Logging configuration settings
     #[serde(default)]
     pub logger: LoggerSettings,
+
+    /// Telemetry and usage tracking settings
     #[serde(default)]
     pub telemetry: Telemetry,
 
+    /// Metric collection configuration
     #[serde(default)]
     pub metric: MetricLabels,
 
+    /// Feature flag settings
     #[serde(default)]
     pub features: Features,
+
+    /// Development-specific settings
+    #[serde(default)]
+    pub dev: DevSettings,
 }
 
+/// Development-specific configuration options
+#[derive(Deserialize, Debug, Default)]
+pub struct DevSettings {
+    /// Optional custom path to container CLI executable
+    pub container_cli_path: Option<PathBuf>,
+}
+
+/// Returns the path to the config file in the user's home directory
 fn config_path() -> PathBuf {
     let mut path: PathBuf = user_directory();
     path.push(CLI_CONFIG_FILE);
     path
 }
 
+/// Returns the path to the Moose user directory
 pub fn user_directory() -> PathBuf {
     let mut path: PathBuf = home_dir().unwrap();
     path.push(CLI_USER_DIRECTORY);
     path
 }
 
+/// Creates the Moose user directory if it doesn't exist
 pub fn setup_user_directory() -> Result<(), std::io::Error> {
     let path = user_directory();
     std::fs::create_dir_all(path.clone())?;
     Ok(())
 }
 
-// TODO: Turn this part of the code into a routine
+/// Reads and parses the settings from all configuration sources
+///
+/// Configuration is loaded in the following order:
+/// 1. Default values
+/// 2. Local configuration file
+/// 3. Environment variables
+///
+/// Returns a Result containing the parsed Settings or a ConfigError
 pub fn read_settings() -> Result<Settings, ConfigError> {
     let config_file_location: PathBuf = config_path();
 
     let s = Config::builder()
-        // Start off by merging in the "default" values
-        // Add the local configuration
         .add_source(File::from(config_file_location).required(false))
-        // Add in settings from the environment (with a prefix of APP)
-        // Eg.. `MOOSE_DEBUG=1 ./target/app` would set the `debug` key
         .add_source(
             Environment::with_prefix(ENVIRONMENT_VARIABLE_PREFIX)
                 .try_parsing(true)
@@ -124,6 +181,15 @@ pub fn read_settings() -> Result<Settings, ConfigError> {
     s.try_deserialize()
 }
 
+/// Initializes the config file with default values if it doesn't exist
+///
+/// If the config file already exists, this function will:
+/// 1. Parse the existing TOML
+/// 2. Ensure required fields are present
+/// 3. Add any missing fields with default values
+/// 4. Write the updated config back to disk
+///
+/// Returns a Result indicating success or an IO error
 pub fn init_config_file() -> Result<(), std::io::Error> {
     let path = config_path();
     if !path.exists() {

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -59,372 +59,492 @@ pub struct NetworkRow {
     pub scope: String,
 }
 
-/// Creates a new Command using the configured container CLI
-fn create_container_command(settings: &Settings) -> Command {
-    let cli = settings
-        .dev
-        .container_cli_path
-        .as_ref()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| "docker".to_string());
-    Command::new(cli)
+/// Client for interacting with container runtime (docker/finch)
+pub struct DockerClient {
+    /// The container runtime CLI command to use
+    cli_command: String,
 }
 
+impl DockerClient {
+    /// Creates a new DockerClient instance from settings
+    pub fn new(settings: &Settings) -> Self {
+        let cli_command = settings
+            .dev
+            .container_cli_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| "docker".to_string());
+
+        Self { cli_command }
+    }
+
+    /// Creates a new Command using the configured container CLI
+    fn create_command(&self) -> Command {
+        Command::new(&self.cli_command)
+    }
+
+    /// Creates a compose command for the given project
+    fn compose_command(&self, project: &Project) -> Command {
+        let mut command = self.create_command();
+        command
+            .arg("compose")
+            .arg("-f")
+            .arg(project.internal_dir().unwrap().join("docker-compose.yml"))
+            .arg("-p")
+            .arg(project.name().to_lowercase());
+        command
+    }
+
+    /// Lists all containers for the project
+    pub fn list_containers(&self, project: &Project) -> std::io::Result<Vec<ContainerRow>> {
+        let child = self
+            .compose_command(project)
+            .arg("ps")
+            .arg("-a")
+            .arg("--no-trunc")
+            .arg("--format")
+            .arg("json")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Failed to list Docker containers",
+            ));
+        }
+
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        let containers: Vec<ContainerRow> = output_str
+            .split('\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| from_str(line).expect("Failed to parse container row"))
+            .collect();
+
+        Ok(containers)
+    }
+
+    /// Lists names of all containers
+    pub fn list_container_names(&self) -> std::io::Result<Vec<String>> {
+        let child = self
+            .create_command()
+            .arg("ps")
+            .arg("--format")
+            .arg("{{json .Names}}")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Failed to list Docker container names",
+            ));
+        }
+
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        let containers: Vec<String> = output_str
+            .split('\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| from_str(line).expect("Failed to parse container row"))
+            .collect();
+
+        Ok(containers)
+    }
+
+    /// Stops all containers for the project
+    pub fn stop_containers(&self, project: &Project) -> anyhow::Result<()> {
+        let child = self
+            .compose_command(project)
+            .arg("down")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            error!(
+                "Failed to stop containers: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Err(anyhow::anyhow!("Failed to stop containers"))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Starts all containers for the project
+    pub fn start_containers(&self, project: &Project) -> anyhow::Result<()> {
+        let temporal_env_vars = project.temporal_config.to_env_vars();
+
+        let mut child = self.compose_command(project);
+
+        // Add all temporal environment variables
+        for (key, value) in temporal_env_vars {
+            child.env(key, value);
+        }
+
+        child
+            .arg("up")
+            .arg("-d")
+            .env("DB_NAME", project.clickhouse_config.db_name.clone())
+            .env("CLICKHOUSE_USER", project.clickhouse_config.user.clone())
+            .env(
+                "CLICKHOUSE_PASSWORD",
+                project.clickhouse_config.password.clone(),
+            )
+            .env(
+                "CLICKHOUSE_HOST_PORT",
+                project.clickhouse_config.host_port.to_string(),
+            );
+
+        let child = child
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            let error_message = String::from_utf8_lossy(&output.stderr);
+            error!("Failed to start containers: {}", error_message);
+
+            let mapped_error_message =
+                if let Some(stuff) = PORT_ALLOCATED_REGEX.captures(&error_message) {
+                    format!("Port {} already in use.", stuff.get(1).unwrap().as_str())
+                } else {
+                    error_message.to_string()
+                };
+
+            Err(anyhow::anyhow!(
+                "Failed to start containers: {}",
+                mapped_error_message
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Gets the ID of a container by name
+    fn get_container_id(&self, container_name: &str) -> anyhow::Result<String> {
+        let child = self
+            .create_command()
+            .arg("ps")
+            .arg("-aqf")
+            .arg(format!("name={}", container_name))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            error!(
+                "Failed to get container id: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Err(anyhow::anyhow!(format!(
+                "Failed to get container id for {}",
+                container_name
+            )))
+        } else {
+            let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok(container_id)
+        }
+    }
+
+    /// Tails logs for a specific container
+    pub fn tail_container_logs(
+        &self,
+        project: &Project,
+        container_name: &str,
+    ) -> anyhow::Result<()> {
+        let full_container_name = format!("{}-{}", project.name().to_lowercase(), container_name);
+        let container_id = self.get_container_id(&full_container_name)?;
+
+        let mut child = tokio::process::Command::new(&self.cli_command)
+            .arg("logs")
+            .arg("--follow")
+            .arg(container_id)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let stdout = child.stdout.take().ok_or(anyhow::anyhow!(
+            "Failed to get stdout for {}",
+            full_container_name
+        ))?;
+
+        let stderr = child.stderr.take().ok_or(anyhow::anyhow!(
+            "Failed to get stderr for {}",
+            full_container_name
+        ))?;
+
+        let mut stdout_reader = BufReader::new(stdout).lines();
+        let mut stderr_reader = BufReader::new(stderr).lines();
+
+        let log_identifier_stdout = full_container_name.clone();
+        tokio::spawn(async move {
+            while let Ok(Some(line)) = stdout_reader.next_line().await {
+                info!("<{}> {}", log_identifier_stdout, line);
+            }
+        });
+
+        let log_identifier_stderr = full_container_name;
+        tokio::spawn(async move {
+            while let Ok(Some(line)) = stderr_reader.next_line().await {
+                error!("<{}> {}", log_identifier_stderr, line);
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Creates the docker-compose file for the project
+    pub fn create_compose_file(
+        &self,
+        project: &Project,
+        settings: &Settings,
+    ) -> Result<(), DockerError> {
+        let compose_file = project.internal_dir()?.join("docker-compose.yml");
+
+        let mut handlebars = Handlebars::new();
+        handlebars.register_escape_fn(handlebars::no_escape);
+
+        let data = json!({
+            "scripts_feature": settings.features.scripts
+        });
+
+        let rendered = handlebars
+            .render_template(COMPOSE_FILE, &data)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+        Ok(std::fs::write(compose_file, rendered)?)
+    }
+
+    /// Runs rpk cluster info command
+    pub fn run_rpk_cluster_info(&self, project_name: &str, attempts: usize) -> anyhow::Result<()> {
+        let child = self
+            .create_command()
+            .arg("exec")
+            .arg(format!(
+                "{}-{}",
+                project_name.to_lowercase(),
+                REDPANDA_CONTAINER_NAME
+            ))
+            .arg("rpk")
+            .arg("cluster")
+            .arg("info")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            if attempts > 0 {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                self.run_rpk_cluster_info(project_name, attempts - 1)
+            } else {
+                error!(
+                    "Failed to run redpanda cluster info: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                Err(anyhow::anyhow!("Failed to run redpanda cluster info"))
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Runs an rpk command
+    pub fn run_rpk_command(
+        &self,
+        project_name: &str,
+        args: Vec<String>,
+    ) -> std::io::Result<String> {
+        let child = self
+            .create_command()
+            .arg("exec")
+            .arg(format!("{}-{}", project_name, REDPANDA_CONTAINER_NAME))
+            .arg("rpk")
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else if output.stderr.is_empty() {
+            if output.stdout.is_empty() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "No output from command",
+                ));
+            }
+
+            if String::from_utf8_lossy(&output.stdout).contains("TOPIC_ALREADY_EXISTS") {
+                return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+            }
+
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                String::from_utf8_lossy(&output.stdout),
+            ));
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "stdout: {}, stderr: {}",
+                    String::from_utf8_lossy(&output.stdout),
+                    &String::from_utf8_lossy(&output.stderr)
+                ),
+            ))
+        }
+    }
+
+    /// Checks the container runtime status
+    pub fn check_status(&self) -> std::io::Result<Vec<String>> {
+        let child = self
+            .create_command()
+            .arg("info")
+            .arg("--format")
+            .arg("{{json .ServerErrors}}")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Failed to get Docker info",
+            ));
+        }
+
+        let errors: Option<Vec<String>> = from_slice(&output.stdout)?;
+        Ok(errors.unwrap_or_default())
+    }
+
+    /// Runs buildx command
+    pub fn buildx(
+        &self,
+        directory: &PathBuf,
+        version: &str,
+        architecture: &str,
+        binarylabel: &str,
+    ) -> std::io::Result<Vec<String>> {
+        let child = self
+            .create_command()
+            .current_dir(directory)
+            .arg("buildx")
+            .arg("build")
+            .arg("--build-arg")
+            .arg(format!(
+                "DOWNLOAD_URL=https://github.com/514-labs/moose/releases/download/v{}/moose-cli-{}",
+                version, binarylabel
+            ))
+            .arg("--platform")
+            .arg(architecture)
+            .arg("--load")
+            .arg("--no-cache")
+            .arg("-t")
+            .arg(format!("moose-df-deployment-{}:latest", binarylabel))
+            .arg(".")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                String::from_utf8_lossy(&output.stderr),
+            ));
+        }
+
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        let containers: Vec<String> = output_str
+            .split('\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| from_str(line).expect("Failed to parse container row"))
+            .collect();
+        Ok(containers)
+    }
+}
+
+// Re-export the old functions as deprecated to maintain backward compatibility
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn list_containers(
     project: &Project,
     settings: &Settings,
 ) -> std::io::Result<Vec<ContainerRow>> {
-    let child = compose_command(project, settings)
-        .arg("ps")
-        .arg("-a")
-        .arg("--no-trunc")
-        .arg("--format")
-        .arg("json")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to list Docker containers",
-        ));
-    }
-
-    let output_str = String::from_utf8_lossy(&output.stdout);
-    let containers: Vec<ContainerRow> = output_str
-        .split('\n')
-        .filter(|line| !line.is_empty())
-        .map(|line| from_str(line).expect("Failed to parse container row"))
-        .collect();
-
-    Ok(containers)
+    DockerClient::new(settings).list_containers(project)
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn list_container_names(settings: &Settings) -> std::io::Result<Vec<String>> {
-    let child = create_container_command(settings)
-        .arg("ps")
-        .arg("--format")
-        .arg("{{json .Names}}")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to list Docker container names",
-        ));
-    }
-
-    let output_str = String::from_utf8_lossy(&output.stdout);
-    let containers: Vec<String> = output_str
-        .split('\n')
-        .filter(|line| !line.is_empty())
-        .map(|line| from_str(line).expect("Failed to parse container row"))
-        .collect();
-
-    Ok(containers)
+    DockerClient::new(settings).list_container_names()
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn stop_containers(project: &Project, settings: &Settings) -> anyhow::Result<()> {
-    let child = compose_command(project, settings)
-        .arg("down")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        error!(
-            "Failed to stop containers: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        Err(anyhow::anyhow!("Failed to stop containers"))
-    } else {
-        Ok(())
-    }
+    DockerClient::new(settings).stop_containers(project)
 }
 
-fn compose_command(project: &Project, settings: &Settings) -> Command {
-    let mut command = create_container_command(settings);
-
-    command
-        .arg("compose")
-        .arg("-f")
-        .arg(project.internal_dir().unwrap().join("docker-compose.yml"))
-        .arg("-p")
-        .arg(project.name().to_lowercase());
-    command
-}
-
-lazy_static! {
-    pub static ref PORT_ALLOCATED_REGEX: Regex =
-        Regex::new("Bind for \\d+.\\d+.\\d+.\\d+:(\\d+) failed: port is already allocated")
-            .unwrap();
-}
-
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn start_containers(project: &Project, settings: &Settings) -> anyhow::Result<()> {
-    let temporal_env_vars = project.temporal_config.to_env_vars();
-
-    let mut child = compose_command(project, settings);
-
-    // Add all temporal environment variables
-    for (key, value) in temporal_env_vars {
-        child.env(key, value);
-    }
-
-    child
-        .arg("up")
-        .arg("-d")
-        .env("DB_NAME", project.clickhouse_config.db_name.clone())
-        .env("CLICKHOUSE_USER", project.clickhouse_config.user.clone())
-        .env(
-            "CLICKHOUSE_PASSWORD",
-            project.clickhouse_config.password.clone(),
-        )
-        .env(
-            "CLICKHOUSE_HOST_PORT",
-            project.clickhouse_config.host_port.to_string(),
-        );
-
-    let child = child
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        let error_message = String::from_utf8_lossy(&output.stderr);
-        error!("Failed to start containers: {}", error_message);
-
-        let mapped_error_message =
-            if let Some(stuff) = PORT_ALLOCATED_REGEX.captures(&error_message) {
-                format!("Port {} already in use.", stuff.get(1).unwrap().as_str())
-            } else {
-                error_message.to_string()
-            };
-
-        Err(anyhow::anyhow!(
-            "Failed to start containers: {}",
-            mapped_error_message
-        ))
-    } else {
-        Ok(())
-    }
+    DockerClient::new(settings).start_containers(project)
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn tail_container_logs(
     project: &Project,
     container_name: &str,
     settings: &Settings,
 ) -> anyhow::Result<()> {
-    let full_container_name = format!("{}-{}", project.name().to_lowercase(), container_name);
-    let container_id = get_container_id(&full_container_name, settings)?;
-
-    let mut child = tokio::process::Command::new(
-        settings
-            .dev
-            .container_cli_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|| "docker".to_string()),
-    )
-    .arg("logs")
-    .arg("--follow")
-    .arg(container_id)
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()?;
-
-    let stdout = child.stdout.take().ok_or(anyhow::anyhow!(
-        "Failed to get stdout for {}",
-        full_container_name
-    ))?;
-
-    let stderr = child.stderr.take().ok_or(anyhow::anyhow!(
-        "Failed to get stderr for {}",
-        full_container_name
-    ))?;
-
-    let mut stdout_reader = BufReader::new(stdout).lines();
-    let mut stderr_reader = BufReader::new(stderr).lines();
-
-    let log_identifier_stdout = full_container_name.clone();
-    tokio::spawn(async move {
-        while let Ok(Some(line)) = stdout_reader.next_line().await {
-            info!("<{}> {}", log_identifier_stdout, line);
-        }
-    });
-
-    let log_identifier_stderr = full_container_name.clone();
-    tokio::spawn(async move {
-        while let Ok(Some(line)) = stderr_reader.next_line().await {
-            error!("<{}> {}", log_identifier_stderr, line);
-        }
-    });
-
-    Ok(())
+    DockerClient::new(settings).tail_container_logs(project, container_name)
 }
 
-fn get_container_id(container_name: &str, settings: &Settings) -> anyhow::Result<String> {
-    let child = create_container_command(settings)
-        .arg("ps")
-        .arg("-aqf")
-        .arg(format!("name={}", container_name))
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        error!(
-            "Failed to get container id: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        Err(anyhow::anyhow!(format!(
-            "Failed to get container id for {}",
-            container_name
-        )))
-    } else {
-        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        Ok(container_id)
-    }
-}
-
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn create_compose_file(project: &Project, settings: &Settings) -> Result<(), DockerError> {
-    let compose_file = project.internal_dir()?.join("docker-compose.yml");
-
-    // Initialize handlebars
-    let mut handlebars = Handlebars::new();
-    // Don't escape HTML characters in the output
-    handlebars.register_escape_fn(handlebars::no_escape);
-
-    // Create template data
-    let data = json!({
-        "scripts_feature": settings.features.scripts
-    });
-
-    // Render the template
-    let rendered = handlebars
-        .render_template(COMPOSE_FILE, &data)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
-
-    Ok(std::fs::write(compose_file, rendered)?)
+    DockerClient::new(settings).create_compose_file(project, settings)
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn run_rpk_cluster_info(
     project_name: &str,
     attempts: usize,
     settings: &Settings,
 ) -> anyhow::Result<()> {
-    let child = create_container_command(settings)
-        .arg("exec")
-        .arg(format!(
-            "{}-{}",
-            project_name.to_lowercase(),
-            REDPANDA_CONTAINER_NAME
-        ))
-        .arg("rpk")
-        .arg("cluster")
-        .arg("info")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        if attempts > 0 {
-            std::thread::sleep(std::time::Duration::from_secs(1));
-            Ok(run_rpk_cluster_info(project_name, attempts - 1, settings)?)
-        } else {
-            error!(
-                "Failed to run redpanda cluster info: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            Err(anyhow::anyhow!("Failed to run redpanda cluster info"))
-        }
-    } else {
-        Ok(())
-    }
+    DockerClient::new(settings).run_rpk_cluster_info(project_name, attempts)
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn run_rpk_command(
     project_name: &str,
     args: Vec<String>,
     settings: &Settings,
 ) -> std::io::Result<String> {
-    let child = create_container_command(settings)
-        .arg("exec")
-        .arg(format!("{}-{}", project_name, REDPANDA_CONTAINER_NAME))
-        .arg("rpk")
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    } else if output.stderr.is_empty() {
-        if output.stdout.is_empty() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "No output from command",
-            ));
-        }
-
-        if String::from_utf8_lossy(&output.stdout).contains("TOPIC_ALREADY_EXISTS") {
-            return Ok(String::from_utf8_lossy(&output.stdout).to_string());
-        }
-
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            String::from_utf8_lossy(&output.stdout),
-        ));
-    } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "stdout: {}, stderr: {}",
-                String::from_utf8_lossy(&output.stdout),
-                &String::from_utf8_lossy(&output.stderr)
-            ),
-        ))
-    }
+    DockerClient::new(settings).run_rpk_command(project_name, args)
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn check_status(settings: &Settings) -> std::io::Result<Vec<String>> {
-    let child = create_container_command(settings)
-        .arg("info")
-        .arg("--format")
-        .arg("{{json .ServerErrors}}")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()?;
-
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to get Docker info",
-        ));
-    }
-
-    let errors: Option<Vec<String>> = from_slice(&output.stdout)?;
-    Ok(errors.unwrap_or_default())
+    DockerClient::new(settings).check_status()
 }
 
+#[deprecated(since = "0.1.0", note = "Use DockerClient instead")]
 pub fn buildx(
     directory: &PathBuf,
     version: &str,
@@ -432,42 +552,11 @@ pub fn buildx(
     binarylabel: &str,
     settings: &Settings,
 ) -> std::io::Result<Vec<String>> {
-    let child = create_container_command(settings)
-        .current_dir(directory)
-        .arg("buildx")
-        .arg("build")
-        .arg("--build-arg")
-        .arg(format!(
-            "DOWNLOAD_URL=https://github.com/514-labs/moose/releases/download/v{}/moose-cli-{}",
-            version, binarylabel
-        ))
-        .arg("--platform")
-        .arg(architecture)
-        .arg("--load")
-        .arg("--no-cache")
-        .arg("-t")
-        // Using latest for the version tag as the user might want to use its own
-        // version tag, this makes it easy for the automation to re-label the image.
-        .arg(format!("moose-df-deployment-{}:latest", binarylabel))
-        .arg(".")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+    DockerClient::new(settings).buildx(directory, version, architecture, binarylabel)
+}
 
-    let output = child.wait_with_output()?;
-
-    if !output.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            String::from_utf8_lossy(&output.stderr),
-        ));
-    }
-
-    let output_str = String::from_utf8_lossy(&output.stdout);
-    let containers: Vec<String> = output_str
-        .split('\n')
-        .filter(|line| !line.is_empty())
-        .map(|line| from_str(line).expect("Failed to parse container row"))
-        .collect();
-    Ok(containers)
+lazy_static! {
+    pub static ref PORT_ALLOCATED_REGEX: Regex =
+        Regex::new("Bind for \\d+.\\d+.\\d+.\\d+:(\\d+) failed: port is already allocated")
+            .unwrap();
 }


### PR DESCRIPTION
[Demo Video](https://cap.so/s/vvrec78qxy6j13h)

The goal of this is PR is to enable users to specify the container runtime in dev. 
The default is still docker.
You can now configure the path to amazon [Finch](https://github.com/runfinch/finch) for example:
File: `~/.moose/config.toml`

```toml
[dev]
container_cli_path="/usr/local/bin/finch"
```

It also integrates the `DockerClient` utility throughout the codebase, replacing direct calls to the `docker` module. The most important changes include updating various routines to use the new `DockerClient`, removing the `Routine` trait and `RoutineController` struct, and modifying the `top_command_handler` function to utilize `DockerClient`.

Integration of `DockerClient`:

* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL334-R337): Updated the `top_command_handler` function to create and use a `DockerClient` instance for Docker-related operations. [[1]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL334-R337) [[2]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dR365-R368) [[3]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL671-R674)
* [`apps/framework-cli/src/cli/local_webserver.rs`](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR973): Modified the `start` method and `shutdown` function to accept a `Settings` parameter and use `DockerClient` for stopping containers. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR973) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1117-R1119) [[3]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1130-R1134)

Removal of `Routine` trait and `RoutineController`:

* [`apps/framework-cli/src/cli/routines.rs`](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL205-L269): Removed the `Routine` trait, `RunMode` enum, and `RoutineController` struct, along with their associated methods. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL205-L269) [[2]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fR446) [[3]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fR542)
* [`apps/framework-cli/src/cli/routines/clean.rs`](diffhunk://#diff-fa9010eae85593070a4859cfea165587eb64f915ec611641519f4a0e81c29e2eL1-R20): Replaced the `CleanProject` struct and its `Routine` implementation with a `clean_project` function that uses `DockerClient`. [[1]](diffhunk://#diff-fa9010eae85593070a4859cfea165587eb64f915ec611641519f4a0e81c29e2eL1-R20) [[2]](diffhunk://#diff-fa9010eae85593070a4859cfea165587eb64f915ec611641519f4a0e81c29e2eL45)

Updates to routines:

* [`apps/framework-cli/src/cli/routines/dev.rs`](diffhunk://#diff-04ee51f6b0a7f916f9ae079b1f574a94e39904a42406f1a2a568f0b497c63ff2L8-R14): Updated the `run_local_infrastructure` function and related helper functions to use `DockerClient` for Docker operations. [[1]](diffhunk://#diff-04ee51f6b0a7f916f9ae079b1f574a94e39904a42406f1a2a568f0b497c63ff2L8-R14) [[2]](diffhunk://#diff-04ee51f6b0a7f916f9ae079b1f574a94e39904a42406f1a2a568f0b497c63ff2R23-R36) [[3]](diffhunk://#diff-04ee51f6b0a7f916f9ae079b1f574a94e39904a42406f1a2a568f0b497c63ff2L55-R61) [[4]](diffhunk://#diff-04ee51f6b0a7f916f9ae079b1f574a94e39904a42406f1a2a568f0b497c63ff2R128-R130)
* [`apps/framework-cli/src/cli/routines/docker_packager.rs`](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L9-R10): Modified the `create_dockerfile` and `build_dockerfile` functions to accept a `DockerClient` parameter and use it for Docker operations. [[1]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L9-R10) [[2]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L99-R103) [[3]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L111-R115) [[4]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894R193) [[5]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L203-R208) [[6]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L294-R299) [[7]](diffhunk://#diff-6d5f47ad5fac8edd5597639dca40f2540e1219dd47145d0d96aee7970a877894L322-R327)