### PR TITLE
ignore .ts-node

### DIFF
--- a/apps/framework-cli/src/utilities/git.rs
+++ b/apps/framework-cli/src/utilities/git.rs
@@ -42,7 +42,7 @@ pub fn create_init_commit(project: Arc<Project>, dir_path: &Path) {
     let mut git_ignore_entries = vec![CLI_USER_DIRECTORY];
     git_ignore_entries.append(&mut match project.language {
         SupportedLanguages::Typescript => {
-            vec!["node_modules", "dist", "coverage"]
+            vec!["node_modules", "dist", "coverage", ".ts-node"]
         }
         SupportedLanguages::Python => vec![
             "__pycache__",


### PR DESCRIPTION
This pull request includes a small change to the `apps/framework-cli/src/utilities/git.rs` file. The change adds `.ts-node` to the list of entries in `.gitignore` for TypeScript projects.

* [`apps/framework-cli/src/utilities/git.rs`](diffhunk://#diff-c2aecb1c159262c18354cc82a74d3f1c51e6afb186804fc1c7da3c774b0194c3L45-R45): Added `.ts-node` to the `.gitignore` entries for TypeScript projects.