### PR TITLE
Nicolas/514oss 1387 endpoint to be able to run the moose plan on a remote moose

### DIFF
--- a/.cursor/rules/protobuff.mdc
+++ b/.cursor/rules/protobuff.mdc
@@ -1,6 +1,7 @@
 ---
 description: Best practices to edit and build .proto files
 globs: *.proto
+alwaysApply: false
 ---
 
 DO NOT MAKE BREAKING CHANGES

--- a/.cursor/rules/rust.mdc
+++ b/.cursor/rules/rust.mdc
@@ -1,5 +1,5 @@
 ---
-description: Rust Langauge best practice
+description: Rust Language best practice
 globs: **/*.rs
 alwaysApply: false
 ---

--- a/.cursor/rules/rust.mdc
+++ b/.cursor/rules/rust.mdc
@@ -1,6 +1,7 @@
 ---
-description: Rust Langauge best practices
-globs: *.rs
+description: Rust Langauge best practice
+globs: **/*.rs
+alwaysApply: false
 ---
 # Architectural Rules
 
@@ -31,8 +32,6 @@ globs: *.rs
 - Sanitize inputs to prevent injection attacks.
 - Follow the principle of least privilege when managing permissions.
 - Keep dependencies updated to mitigate vulnerabilities.
-
-
 
 ## Error Handling
 1. Error types should be located near their unit of fallibility
@@ -75,6 +74,15 @@ globs: *.rs
 
 6. Do NOT use anyhow::Result
    - If you see anyhow::Result being used, refactor using this::error
+
+## newtypes
+   - Define Newtypes as Tuple Structs: Create newtypes by wrapping existing types in tuple structs to provide distinct types with specific behaviors.
+	2.	Implement Constructors with Validation: Provide constructors that enforce invariants, ensuring that only valid data can instantiate the newtype.
+	3.	Derive or Implement Essential Traits: Derive standard traits (e.g., Debug, Clone) and manually implement others as needed to integrate seamlessly with Rust’s ecosystem.
+	4.	Utilize Conversion Traits: Implement From and TryFrom for ergonomic conversions between newtypes and their underlying types, handling infallible and fallible conversions appropriately.
+	5.	Provide Access to Inner Data: Implement traits like AsRef, Deref, or Borrow to grant controlled access to the inner data of the newtype.
+	6.	Avoid Circumventing Validations: Prevent bypassing newtype invariants by restricting direct access to the inner type, ensuring all interactions respect the enforced constraints.
+	7.	Reduce Boilerplate with Crates: Use crates like derive_more or nutype to minimize repetitive code when implementing common traits and behaviors for newtypes.
 
 ## Constants
 - Use `const` for all static values in Rust unless interior mutability or runtime evaluation is required.

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -28,7 +28,6 @@ use routines::datamodel::parse_and_generate;
 use routines::docker_packager::{build_dockerfile, create_dockerfile};
 use routines::ls::{list_db, list_streaming};
 use routines::metrics_console::run_console;
-use routines::plan;
 use routines::ps::show_processes;
 use routines::scripts::{
     get_workflow_status, init_workflow, list_workflows, pause_workflow, run_workflow,
@@ -557,7 +556,7 @@ async fn top_command_handler(
                 "production infrastructure".to_string(),
             )))
         }
