### PR TITLE
Option to skip shutdown of containers in dev mode

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1297,14 +1297,18 @@ async fn shutdown(settings: &Settings, project: &Project, graceful: GracefulShut
     }
 
     if !project.is_production {
-        let docker = DockerClient::new(settings);
-        with_spinner(
-            "Stopping containers",
-            || {
-                let _ = docker.stop_containers(project);
-            },
-            true,
-        );
+        if std::env::var("MOOSE_SKIP_CONTAINER_SHUTDOWN").is_err() {
+            let docker = DockerClient::new(settings);
+            with_spinner(
+                "Stopping containers",
+                || {
+                    let _ = docker.stop_containers(project);
+                },
+                true,
+            );
+        } else {
+            info!("Skipping container shutdown due to MOOSE_SKIP_CONTAINER_SHUTDOWN environment variable");
+        }
     }
     std::process::exit(0);
 }

--- a/apps/framework-cli/src/cli/routines/clean.rs
+++ b/apps/framework-cli/src/cli/routines/clean.rs
@@ -1,5 +1,6 @@
 use crate::utilities::docker::DockerClient;
 use crate::{cli::display::Message, project::Project};
+use log::info;
 
 use super::util::ensure_docker_running;
 use super::{RoutineFailure, RoutineSuccess};
@@ -9,12 +10,19 @@ pub fn clean_project(
     docker_client: &DockerClient,
 ) -> Result<RoutineSuccess, RoutineFailure> {
     ensure_docker_running(docker_client)?;
-    docker_client.stop_containers(project).map_err(|err| {
-        RoutineFailure::new(
-            Message::new("Failed".to_string(), "to stop containers".to_string()),
-            err,
-        )
-    })?;
+
+    if std::env::var("MOOSE_SKIP_CONTAINER_SHUTDOWN").is_err() {
+        docker_client.stop_containers(project).map_err(|err| {
+            RoutineFailure::new(
+                Message::new("Failed".to_string(), "to stop containers".to_string()),
+                err,
+            )
+        })?;
+    } else {
+        info!(
+            "Skipping container shutdown due to MOOSE_SKIP_CONTAINER_SHUTDOWN environment variable"
+        );
+    }
 
     Ok(RoutineSuccess::success(Message::new(
         "Cleaned".to_string(),


### PR DESCRIPTION
This pull request introduces a new feature to allow skipping container shutdown based on an environment variable. 

While developing and locally testing multi-moose functionality it desirable to avoid shutting down moose containers - particularly the Redis container.  This allows for the testing of multiple instances of moose which can be stopped and started without a container tear down process.

The changes in this PR affect the `shutdown` function in `local_webserver.rs` and the `clean_project` function in `clean.rs`. The most important changes are:

* Added a check for the `MOOSE_SKIP_CONTAINER_SHUTDOWN` environment variable in the `shutdown` function to conditionally skip stopping containers. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1300) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1309-R1311)
* Added logging to inform when container shutdown is skipped due to the `MOOSE_SKIP_CONTAINER_SHUTDOWN` environment variable in the `shutdown` function.
* Added a check for the `MOOSE_SKIP_CONTAINER_SHUTDOWN` environment variable in the `clean_project` function to conditionally skip stopping containers.
* Added logging to inform when container shutdown is skipped due to the `MOOSE_SKIP_CONTAINER_SHUTDOWN` environment variable in the `clean_project` function.
* Imported the `log::info` macro in `clean.rs` to enable logging.