### PR TITLE
Base work-in-progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +274,15 @@ dependencies = [
  "getrandom",
  "instant",
  "rand",
+]
+
+[[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -1657,7 +1672,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1757,7 +1772,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.5.2",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2028,15 +2043,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3361,8 +3367,8 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3418,7 +3424,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "prost",
  "prost-build",
  "prost-types",
@@ -3617,21 +3623,24 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
 dependencies = [
- "async-trait",
+ "arc-swap",
+ "backon",
  "bytes",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "native-tls",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -4273,16 +4282,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
@@ -4744,7 +4743,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4868,7 +4867,7 @@ dependencies = [
  "prost",
  "rustls-native-certs",
  "rustls-pemfile",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -68,7 +68,8 @@ tokio-cron-scheduler = "0.11.0"
 cron = "0.13.0"
 tokio-stream = "0.1.16"
 indexmap = "2.5.0"
-redis = { version = "0.24.0", features = [
+redis = { version = "0.28.2", features = [
+    "connection-manager",
     "tokio-comp",
     "aio",
     "tokio-native-tls-comp",

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -247,7 +247,7 @@ pub async fn setup_redis_client(project: Arc<Project>) -> anyhow::Result<Arc<Mut
         .await
         .register_message_handler(callback)
         .await;
-    redis_client.lock().await.start_periodic_tasks();
+    redis_client.lock().await.start_periodic_tasks().await;
 
     Ok(redis_client)
 }


### PR DESCRIPTION
This pull request includes significant changes to the Redis client implementation in the `framework-cli` application. The changes focus on improving connection management, adding connection health checks, and enhancing the periodic tasks and message listener functionalities.

### Improvements to Redis Client Connection Management:
* [`apps/framework-cli/Cargo.toml`](diffhunk://#diff-ac90f75b1a99d56a24089c99fac1cc15fa5b024f1c9952670391228124a586dfL71-R72): Updated the `redis` crate version from `0.24.0` to `0.28.2` and added the `connection-manager` feature.
* [`apps/framework-cli/src/infrastructure/redis/redis_client.rs`](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75L67-R99): Replaced the manual connection handling with `ConnectionManager` for better connection management. [[1]](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75L67-R99) [[2]](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75L123-R299)

### Enhancements to Periodic Tasks and Connection Health Checks:
* [`apps/framework-cli/src/infrastructure/redis/redis_client.rs`](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75L123-R299): Added `start_periodic_tasks` method to handle periodic presence updates and reconnection attempts.
* [`apps/framework-cli/src/infrastructure/redis/redis_client.rs`](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75R577-R604): Introduced `check_connection_health` and `attempt_reconnect` methods to ensure the Redis connection is healthy and to handle reconnections if needed.

### Updates to Message Listener:
* [`apps/framework-cli/src/infrastructure/redis/redis_client.rs`](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75L460-L525): Enhanced the `start_message_listener` method to include connection health checks and channel resubscription logic.

### Additional Improvements:
* [`apps/framework-cli/src/cli/routines.rs`](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL250-R250): Fixed the `setup_redis_client` function to await the `start_periodic_tasks` call.
* [`apps/framework-cli/src/infrastructure/redis/redis_client.rs`](diffhunk://#diff-89c061bca9abd44a0239a1758c6bac7bcd2c96e2453fb978166d77e9e092fb75L33-L35): Added `ConnectionStatus` enum to track the connection status and updated the `RedisClient` struct accordingly.

These changes collectively enhance the reliability and maintainability of the Redis client within the `framework-cli` application.