-        Commands::Plan {} => {
+        Commands::Plan { url, token } => {
             info!("Running plan command");
             let project = load_project()?;
 
@@ -568,7 +567,10 @@ async fn top_command_handler(
             );
 
             check_project_name(&project.name())?;
-            plan(&project).await.map_err(|e| {
+
+            let result = routines::remote_plan(&project, &url, &token).await;
+
+            result.map_err(|e| {
                 RoutineFailure::error(Message {
                     action: "Plan".to_string(),
                     details: format!("Failed to plan changes: {:?}", e),

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -568,7 +568,7 @@ async fn top_command_handler(
 
             check_project_name(&project.name())?;
 
-            let result = routines::remote_plan(&project, &url, &token).await;
+            let result = routines::remote_plan(&project, url, token).await;
 
             result.map_err(|e| {
                 RoutineFailure::error(Message {

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -51,9 +51,18 @@ pub enum Commands {
         #[arg(long, default_value = "false")]
         write_infra_map: bool,
     },
-    /// [Not Ready] Displays the changes that will be applied to the infrastructure during the next deployment
-    /// to production, consdering the current state of the project
-    Plan {},
+    /// Displays the changes that will be applied to the infrastructure during the next deployment
+    /// to production, considering the current state of the project
+    Plan {
+        /// URL of the remote Moose instance (default: http://localhost:4000)
+        #[arg(long)]
+        url: Option<String>,
+
+        /// API token for authentication with the remote Moose instance
+        /// This token will be sent as a Bearer token in the Authorization header
+        #[arg(long)]
+        token: Option<String>,
+    },
     /// Starts a local development environment to build your data-intensive app or service
     Dev {},
     /// Start a remote environment for use in cloud deployments

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -9,14 +9,9 @@ use crate::cli::display::with_spinner;
 use crate::framework::controller::RouteMeta;
 
 use crate::framework::core::infrastructure::api_endpoint::APIType;
-use crate::framework::core::infrastructure::topic::Topic;
-use crate::framework::core::infrastructure::view::View;
 use crate::framework::core::infrastructure_map::Change;
 use crate::framework::core::infrastructure_map::{ApiChange, InfrastructureMap};
-use crate::framework::core::infrastructure_map::{
-    ColumnChange, InfraChanges, InitialDataLoadChange, OlapChange, ProcessChange, StreamingChange,
-    TableChange,
-};
+use crate::framework::core::infrastructure_map::{InfraChanges, OlapChange, TableChange};
 use crate::metrics::Metrics;
 use crate::utilities::auth::{get_claims, validate_jwt};
 
@@ -78,7 +73,6 @@ use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
 use crate::framework::core::infra_reality_checker::InfraDiscrepancies;
-use crate::framework::core::infrastructure::api_endpoint::ApiEndpoint;
 use crate::framework::core::infrastructure::table::Table;
 use crate::infrastructure::olap::clickhouse_alt_client::{get_pool, store_infrastructure_map};
 

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1713,7 +1713,7 @@ async fn admin_plan_route(
             // Prepare the response
             let response = PlanResponse {
                 status: "success".to_string(),
-                changes: changes,
+                changes,
             };
 
             // Serialize the response to JSON

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1713,7 +1713,7 @@ async fn admin_plan_route(
             // Prepare the response
             let response = PlanResponse {
                 status: "success".to_string(),
-                changes: changes.into(),
+                changes: changes,
             };
 
             // Serialize the response to JSON

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -612,7 +612,7 @@ pub async fn remote_plan(
     // Determine the target URL
     let target_url = match url {
         Some(u) => format!("{}/admin/plan", u.trim_end_matches('/')),
-        None => format!("http://localhost:4000/admin/plan"),
+        None => "http://localhost:4000/admin/plan".to_string(),
     };
 
     display::show_message_wrapper(

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -99,10 +99,7 @@ use tokio::time::{interval, Duration};
 use crate::cli::routines::openapi::openapi;
 use crate::framework::controller::RouteMeta;
 use crate::framework::core::execute::execute_initial_infra_change;
-use crate::framework::core::infrastructure_map::{
-    ApiChange, Change, ColumnChange, InfraChanges, InfrastructureMap, InitialDataLoadChange,
-    OlapChange, ProcessChange, StreamingChange, TableChange,
-};
+use crate::framework::core::infrastructure_map::InfrastructureMap;
 use crate::infrastructure::olap::clickhouse_alt_client::{get_pool, store_infrastructure_map};
 use crate::infrastructure::processes::cron_registry::CronRegistry;
 use crate::infrastructure::processes::kafka_clickhouse_sync::clickhouse_writing_pause_button;
@@ -118,7 +115,6 @@ use super::{Message, MessageType};
 use crate::framework::core::plan::plan_changes;
 use crate::framework::core::plan::InfraPlan;
 use crate::framework::core::primitive_map::PrimitiveMap;
-use serde::Deserialize;
 
 pub mod auth;
 pub mod block;

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -99,8 +99,10 @@ use tokio::time::{interval, Duration};
 use crate::cli::routines::openapi::openapi;
 use crate::framework::controller::RouteMeta;
 use crate::framework::core::execute::execute_initial_infra_change;
-use crate::framework::core::infrastructure_map::InfrastructureMap;
-use crate::framework::core::plan::plan_changes;
+use crate::framework::core::infrastructure_map::{
+    ApiChange, Change, ColumnChange, InfraChanges, InfrastructureMap, InitialDataLoadChange,
+    OlapChange, ProcessChange, StreamingChange, TableChange,
+};
 use crate::infrastructure::olap::clickhouse_alt_client::{get_pool, store_infrastructure_map};
 use crate::infrastructure::processes::cron_registry::CronRegistry;
 use crate::infrastructure::processes::kafka_clickhouse_sync::clickhouse_writing_pause_button;
@@ -108,10 +110,15 @@ use crate::project::Project;
 
 use super::super::metrics::Metrics;
 use super::display;
-use super::local_webserver::Webserver;
+use super::local_webserver::{PlanRequest, PlanResponse, Webserver};
 use super::settings::Settings;
 use super::watcher::FileWatcher;
 use super::{Message, MessageType};
+
+use crate::framework::core::plan::plan_changes;
+use crate::framework::core::plan::InfraPlan;
+use crate::framework::core::primitive_map::PrimitiveMap;
+use serde::Deserialize;
 
 pub mod auth;
 pub mod block;
@@ -171,7 +178,7 @@ impl RoutineSuccess {
     }
 
     pub fn show(&self) {
-        show_message!(self.message_type, self.message);
+        display::show_message_wrapper(self.message_type, self.message.clone());
     }
 }
 
@@ -212,12 +219,12 @@ pub async fn setup_redis_client(project: Arc<Project>) -> anyhow::Result<Arc<Mut
         )
     };
 
-    show_message!(
+    display::show_message_wrapper(
         MessageType::Info,
         Message {
             action: "Node Id:".to_string(),
             details: format!("{}::{}", service_name, instance_id),
-        }
+        },
     );
 
     // Register the leadership lock
@@ -371,12 +378,12 @@ pub async fn start_development_mode(
     redis_client: Arc<Mutex<RedisClient>>,
     settings: &Settings,
 ) -> anyhow::Result<()> {
-    show_message!(
+    display::show_message_wrapper(
         MessageType::Info,
         Message {
             action: "Starting".to_string(),
             details: "development mode".to_string(),
-        }
+        },
     );
 
     let server_config = project.http_server_config.clone();
@@ -486,12 +493,12 @@ pub async fn start_production_mode(
     metrics: Arc<Metrics>,
     redis_client: Arc<Mutex<RedisClient>>,
 ) -> anyhow::Result<()> {
-    show_message!(
+    display::show_message_wrapper(
         MessageType::Success,
         Message {
             action: "Starting".to_string(),
             details: "production mode".to_string(),
-        }
+        },
     );
 
     if std::env::var("MOOSE_TEST__CRASH").is_ok() {
@@ -575,22 +582,118 @@ pub async fn start_production_mode(
     Ok(())
 }
 
-pub async fn plan(project: &Project) -> anyhow::Result<()> {
-    let mut client = get_pool(&project.clickhouse_config).get_handle().await?;
+/// Authentication for remote plan requests:
+///
+/// When making requests to a remote Moose instance, authentication is required for admin operations.
+/// The authentication token is sent as a Bearer token in the Authorization header.
+///
+/// The token is determined in the following order of precedence:
+/// 1. Command line parameter: `--token <value>`
+/// 2. Environment variable: `MOOSE_ADMIN_TOKEN`
+/// 3. Project configuration: `authentication.admin_api_key` in moose.yaml
+///
+/// Note that the admin_api_key in the project configuration is typically stored in hashed form,
+/// so options 1 or 2 are recommended for remote plan operations.
+///
+/// Simulates a plan command against a remote Moose instance
+///
+/// # Arguments
+/// * `project` - Reference to the project
+/// * `url` - Optional URL of the remote Moose instance (default: http://localhost:4000)
+/// * `token` - Optional API token for authentication (overrides MOOSE_ADMIN_TOKEN env var)
+///
+/// # Returns
+/// * Result indicating success or failure
+pub async fn remote_plan(
+    project: &Project,
+    url: &Option<String>,
+    token: &Option<String>,
+) -> anyhow::Result<()> {
+    // Build the inframap from the local project
+    let primitive_map = PrimitiveMap::load(project).await?;
+    let local_infra_map = InfrastructureMap::new(project, primitive_map);
 
-    let plan_results = plan_changes(&mut client, project).await?;
+    // Determine the target URL
+    let target_url = match url {
+        Some(u) => format!("{}/admin/plan", u.trim_end_matches('/')),
+        None => format!("http://localhost:4000/admin/plan"),
+    };
 
-    display::show_changes(&plan_results);
+    display::show_message_wrapper(
+        MessageType::Info,
+        Message {
+            action: "Remote Plan".to_string(),
+            details: format!(
+                "Comparing local project code with remote instance at {}",
+                target_url
+            ),
+        },
+    );
 
-    if plan_results.changes.is_empty() {
-        show_message!(
+    let request_body = PlanRequest {
+        infra_map: local_infra_map,
+    };
+
+    // Get authentication token - prioritize command line parameter, then env var, then project config
+    let auth_token = token
+        .clone()
+        .or_else(|| std::env::var("MOOSE_ADMIN_TOKEN").ok())
+        .ok_or_else(|| anyhow::anyhow!("Authentication token required. Please provide token via --token parameter or MOOSE_ADMIN_TOKEN environment variable"))?;
+
+    // Create HTTP client
+    let client = reqwest::Client::new();
+    let mut request_builder = client
+        .post(&target_url)
+        .header("Content-Type", "application/json")
+        .json(&request_body);
+
+    // Add authorization header if token is available
+    request_builder = request_builder.header("Authorization", format!("Bearer {}", auth_token));
+
+    // Send request
+    let response = request_builder.send().await?;
+
+    // Check response status
+    if !response.status().is_success() {
+        let error_text = response.text().await?;
+        return Err(anyhow::anyhow!(
+            "Failed to get plan from remote instance: {}",
+            error_text
+        ));
+    }
+
+    // Parse response
+    let plan_response: PlanResponse = response.json().await?;
+
+    // Display results
+    display::show_message_wrapper(
+        MessageType::Success,
+        Message {
+            action: "Remote Plan".to_string(),
+            details: "Retrieved plan from remote instance".to_string(),
+        },
+    );
+
+    // Check if there are any changes to display
+    if plan_response.changes.is_empty() {
+        display::show_message_wrapper(
             MessageType::Info,
             Message {
-                action: "No".to_string(),
-                details: "changes detected".to_string(),
-            }
+                action: "No Changes".to_string(),
+                details: "No changes detected".to_string(),
+            },
         );
+        return Ok(());
     }
+
+    // Create a temporary InfraPlan to use with the show_changes function
+    let temp_plan = InfraPlan {
+        changes: plan_response.changes,
+        target_infra_map: InfrastructureMap::new(project, PrimitiveMap::default()),
+    };
+
+    // Use the existing display method to show the changes
+    display::show_changes(&temp_plan);
 
     Ok(())
 }

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -245,55 +245,142 @@ impl InfrastructureMap {
         target_tables: &HashMap<String, Table>,
         olap_changes: &mut Vec<OlapChange>,
     ) {
+        log::info!(
+            "Analyzing table differences between {} source tables and {} target tables",
+            self_tables.len(),
+            target_tables.len()
+        );
+
+        let mut table_updates = 0;
+        let mut table_removals = 0;
+        let mut table_additions = 0;
+
         for (id, table) in self_tables {
             if let Some(target_table) = target_tables.get(id) {
                 if table != target_table {
                     // Debug logging to identify what's different
+                    log::debug!("Table '{}' has differences:", id);
                     if table.name != target_table.name {
                         log::debug!(
-                            "Table {} differs in name: {} vs {}",
-                            id,
+                            "  - Name changed: '{}' -> '{}'",
                             table.name,
                             target_table.name
                         );
                     }
                     if table.columns != target_table.columns {
-                        log::debug!("Table {} differs in columns", id);
+                        log::debug!("  - Column differences detected");
+                        // Detail column differences
+                        for col in &table.columns {
+                            if !target_table
+                                .columns
+                                .iter()
+                                .any(|c| c.name == col.name && c == col)
+                            {
+                                if target_table.columns.iter().any(|c| c.name == col.name) {
+                                    log::debug!("    * Column '{}' modified", col.name);
+                                } else {
+                                    log::debug!("    * Column '{}' removed", col.name);
+                                }
+                            }
+                        }
+                        for col in &target_table.columns {
+                            if !table.columns.iter().any(|c| c.name == col.name) {
+                                log::debug!("    * Column '{}' added", col.name);
+                            }
+                        }
                     }
                     if table.order_by != target_table.order_by {
                         log::debug!(
-                            "Table {} differs in order_by: {:?} vs {:?}",
-                            id,
+                            "  - Order by changed: {:?} -> {:?}",
                             table.order_by,
                             target_table.order_by
                         );
                     }
                     if table.deduplicate != target_table.deduplicate {
                         log::debug!(
-                            "Table {} differs in deduplicate: {} vs {}",
-                            id,
+                            "  - Deduplicate changed: {} -> {}",
                             table.deduplicate,
                             target_table.deduplicate
                         );
                     }
                     if table.version != target_table.version {
                         log::debug!(
-                            "Table {} differs in version: {} vs {}",
-                            id,
+                            "  - Version changed: {} -> {}",
                             table.version,
                             target_table.version
                         );
                     }
                     if table.source_primitive != target_table.source_primitive {
                         log::debug!(
-                            "Table {} differs in source_primitive: {:?} vs {:?}",
-                            id,
+                            "  - Source primitive changed: {:?} -> {:?}",
                             table.source_primitive,
                             target_table.source_primitive
                         );
                     }
 
                     let column_changes = compute_table_diff(table, target_table);
+
+                    // Log column change details
+                    if !column_changes.is_empty() {
+                        log::debug!("Column changes for table '{}':", table.name);
+                        for change in &column_changes {
+                            match change {
+                                ColumnChange::Added(col) => {
+                                    log::debug!(
+                                        "  - Added column: {} ({})",
+                                        col.name,
+                                        col.data_type
+                                    );
+                                }
+                                ColumnChange::Removed(col) => {
+                                    log::debug!(
+                                        "  - Removed column: {} ({})",
+                                        col.name,
+                                        col.data_type
+                                    );
+                                }
+                                ColumnChange::Updated { before, after } => {
+                                    log::debug!("  - Updated column: {}", before.name);
+                                    if before.data_type != after.data_type {
+                                        log::debug!(
+                                            "    * Type changed: {:?} -> {:?}",
+                                            before.data_type,
+                                            after.data_type
+                                        );
+                                    }
+                                    if before.required != after.required {
+                                        log::debug!(
+                                            "    * Required changed: {:?} -> {:?}",
+                                            before.required,
+                                            after.required
+                                        );
+                                    }
+                                    if before.unique != after.unique {
+                                        log::debug!(
+                                            "    * Unique changed: {:?} -> {:?}",
+                                            before.unique,
+                                            after.unique
+                                        );
+                                    }
+                                    if before.primary_key != after.primary_key {
+                                        log::debug!(
+                                            "    * Primary key changed: {:?} -> {:?}",
+                                            before.primary_key,
+                                            after.primary_key
+                                        );
+                                    }
+                                    if before.default != after.default {
+                                        log::debug!(
+                                            "    * Default value changed: {:?} -> {:?}",
+                                            before.default,
+                                            after.default
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     let order_by_change = if table.order_by != target_table.order_by {
                         OrderByChange {
                             before: table.order_by.clone(),
@@ -311,6 +398,7 @@ impl InfrastructureMap {
                         || table.order_by != target_table.order_by
                         || table.deduplicate != target_table.deduplicate
                     {
+                        table_updates += 1;
                         olap_changes.push(OlapChange::Table(TableChange::Updated {
                             name: table.name.clone(),
                             column_changes,
@@ -321,15 +409,33 @@ impl InfrastructureMap {
                     }
                 }
             } else {
+                log::debug!("Table '{}' removed", table.name);
+                table_removals += 1;
                 olap_changes.push(OlapChange::Table(TableChange::Removed(table.clone())));
             }
         }
 
         for (id, table) in target_tables {
             if !self_tables.contains_key(id) {
+                log::debug!(
+                    "Table '{}' added with {} columns",
+                    table.name,
+                    table.columns.len()
+                );
+                for col in &table.columns {
+                    log::trace!("  - Column: {} ({})", col.name, col.data_type);
+                }
+                table_additions += 1;
                 olap_changes.push(OlapChange::Table(TableChange::Added(table.clone())));
             }
         }
+
+        log::info!(
+            "Table changes: {} added, {} removed, {} updated",
+            table_additions,
+            table_removals,
+            table_updates
+        );
     }
 
     // we want to add the prefix as soon as possible
@@ -543,7 +649,8 @@ impl InfrastructureMap {
         // consumption api endpoints
         let consumption_api_web_server = ConsumptionApiWebServer {};
         for api_endpoint in primitive_map.consumption.endpoint_files {
-            api_endpoints.insert(api_endpoint.id(), api_endpoint.into());
+            let api_endpoint_infra = ApiEndpoint::from(api_endpoint);
+            api_endpoints.insert(api_endpoint_infra.id(), api_endpoint_infra);
         }
 
         // Orchestration workers
@@ -577,10 +684,16 @@ impl InfrastructureMap {
         // =================================================================
         //                              Topics
         // =================================================================
+        log::info!("Analyzing changes in Topics...");
+        let mut topic_updates = 0;
+        let mut topic_removals = 0;
+        let mut topic_additions = 0;
 
         for (id, topic) in &self.topics {
             if let Some(target_topic) = target_map.topics.get(id) {
                 if topic != target_topic {
+                    log::debug!("Topic updated: {} ({})", topic.name, id);
+                    topic_updates += 1;
                     changes
                         .streaming_engine_changes
                         .push(StreamingChange::Topic(Change::<Topic>::Updated {
@@ -589,6 +702,8 @@ impl InfrastructureMap {
                         }));
                 }
             } else {
+                log::debug!("Topic removed: {} ({})", topic.name, id);
+                topic_removals += 1;
                 changes
                     .streaming_engine_changes
                     .push(StreamingChange::Topic(Change::<Topic>::Removed(Box::new(
@@ -599,6 +714,8 @@ impl InfrastructureMap {
 
         for (id, topic) in &target_map.topics {
             if !self.topics.contains_key(id) {
+                log::debug!("Topic added: {} ({})", topic.name, id);
+                topic_additions += 1;
                 changes
                     .streaming_engine_changes
                     .push(StreamingChange::Topic(Change::<Topic>::Added(Box::new(
@@ -607,13 +724,26 @@ impl InfrastructureMap {
             }
         }
 
+        log::info!(
+            "Topic changes: {} added, {} removed, {} updated",
+            topic_additions,
+            topic_removals,
+            topic_updates
+        );
+
         // =================================================================
         //                              API Endpoints
         // =================================================================
+        log::info!("Analyzing changes in API Endpoints...");
+        let mut api_updates = 0;
+        let mut api_removals = 0;
+        let mut api_additions = 0;
 
         for (id, api_endpoint) in &self.api_endpoints {
             if let Some(target_api_endpoint) = target_map.api_endpoints.get(id) {
                 if api_endpoint != target_api_endpoint {
+                    log::debug!("API Endpoint updated: {}", id);
+                    api_updates += 1;
                     changes.api_changes.push(ApiChange::ApiEndpoint(
                         Change::<ApiEndpoint>::Updated {
                             before: Box::new(api_endpoint.clone()),
@@ -622,6 +752,8 @@ impl InfrastructureMap {
                     ));
                 }
             } else {
+                log::debug!("API Endpoint removed: {}", id);
+                api_removals += 1;
                 changes
                     .api_changes
                     .push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Removed(
@@ -632,6 +764,8 @@ impl InfrastructureMap {
 
         for (id, api_endpoint) in &target_map.api_endpoints {
             if !self.api_endpoints.contains_key(id) {
+                log::debug!("API Endpoint added: {}", id);
+                api_additions += 1;
                 changes
                     .api_changes
                     .push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Added(
@@ -640,19 +774,35 @@ impl InfrastructureMap {
             }
         }
 
+        log::info!(
+            "API Endpoint changes: {} added, {} removed, {} updated",
+            api_additions,
+            api_removals,
+            api_updates
+        );
+
         // =================================================================
         //                              Tables
         // =================================================================
-
+        log::info!("Analyzing changes in Tables...");
+        let olap_changes_len_before = changes.olap_changes.len();
         Self::diff_tables(&self.tables, &target_map.tables, &mut changes.olap_changes);
+        let table_changes = changes.olap_changes.len() - olap_changes_len_before;
+        log::info!("Table changes detected: {}", table_changes);
 
         // =================================================================
         //                              Views
         // =================================================================
+        log::info!("Analyzing changes in Views...");
+        let mut view_updates = 0;
+        let mut view_removals = 0;
+        let mut view_additions = 0;
 
         for (id, view) in &self.views {
             if let Some(target_view) = target_map.views.get(id) {
                 if view != target_view {
+                    log::debug!("View updated: {}", view.name);
+                    view_updates += 1;
                     changes
                         .olap_changes
                         .push(OlapChange::View(Change::<View>::Updated {
@@ -661,6 +811,8 @@ impl InfrastructureMap {
                         }));
                 }
             } else {
+                log::debug!("View removed: {}", view.name);
+                view_removals += 1;
                 changes
                     .olap_changes
                     .push(OlapChange::View(Change::<View>::Removed(Box::new(
@@ -671,6 +823,8 @@ impl InfrastructureMap {
 
         for (id, view) in &target_map.views {
             if !self.views.contains_key(id) {
+                log::debug!("View added: {}", view.name);
+                view_additions += 1;
                 changes
                     .olap_changes
                     .push(OlapChange::View(Change::<View>::Added(Box::new(
@@ -679,15 +833,28 @@ impl InfrastructureMap {
             }
         }
 
+        log::info!(
+            "View changes: {} added, {} removed, {} updated",
+            view_additions,
+            view_removals,
+            view_updates
+        );
+
         // =================================================================
         //                              Topic to Table Sync Processes
         // =================================================================
+        log::info!("Analyzing changes in Topic to Table Sync Processes...");
+        let mut t2t_sync_updates = 0;
+        let mut t2t_sync_removals = 0;
+        let mut t2t_sync_additions = 0;
 
         for (id, topic_to_table_sync_process) in &self.topic_to_table_sync_processes {
             if let Some(target_topic_to_table_sync_process) =
                 target_map.topic_to_table_sync_processes.get(id)
             {
                 if topic_to_table_sync_process != target_topic_to_table_sync_process {
+                    log::debug!("Topic to Table Sync Process updated: {}", id);
+                    t2t_sync_updates += 1;
                     changes
                         .processes_changes
                         .push(ProcessChange::TopicToTableSyncProcess(Change::<
@@ -698,6 +865,8 @@ impl InfrastructureMap {
                         }));
                 }
             } else {
+                log::debug!("Topic to Table Sync Process removed: {}", id);
+                t2t_sync_removals += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::TopicToTableSyncProcess(Change::<
@@ -710,6 +879,8 @@ impl InfrastructureMap {
 
         for (id, topic_to_table_sync_process) in &target_map.topic_to_table_sync_processes {
             if !self.topic_to_table_sync_processes.contains_key(id) {
+                log::debug!("Topic to Table Sync Process added: {}", id);
+                t2t_sync_additions += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::TopicToTableSyncProcess(Change::<
@@ -720,15 +891,28 @@ impl InfrastructureMap {
             }
         }
 
+        log::info!(
+            "Topic to Table Sync Process changes: {} added, {} removed, {} updated",
+            t2t_sync_additions,
+            t2t_sync_removals,
+            t2t_sync_updates
+        );
+
         // =================================================================
         //                              Topic to Topic Sync Processes
         // =================================================================
+        log::info!("Analyzing changes in Topic to Topic Sync Processes...");
+        let mut t2t_topic_sync_updates = 0;
+        let mut t2t_topic_sync_removals = 0;
+        let mut t2t_topic_sync_additions = 0;
 
         for (id, topic_to_topic_sync_process) in &self.topic_to_topic_sync_processes {
             if let Some(target_topic_to_topic_sync_process) =
                 target_map.topic_to_topic_sync_processes.get(id)
             {
                 if topic_to_topic_sync_process != target_topic_to_topic_sync_process {
+                    log::debug!("Topic to Topic Sync Process updated: {}", id);
+                    t2t_topic_sync_updates += 1;
                     changes
                         .processes_changes
                         .push(ProcessChange::TopicToTopicSyncProcess(Change::<
@@ -739,6 +923,8 @@ impl InfrastructureMap {
                         }));
                 }
             } else {
+                log::debug!("Topic to Topic Sync Process removed: {}", id);
+                t2t_topic_sync_removals += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::TopicToTopicSyncProcess(Change::<
@@ -751,6 +937,8 @@ impl InfrastructureMap {
 
         for (id, topic_to_topic_sync_process) in &target_map.topic_to_topic_sync_processes {
             if !self.topic_to_topic_sync_processes.contains_key(id) {
+                log::debug!("Topic to Topic Sync Process added: {}", id);
+                t2t_topic_sync_additions += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::TopicToTopicSyncProcess(Change::<
@@ -761,9 +949,20 @@ impl InfrastructureMap {
             }
         }
 
+        log::info!(
+            "Topic to Topic Sync Process changes: {} added, {} removed, {} updated",
+            t2t_topic_sync_additions,
+            t2t_topic_sync_removals,
+            t2t_topic_sync_updates
+        );
+
         // =================================================================
         //                             Function Processes
         // =================================================================
+        log::info!("Analyzing changes in Function Processes...");
+        let mut function_updates = 0;
+        let mut function_removals = 0;
+        let mut function_additions = 0;
 
         for (id, function_process) in &self.function_processes {
             if let Some(target_function_process) = target_map.function_processes.get(id) {
@@ -771,6 +970,8 @@ impl InfrastructureMap {
                 // dependendant on changing one file, but also on its dependencies. Untill we are able to
                 // properly compare the function processes wholisticaly (File + Dependencies), we will just
                 // assume that the function process has changed.
+                log::debug!("Function Process updated: {}", id);
+                function_updates += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::FunctionProcess(
@@ -780,6 +981,8 @@ impl InfrastructureMap {
                         },
                     ));
             } else {
+                log::debug!("Function Process removed: {}", id);
+                function_removals += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::FunctionProcess(
@@ -790,6 +993,8 @@ impl InfrastructureMap {
 
         for (id, function_process) in &target_map.function_processes {
             if !self.function_processes.contains_key(id) {
+                log::debug!("Function Process added: {}", id);
+                function_additions += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::FunctionProcess(
@@ -798,17 +1003,37 @@ impl InfrastructureMap {
             }
         }
 
+        log::info!(
+            "Function Process changes: {} added, {} removed, {} updated",
+            function_additions,
+            function_removals,
+            function_updates
+        );
+
         // =================================================================
         //                             Initial Data Loads
         // =================================================================
+        log::info!("Analyzing changes in Initial Data Loads...");
+        let mut data_load_changes = 0;
+
         for (id, load) in &target_map.initial_data_loads {
             let existing = self.initial_data_loads.get(id);
             match existing {
-                None => changes
-                    .initial_data_loads
-                    .push(InitialDataLoadChange::Addition(load.clone())),
+                None => {
+                    log::debug!("Initial Data Load added: {}", id);
+                    data_load_changes += 1;
+                    changes
+                        .initial_data_loads
+                        .push(InitialDataLoadChange::Addition(load.clone()));
+                }
                 Some(existing) => match existing.status {
                     InitialDataLoadStatus::InProgress(resume_from) => {
+                        log::debug!(
+                            "Initial Data Load resumption: {} (from {})",
+                            id,
+                            resume_from
+                        );
+                        data_load_changes += 1;
                         changes
                             .initial_data_loads
                             .push(InitialDataLoadChange::Resumption {
@@ -816,14 +1041,19 @@ impl InfrastructureMap {
                                 load: load.clone(),
                             });
                     }
-                    InitialDataLoadStatus::Completed => {}
+                    InitialDataLoadStatus::Completed => {
+                        log::debug!("Initial Data Load already completed: {}", id);
+                    }
                 },
             }
         }
 
+        log::info!("Initial Data Load changes: {}", data_load_changes);
+
         // =================================================================
         //                             Blocks Processes
         // =================================================================
+        log::info!("Analyzing changes in OLAP Processes...");
 
         // Until we refactor to have multiple processes, we will consider that we need to restart
         // the process all the times and the blocks changes all the time.
@@ -831,6 +1061,7 @@ impl InfrastructureMap {
         // the process if there are changes
 
         // currently we assume there is always a change and restart the processes
+        log::debug!("OLAP Process updated (assumed for now)");
         changes.processes_changes.push(ProcessChange::OlapProcess(
             Change::<OlapProcess>::Updated {
                 before: Box::new(OlapProcess {}),
@@ -841,12 +1072,13 @@ impl InfrastructureMap {
         // =================================================================
         //                          Consumption Process
         // =================================================================
+        log::info!("Analyzing changes in Consumption API Web Server...");
 
         // We are currently not tracking individual consumption endpoints, so we will just restart
         // the consumption web server when something changed. we might want to change that in the future
         // to be able to only make changes when something in the dependency tree of a consumption api has
         // changed.
-
+        log::debug!("Consumption API Web Server updated (assumed for now)");
         changes
             .processes_changes
             .push(ProcessChange::ConsumptionApiWebServer(Change::<
@@ -859,10 +1091,16 @@ impl InfrastructureMap {
         // =================================================================
         //                      Orchestration Workers
         // =================================================================
+        log::info!("Analyzing changes in Orchestration Workers...");
+        let mut worker_updates = 0;
+        let mut worker_removals = 0;
+        let mut worker_additions = 0;
 
         for (id, orchestration_worker) in &self.orchestration_workers {
             if let Some(target_orchestration_worker) = target_map.orchestration_workers.get(id) {
                 // Until we track individual files changes, we want workers to be restarted for every change
+                log::debug!("Orchestration Worker updated: {}", id);
+                worker_updates += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::OrchestrationWorker(Change::<
@@ -872,6 +1110,8 @@ impl InfrastructureMap {
                         after: Box::new(target_orchestration_worker.clone()),
                     }));
             } else {
+                log::debug!("Orchestration Worker removed: {}", id);
+                worker_removals += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::OrchestrationWorker(Change::<
@@ -884,6 +1124,8 @@ impl InfrastructureMap {
 
         for (id, orchestration_worker) in &target_map.orchestration_workers {
             if !self.orchestration_workers.contains_key(id) {
+                log::debug!("Orchestration Worker added: {}", id);
+                worker_additions += 1;
                 changes
                     .processes_changes
                     .push(ProcessChange::OrchestrationWorker(Change::<
@@ -893,6 +1135,23 @@ impl InfrastructureMap {
                     )));
             }
         }
+
+        log::info!(
+            "Orchestration Worker changes: {} added, {} removed, {} updated",
+            worker_additions,
+            worker_removals,
+            worker_updates
+        );
+
+        // Summarize total changes
+        log::info!(
+            "Total changes: {} OLAP, {} Process, {} API, {} Streaming, {} Initial Data Load",
+            changes.olap_changes.len(),
+            changes.processes_changes.len(),
+            changes.api_changes.len(),
+            changes.streaming_engine_changes.len(),
+            changes.initial_data_loads.len()
+        );
 
         changes
     }
@@ -1152,6 +1411,7 @@ impl InfrastructureMap {
 }
 
 pub fn compute_table_diff(before: &Table, after: &Table) -> Vec<ColumnChange> {
+    log::debug!("Computing detailed diff for table '{}'", before.name);
     let mut diff = Vec::new();
 
     // Check for added or modified columns
@@ -1159,6 +1419,44 @@ pub fn compute_table_diff(before: &Table, after: &Table) -> Vec<ColumnChange> {
         match before.columns.iter().find(|c| c.name == after_col.name) {
             // If the column is in the before table, but different, then it is modified
             Some(before_col) if before_col != after_col => {
+                log::trace!("Column '{}' has been modified", before_col.name);
+                // Log specific differences
+                if before_col.data_type != after_col.data_type {
+                    log::trace!(
+                        "  - Type changed: {:?} -> {:?}",
+                        before_col.data_type,
+                        after_col.data_type
+                    );
+                }
+                if before_col.required != after_col.required {
+                    log::trace!(
+                        "  - Required changed: {} -> {}",
+                        before_col.required,
+                        after_col.required
+                    );
+                }
+                if before_col.unique != after_col.unique {
+                    log::trace!(
+                        "  - Unique changed: {} -> {}",
+                        before_col.unique,
+                        after_col.unique
+                    );
+                }
+                if before_col.primary_key != after_col.primary_key {
+                    log::trace!(
+                        "  - Primary key changed: {} -> {}",
+                        before_col.primary_key,
+                        after_col.primary_key
+                    );
+                }
+                if before_col.default != after_col.default {
+                    log::trace!(
+                        "  - Default value changed: {:?} -> {:?}",
+                        before_col.default,
+                        after_col.default
+                    );
+                }
+
                 diff.push(ColumnChange::Updated {
                     before: before_col.clone(),
                     after: after_col.clone(),
@@ -1166,19 +1464,32 @@ pub fn compute_table_diff(before: &Table, after: &Table) -> Vec<ColumnChange> {
             }
             // If the column is not in the before table, then it is added
             None => {
+                log::trace!(
+                    "Column '{}' has been added with type {:?}",
+                    after_col.name,
+                    after_col.data_type
+                );
                 diff.push(ColumnChange::Added(after_col.clone()));
             }
-            _ => {}
+            _ => {
+                log::trace!("Column '{}' unchanged", after_col.name);
+            }
         }
     }
 
     // Check for dropped columns
     for before_col in &before.columns {
         if !after.columns.iter().any(|c| c.name == before_col.name) {
+            log::trace!("Column '{}' has been removed", before_col.name);
             diff.push(ColumnChange::Removed(before_col.clone()));
         }
     }
 
+    log::debug!(
+        "Found {} column changes for table '{}'",
+        diff.len(),
+        before.name
+    );
     diff
 }
 

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -91,20 +91,20 @@ impl PrimitiveTypes {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ColumnChange {
     Added(Column),
     Removed(Column),
     Updated { before: Column, after: Column },
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderByChange {
     pub before: Vec<String>,
     pub after: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum TableChange {
     Added(Table),
@@ -118,7 +118,7 @@ pub enum TableChange {
     },
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Change<T: Serialize> {
     Added(Box<T>),
     Removed(Box<T>),
@@ -126,7 +126,7 @@ pub enum Change<T: Serialize> {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum InfraChange {
     Olap(OlapChange),
     Streaming(StreamingChange),
@@ -134,24 +134,24 @@ pub enum InfraChange {
     Process(ProcessChange),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum OlapChange {
     Table(TableChange),
     View(Change<View>),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StreamingChange {
     Topic(Change<Topic>),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ApiChange {
     ApiEndpoint(Change<ApiEndpoint>),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProcessChange {
     TopicToTableSyncProcess(Change<TopicToTableSyncProcess>),
     TopicToTopicSyncProcess(Change<TopicToTopicSyncProcess>),
@@ -161,7 +161,7 @@ pub enum ProcessChange {
     OrchestrationWorker(Change<OrchestrationWorker>),
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InfraChanges {
     pub olap_changes: Vec<OlapChange>,
     pub processes_changes: Vec<ProcessChange>,
@@ -170,7 +170,7 @@ pub struct InfraChanges {
     pub initial_data_loads: Vec<InitialDataLoadChange>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum InitialDataLoadChange {
     Addition(InitialDataLoad),
     Resumption {
@@ -188,8 +188,6 @@ impl InfraChanges {
     }
 }
 
-// TODO we should not expose the internals of the infrastructure map.
-// We should have apis to be able to change it.
 /// Represents the complete infrastructure map of the system, containing all components and their relationships
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InfrastructureMap {


### PR DESCRIPTION
This pull request introduces significant updates to the `framework-cli` application, focusing on enhancing the infrastructure planning capabilities and improving code maintainability. The key changes include the addition of a new remote planning feature, updates to the Rust best practices, and various refactorings for better code organization and clarity.

Enhancements to infrastructure planning:

* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL31): Modified the `Plan` command to accept `url` and `token` parameters for remote planning. [[1]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL31) [[2]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL560-R559) [[3]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL571-R573)
* [`apps/framework-cli/src/cli/commands.rs`](diffhunk://#diff-e7f0aaaa20bae413611601b71b7dcb324e95b5d4bea41ab3c88fcb1efb4ba20fL54-R65): Updated the `Plan` command to include URL and token fields for remote planning.
* [`apps/framework-cli/src/cli/local_webserver.rs`](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR859-R861): Added the `admin_plan_route` function to handle remote planning requests and return the calculated changes. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR859-R861) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1629-R1741)
* [`apps/framework-cli/src/cli/routines.rs`](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL578-R693): Implemented the `remote_plan` function to send planning requests to a remote Moose instance and display the results.

Updates to Rust best practices:

* [`.cursor/rules/rust.mdc`](diffhunk://#diff-057ae16075c841471e63a763984d2a46d826c987cfc462e5019f26d86fb033a6L2-R4): Added new guidelines for defining and using newtypes in Rust, and updated the glob pattern to include all Rust files recursively. [[1]](diffhunk://#diff-057ae16075c841471e63a763984d2a46d826c987cfc462e5019f26d86fb033a6L2-R4) [[2]](diffhunk://#diff-057ae16075c841471e63a763984d2a46d826c987cfc462e5019f26d86fb033a6L35-L36) [[3]](diffhunk://#diff-057ae16075c841471e63a763984d2a46d826c987cfc462e5019f26d86fb033a6R78-R86)

Code refactoring and cleanup:

* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL31): Removed unused import for `plan` from `routines`.
* [`apps/framework-cli/src/cli/local_webserver.rs`](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR14): Consolidated imports related to `InfrastructureMap`. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR14) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL76)
* [`apps/framework-cli/src/cli/routines.rs`](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL174-R177): Replaced `show_message!` macro calls with `display::show_message_wrapper` for consistency. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL174-R177) [[2]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL215-R223) [[3]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL374-R382) [[4]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL489-R497)

Serialization updates:

* [`apps/framework-cli/src/framework/core/infrastructure_map.rs`](diffhunk://#diff-dbeb569f822ceeacce1ef3ac85fc505cf5cf8fd91c82eb198127170d2d4268a6L94-R107): Added `Deserialize` trait implementations for various structs and enums to facilitate JSON deserialization. [[1]](diffhunk://#diff-dbeb569f822ceeacce1ef3ac85fc505cf5cf8fd91c82eb198127170d2d4268a6L94-R107) [[2]](diffhunk://#diff-dbeb569f822ceeacce1ef3ac85fc505cf5cf8fd91c82eb198127170d2d4268a6L121-R154)