### PR TITLE
optional py workflow input data

### DIFF
--- a/apps/framework-cli/src/framework/python/wrappers/scripts/python_worker_wrapper/activity.py
+++ b/apps/framework-cli/src/framework/python/wrappers/scripts/python_worker_wrapper/activity.py
@@ -60,9 +60,15 @@ def create_activity_for_script(script_name: str) -> Callable:
             input_data = execution_input.input_data.get('data', execution_input.input_data) if execution_input.input_data else {}
             log.info(f"Processed input_data for task: {input_data}")
             if asyncio.iscoroutinefunction(task_func):
-                result = await task_func(input=input_data)
+                if input_data:
+                    result = await task_func(input=input_data)
+                else:
+                    result = await task_func()
             else:
-                result = task_func(input=input_data)
+                if input_data:
+                    result = task_func(input=input_data)
+                else:
+                    result = task_func()
             
             # Validate and encode result
             if not isinstance(result, dict):


### PR DESCRIPTION
For example, you can do `moose-cli workflow run wfname` and just define the task function without arguments

```
@task
def task1():
    return {
        "task": "task1",
        "data": {
            "hello": "world"
        }
    }

@task
def task2(input: dict):
    task2.logger.info(f"task2 input: {input.get("hello")}")

    return {
        "task": "task2",
        "data": None
    }
```

