### PR TITLE
Moose build without docker

### DIFF
--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -37,7 +37,8 @@ pub enum Commands {
     },
     /// Builds your moose project
     Build {
-        #[arg(short, long)]
+        /// Build for docker
+        #[arg(short, long, default_value = "false")]
         docker: bool,
         /// Build for amd64 architecture
         #[arg(long)]

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -866,31 +866,31 @@ async fn router(
     let metrics_method = req.method().to_string();
 
     let route_split = route.to_str().unwrap().split('/').collect::<Vec<&str>>();
-    let res = match (req.method(), &route_split[..]) {
-        (&hyper::Method::POST, ["ingest", _]) if project.features.streaming_engine => {
+    let res = match (configured_producer, req.method(), &route_split[..]) {
+        (Some(configured_producer), &hyper::Method::POST, ["ingest", _]) => {
             ingest_route(
                 req,
                 // without explicit version, go to current project version
                 route.join(current_version),
-                configured_producer.unwrap(),
+                configured_producer,
                 route_table,
                 is_prod,
                 jwt_config,
             )
             .await
         }
-        (&hyper::Method::POST, ["ingest", _, _]) if project.features.streaming_engine => {
+        (Some(configured_producer), &hyper::Method::POST, ["ingest", _, _]) => {
             ingest_route(
                 req,
                 route,
-                configured_producer.unwrap(),
+                configured_producer,
                 route_table,
                 is_prod,
                 jwt_config,
             )
             .await
         }
-        (&hyper::Method::POST, ["admin", "integrate-changes"]) => {
+        (_, &hyper::Method::POST, ["admin", "integrate-changes"]) => {
             admin_integrate_changes_route(
                 req,
                 &project.authentication.admin_api_key,
@@ -899,10 +899,10 @@ async fn router(
             )
             .await
         }
-        (&hyper::Method::POST, ["admin", "plan"]) => {
+        (_, &hyper::Method::POST, ["admin", "plan"]) => {
             admin_plan_route(req, &project.authentication.admin_api_key, &redis_client).await
         }
-        (&hyper::Method::GET, ["consumption", _rt]) => {
+        (_, &hyper::Method::GET, ["consumption", _rt]) => {
             match get_consumption_api_res(http_client, req, host, consumption_apis, is_prod).await {
                 Ok(response) => Ok(response),
                 Err(e) => {
@@ -913,8 +913,8 @@ async fn router(
                 }
             }
         }
-        (&hyper::Method::GET, ["health"]) => health_route().await,
-        (&hyper::Method::GET, ["admin", "reality-check"]) => {
+        (_, &hyper::Method::GET, ["health"]) => health_route().await,
+        (_, &hyper::Method::GET, ["admin", "reality-check"]) => {
             admin_reality_check_route(
                 req,
                 &project.authentication.admin_api_key,
@@ -923,7 +923,7 @@ async fn router(
             )
             .await
         }
-        (&hyper::Method::OPTIONS, _) => options_route(),
+        (_, &hyper::Method::OPTIONS, _) => options_route(),
         _ => route_not_found_response(),
     };
 

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -117,6 +117,7 @@ use crate::framework::core::primitive_map::PrimitiveMap;
 
 pub mod auth;
 pub mod block;
+pub mod build;
 pub mod clean;
 pub mod consumption;
 pub mod datamodel;

--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -395,34 +395,22 @@ fn create_archive(project: &Project, package_dir: &Path) -> Result<PathBuf, Buil
 
     let archive_path = internal_dir.join(&archive_name);
 
-    let result = with_spinner(
-        &format!("Creating archive {}", archive_name),
-        || {
-            // Use zip command to create archive
-            let status = Command::new("zip")
-                .current_dir(package_dir.parent().unwrap())
-                .args(["-r", &archive_name, "packager"])
-                .status()?;
+    // Use zip command to create archive
+    let status = Command::new("zip")
+        .current_dir(package_dir.parent().unwrap())
+        .args(["-r", &archive_name, "packager"])
+        .status()?;
 
-            if !status.success() {
-                return Err(BuildError::ArchiveFailed("zip command failed".to_string()));
-            }
+    if !status.success() {
+        return Err(BuildError::ArchiveFailed("zip command failed".to_string()));
+    }
 
-            // Move the archive to the .moose directory
-            let temp_archive = package_dir.parent().unwrap().join(&archive_name);
-            if temp_archive.exists() {
-                fs::rename(&temp_archive, &archive_path)?;
-            } else {
-                return Err(BuildError::ArchiveFailed("archive not found".to_string()));
-            }
-
-            Ok(())
-        },
-        false,
-    );
-
-    if let Err(err) = result {
-        return Err(BuildError::ArchiveFailed(err.to_string()));
+    // Move the archive to the .moose directory
+    let temp_archive = package_dir.parent().unwrap().join(&archive_name);
+    if temp_archive.exists() {
+        fs::rename(&temp_archive, &archive_path)?;
+    } else {
+        return Err(BuildError::ArchiveFailed("archive not found".to_string()));
     }
 
     info!("Archive created successfully at: {:?}", archive_path);

--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -1,65 +1,148 @@
+/// # Build Module
+///
+/// This module provides functionality for creating deployment packages without Docker.
+/// It builds a standalone ZIP archive that can be deployed to any server running Moose.
+///
+/// ## Architecture
+///
+/// The build process follows these steps:
+/// 1. Create a staging directory in the project's `.moose/packager` folder
+/// 2. Copy essential project files (app directory, config files)
+/// 3. Handle language-specific dependencies based on the project type (Node.js or Python)
+/// 4. Run validation with `moose check` to ensure the package is valid
+/// 5. Create a README with deployment instructions
+/// 6. Package everything into a ZIP archive with the project name and current date
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// use crate::project::Project;
+/// use crate::cli::routines::build::build_package;
+///
+/// fn deploy(project: &Project) -> Result<(), Box<dyn std::error::Error>> {
+///     let package_path = build_package(project)?;
+///     println!("Package created at: {}", package_path.display());
+///     Ok(())
+/// }
+/// ```
 use chrono::Local;
 use log::{debug, error, info};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
+use crate::cli::display::with_spinner;
 use crate::framework::languages::SupportedLanguages;
 use crate::project::Project;
 use crate::project::ProjectFileError;
-use crate::utilities::constants::{
-    APP_DIR, PACKAGE_JSON, PROJECT_CONFIG_FILE, SETUP_PY, TSCONFIG_JSON,
-};
+use crate::utilities::constants::{APP_DIR, OLD_PROJECT_CONFIG_FILE, PROJECT_CONFIG_FILE};
 use crate::utilities::system;
 
-/// Represents errors that can occur during the build process
+/// Represents errors that can occur during the build process.
+///
+/// This enum provides specific error variants for different failure scenarios
+/// during the package creation process, allowing for clear error reporting and
+/// targeted error handling.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum BuildError {
-    /// IO error during file operations
+    /// Standard IO errors that may occur during file operations.
+    ///
+    /// This includes file not found, permission denied, etc.
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),
 
-    /// Project file error
+    /// Project-specific file errors.
+    ///
+    /// Occurs when there are issues with project configuration files or structure.
     #[error("Project file error: {0}")]
     ProjectFile(#[from] ProjectFileError),
 
-    /// Error cleaning up package directory
+    /// Error when cleaning up an existing package directory.
+    ///
+    /// This happens when trying to remove a previous build directory fails.
     #[error("Failed to clean up existing package directory: {0}")]
     CleanupFailed(String),
 
-    /// Error creating package directory
+    /// Error when creating the package directory.
+    ///
+    /// This happens when the system cannot create the directory for staging files.
     #[error("Failed to create package directory: {0}")]
     CreateDirFailed(String),
 
-    /// Error copying file to package directory
+    /// Error when copying a file to the package directory.
+    ///
+    /// The first parameter identifies the file being copied,
+    /// and the second parameter provides the error details.
     #[error("Failed to copy {0} to package directory: {1}")]
     FileCopyFailed(String, String),
 
-    /// Error with Node dependencies
+    /// Error with Node.js dependencies.
+    ///
+    /// This includes failures in npm installation or copying node_modules.
     #[error("Failed to copy Node dependencies: {0}")]
     NodeDependenciesFailed(String),
 
-    /// Error with Python dependencies
+    /// Error with Python dependencies.
+    ///
+    /// This includes failures in generating requirements.txt or other Python-specific steps.
     #[error("Failed to copy Python dependencies: {0}")]
     PythonDependenciesFailed(String),
 
-    /// Error running moose check
+    /// Error running the moose check command.
+    ///
+    /// This happens when validation of the package contents fails.
     #[error("Failed to run moose check: {0}")]
     MooseCheckFailed(String),
 
-    /// Error creating README
+    /// Error creating the README file.
+    ///
+    /// This happens when the system cannot write the README.md file to the package.
     #[error("Failed to create README file: {0}")]
     ReadmeFailed(String),
 
-    /// Error creating archive
+    /// Error creating the ZIP archive.
+    ///
+    /// This happens when the system cannot create or move the final ZIP archive.
     #[error("Failed to create archive: {0}")]
     ArchiveFailed(String),
 }
 
+/// Directory name for the package staging area.
+///
+/// This is the directory where files are collected before being archived.
 pub const BUILD_PACKAGE_DIR: &str = "packager";
 
-/// Builds a deployment package without using Docker
+/// Builds a deployment package for a Moose project without using Docker.
+///
+/// This function creates a self-contained ZIP archive that includes all the necessary
+/// files to run a Moose application on a server. The package includes:
+///  - The app directory with application code
+///  - Configuration files
+///  - Language-specific dependencies
+///  - A generated README with deployment instructions
+///
+/// # Arguments
+///
+/// * `project` - A reference to the Project being packaged
+///
+/// # Returns
+///
+/// * `Result<PathBuf, BuildError>` - On success, returns the path to the created archive
+///
+/// # Errors
+///
+/// Returns a `BuildError` if any step of the build process fails, including:
+/// - IO operations
+/// - Dependency collection
+/// - Validation
+/// - Archive creation
+///
+/// # Side Effects
+///
+/// - Creates a `.moose/packager` directory
+/// - Runs `moose check --write-infra-map` in the package directory
+/// - Creates a ZIP archive in the `.moose` directory
 pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
     info!("Starting build process for deployment package");
 
@@ -88,13 +171,7 @@ pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
     let project_root_path = project.project_location.clone();
 
     // Files to include in the package
-    let files_to_copy = [
-        APP_DIR,
-        PROJECT_CONFIG_FILE,
-        PACKAGE_JSON,
-        SETUP_PY,
-        TSCONFIG_JSON,
-    ];
+    let files_to_copy = [APP_DIR, PROJECT_CONFIG_FILE, OLD_PROJECT_CONFIG_FILE];
 
     for item in &files_to_copy {
         let source_path = project_root_path.join(item);
@@ -126,9 +203,8 @@ pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
                 .map_err(|e| BuildError::NodeDependenciesFailed(e.to_string()))?;
         }
         SupportedLanguages::Python => {
-            return Err(BuildError::PythonDependenciesFailed(
-                "Python project not supported, please contact support@fiveonefour.com to get it supported".to_string(),
-            ));
+            copy_python_dependencies(project, &package_dir)
+                .map_err(|e| BuildError::PythonDependenciesFailed(e.to_string()))?;
         }
     }
 
@@ -150,7 +226,30 @@ pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
     Ok(archive_path)
 }
 
-/// Recursively copies files and directories from source to destination
+/// Recursively copies files and directories from source to destination.
+///
+/// This is a utility function that handles both individual files and directory structures,
+/// preserving the file hierarchy in the destination.
+///
+/// # Arguments
+///
+/// * `source` - Path to the source file or directory
+/// * `destination` - Path where the file or directory should be copied
+///
+/// # Returns
+///
+/// * `Result<(), std::io::Error>` - Returns Ok(()) on success
+///
+/// # Errors
+///
+/// Returns an IO error if any file operation fails, such as:
+/// - Reading directory contents
+/// - Creating directories
+/// - Copying files
+///
+/// # Notes
+///
+/// This function will create parent directories if they don't exist.
 fn copy_recursive(source: &PathBuf, destination: &PathBuf) -> Result<(), std::io::Error> {
     if source.is_dir() {
         fs::create_dir_all(destination)?;
@@ -178,16 +277,61 @@ fn copy_recursive(source: &PathBuf, destination: &PathBuf) -> Result<(), std::io
     }
 }
 
-/// Copies Node.js dependencies to the package directory
+/// Copies Node.js dependencies to the package directory.
+///
+/// This function handles copying the node_modules directory to the package.
+/// If node_modules doesn't exist, it attempts to install dependencies first.
+///
+/// # Arguments
+///
+/// * `project` - A reference to the Project containing Node.js dependencies
+/// * `package_dir` - Path to the package directory where dependencies should be copied
+///
+/// # Returns
+///
+/// * `Result<(), BuildError>` - Returns Ok(()) on success
+///
+/// # Errors
+///
+/// Returns a `BuildError` if:
+/// - npm install fails
+/// - Copying node_modules fails
+/// - node_modules doesn't exist even after attempting installation
+///
+/// # Side Effects
+///
+/// May run `npm install` in the project directory if node_modules doesn't exist
 fn copy_node_dependencies(project: &Project, package_dir: &PathBuf) -> Result<(), BuildError> {
     info!("Copying Node.js dependencies");
 
     let node_modules_path = project.project_location.join("node_modules");
     if !node_modules_path.exists() {
         // Try to install dependencies if node_modules doesn't exist
-        return Err(BuildError::NodeDependenciesFailed(
-            "node_modules directory not found, please run `npm install` or your package manager of choice to install dependencies".to_string(),
-        ));
+        info!("node_modules not found, installing dependencies...");
+        let result = with_spinner(
+            "Installing npm dependencies",
+            || {
+                let mut cmd = Command::new("npm");
+                cmd.current_dir(&project.project_location);
+                cmd.arg("install");
+                let output = cmd.output()?;
+                if !output.status.success() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!(
+                            "npm install failed: {}",
+                            String::from_utf8_lossy(&output.stderr)
+                        ),
+                    ));
+                }
+                Ok(())
+            },
+            false,
+        );
+
+        if let Err(err) = result {
+            return Err(BuildError::NodeDependenciesFailed(err.to_string()));
+        }
     }
 
     // Now copy the node_modules
@@ -209,32 +353,143 @@ fn copy_node_dependencies(project: &Project, package_dir: &PathBuf) -> Result<()
     Ok(())
 }
 
-/// Runs moose check with --write-infra-map in the package directory
+/// Copies Python dependencies to the package directory.
+///
+/// Instead of copying the virtual environment, this function generates
+/// a requirements.txt file by freezing the current environment.
+///
+/// # Arguments
+///
+/// * `project` - A reference to the Project containing Python dependencies
+/// * `package_dir` - Path to the package directory where the requirements.txt will be created
+///
+/// # Returns
+///
+/// * `Result<(), BuildError>` - Returns Ok(()) on success
+///
+/// # Errors
+///
+/// Returns a `BuildError` if:
+/// - Running pip freeze fails
+/// - Writing the requirements.txt file fails
+///
+/// # Side Effects
+///
+/// Runs `pip freeze --exclude-editable` in the project directory
+fn copy_python_dependencies(project: &Project, package_dir: &PathBuf) -> Result<(), BuildError> {
+    info!("Preparing Python dependencies");
+
+    // Create requirements.txt file
+    let requirements_path = package_dir.join("requirements.txt");
+    let result = with_spinner(
+        "Generating requirements.txt",
+        || {
+            let mut cmd = Command::new("pip");
+            cmd.current_dir(&project.project_location);
+            cmd.args(["freeze", "--exclude-editable"]);
+            let output = cmd.output()?;
+            if !output.status.success() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "pip freeze failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                ));
+            }
+
+            let requirements = String::from_utf8_lossy(&output.stdout).to_string();
+            fs::write(&requirements_path, requirements)?;
+            Ok(())
+        },
+        false,
+    );
+
+    if let Err(err) = result {
+        return Err(BuildError::PythonDependenciesFailed(err.to_string()));
+    }
+
+    info!("Requirements.txt generated successfully");
+    Ok(())
+}
+
+/// Runs moose check with --write-infra-map in the package directory.
+///
+/// This validates the package and generates necessary infrastructure maps.
+///
+/// # Arguments
+///
+/// * `package_dir` - Path to the package directory where moose check should run
+///
+/// # Returns
+///
+/// * `Result<(), BuildError>` - Returns Ok(()) on success
+///
+/// # Errors
+///
+/// Returns a `BuildError` if the moose check command fails
+///
+/// # Side Effects
+///
+/// Runs `moose check --write-infra-map` in the package directory,
+/// which updates the infrastructure map files
 fn run_moose_check(package_dir: &PathBuf) -> Result<(), BuildError> {
     info!("Running moose check with --write-infra-map");
 
-    let mut cmd = Command::new("moose");
-    cmd.current_dir(package_dir);
-    cmd.args(["check", "--write-infra-map"]);
-    let output = cmd.output()?;
-    if !output.status.success() {
-        return Err(BuildError::MooseCheckFailed(
-            "moose check failed".to_string(),
-        ));
+    let result = with_spinner(
+        "Running moose check",
+        || {
+            let mut cmd = Command::new("moose");
+            cmd.current_dir(package_dir);
+            cmd.args(["check", "--write-infra-map"]);
+            let output = cmd.output()?;
+            if !output.status.success() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "moose check failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                ));
+            }
+            Ok(())
+        },
+        false,
+    );
+
+    if let Err(err) = result {
+        return Err(BuildError::MooseCheckFailed(err.to_string()));
     }
 
     info!("Moose check completed successfully");
     Ok(())
 }
 
-/// Creates a README file with deployment instructions
+/// Creates a README file with deployment instructions in the package directory.
+///
+/// This provides users with guidance on how to deploy the package on a server.
+///
+/// # Arguments
+///
+/// * `package_dir` - Path to the package directory where the README should be created
+///
+/// # Returns
+///
+/// * `Result<(), BuildError>` - Returns Ok(()) on success
+///
+/// # Errors
+///
+/// Returns a `BuildError` if writing the README file fails
+///
+/// # Side Effects
+///
+/// Creates a README.md file in the package directory
 fn create_readme(package_dir: &PathBuf) -> Result<(), BuildError> {
     info!("Creating README with deployment instructions");
 
     let readme_content = r#"# Moose Application Deployment Package
 
-This package contains a Moose application ready for deployment. The builds needs to run 
-on a machine that has the same os and architecture as the deployment target.
+This package contains a Moose application ready for deployment.
 
 ## Deployment Instructions
 
@@ -254,36 +509,76 @@ For more information about Moose, visit https://www.moosejs.com/
     Ok(())
 }
 
-/// Creates a zip archive of the package directory
+/// Creates a zip archive of the package directory.
+///
+/// The archive name includes the project name and current date.
+///
+/// # Arguments
+///
+/// * `project` - A reference to the Project being packaged
+/// * `package_dir` - Path to the package directory that should be archived
+///
+/// # Returns
+///
+/// * `Result<PathBuf, BuildError>` - On success, returns the path to the created archive
+///
+/// # Errors
+///
+/// Returns a `BuildError` if:
+/// - Creating the zip archive fails
+/// - Moving the archive to the .moose directory fails
+///
+/// # Side Effects
+///
+/// - Creates a ZIP file in the parent directory of the package directory
+/// - Moves the ZIP file to the .moose directory
 fn create_archive(project: &Project, package_dir: &PathBuf) -> Result<PathBuf, BuildError> {
     info!("Creating zip archive of package");
 
     let project_name = project.name();
     let date = Local::now().format("%Y-%m-%d");
     let archive_name = format!("{}-{}.zip", project_name, date);
-    let internal_dir = project.internal_dir()?;
+    let internal_dir = project.internal_dir().map_err(|err| {
+        error!("Failed to get internal directory for project: {}", err);
+        BuildError::ProjectFile(err)
+    })?;
 
     let archive_path = internal_dir.join(&archive_name);
 
-    // Use zip command to create archive silently
-    // Change directory into the packager directory first so files are at top level in the zip
-    let status = Command::new("zip")
-        .current_dir(package_dir) // Changed to package_dir instead of parent
-        .args(["-q", "-r", &archive_name, "."]) // Changed "packager" to "." to zip current directory contents
-        .status()?;
+    let result = with_spinner(
+        &format!("Creating archive {}", archive_name),
+        || {
+            // Use zip command to create archive
+            let status = Command::new("zip")
+                .current_dir(package_dir.parent().unwrap())
+                .args(["-r", &archive_name, "packager"])
+                .status()?;
 
-    if !status.success() {
-        return Err(BuildError::ArchiveFailed("zip command failed".to_string()));
-    }
+            if !status.success() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "zip command failed",
+                ));
+            }
 
-    // Move the archive to the .moose directory
-    let temp_archive = package_dir.join(&archive_name);
-    if temp_archive.exists() {
-        fs::rename(&temp_archive, &archive_path)?;
-    } else {
-        return Err(BuildError::ArchiveFailed(
-            "Archive was not created correctly".to_string(),
-        ));
+            // Move the archive to the .moose directory
+            let temp_archive = package_dir.parent().unwrap().join(&archive_name);
+            if temp_archive.exists() {
+                fs::rename(&temp_archive, &archive_path)?;
+            } else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "Archive was not created correctly",
+                ));
+            }
+
+            Ok(())
+        },
+        false,
+    );
+
+    if let Err(err) = result {
+        return Err(BuildError::ArchiveFailed(err.to_string()));
     }
 
     info!("Archive created successfully at: {:?}", archive_path);

--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -1,0 +1,291 @@
+use chrono::Local;
+use log::{debug, error, info};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::framework::languages::SupportedLanguages;
+use crate::project::Project;
+use crate::project::ProjectFileError;
+use crate::utilities::constants::{
+    APP_DIR, PACKAGE_JSON, PROJECT_CONFIG_FILE, SETUP_PY, TSCONFIG_JSON,
+};
+use crate::utilities::system;
+
+/// Represents errors that can occur during the build process
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BuildError {
+    /// IO error during file operations
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+
+    /// Project file error
+    #[error("Project file error: {0}")]
+    ProjectFile(#[from] ProjectFileError),
+
+    /// Error cleaning up package directory
+    #[error("Failed to clean up existing package directory: {0}")]
+    CleanupFailed(String),
+
+    /// Error creating package directory
+    #[error("Failed to create package directory: {0}")]
+    CreateDirFailed(String),
+
+    /// Error copying file to package directory
+    #[error("Failed to copy {0} to package directory: {1}")]
+    FileCopyFailed(String, String),
+
+    /// Error with Node dependencies
+    #[error("Failed to copy Node dependencies: {0}")]
+    NodeDependenciesFailed(String),
+
+    /// Error with Python dependencies
+    #[error("Failed to copy Python dependencies: {0}")]
+    PythonDependenciesFailed(String),
+
+    /// Error running moose check
+    #[error("Failed to run moose check: {0}")]
+    MooseCheckFailed(String),
+
+    /// Error creating README
+    #[error("Failed to create README file: {0}")]
+    ReadmeFailed(String),
+
+    /// Error creating archive
+    #[error("Failed to create archive: {0}")]
+    ArchiveFailed(String),
+}
+
+pub const BUILD_PACKAGE_DIR: &str = "packager";
+
+/// Builds a deployment package without using Docker
+pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
+    info!("Starting build process for deployment package");
+
+    // Get internal directory for staging
+    let internal_dir = project.internal_dir()?;
+
+    // Create the package directory (equivalent to packager in docker_packager)
+    let package_dir = internal_dir.join(BUILD_PACKAGE_DIR);
+    info!("Setting up package directory at: {:?}", package_dir);
+
+    // Clean up any existing packager directory
+    if package_dir.exists() {
+        fs::remove_dir_all(&package_dir).map_err(|err| {
+            error!("Failed to clean up existing package directory: {}", err);
+            BuildError::CleanupFailed(err.to_string())
+        })?;
+    }
+
+    // Create the package directory
+    fs::create_dir_all(&package_dir).map_err(|err| {
+        error!("Failed to create package directory: {}", err);
+        BuildError::CreateDirFailed(err.to_string())
+    })?;
+
+    // Copy project files to packager directory
+    let project_root_path = project.project_location.clone();
+
+    // Files to include in the package
+    let files_to_copy = [
+        APP_DIR,
+        PROJECT_CONFIG_FILE,
+        PACKAGE_JSON,
+        SETUP_PY,
+        TSCONFIG_JSON,
+    ];
+
+    for item in &files_to_copy {
+        let source_path = project_root_path.join(item);
+        let dest_path = package_dir.join(item);
+
+        if !source_path.exists() {
+            debug!("Skipping {}, does not exist", item);
+            continue;
+        }
+
+        match copy_recursive(&source_path, &dest_path) {
+            Ok(_) => {
+                debug!("Copied {} to package directory", item);
+            }
+            Err(err) => {
+                error!("Failed to copy {} to package directory: {}", item, err);
+                return Err(BuildError::FileCopyFailed(
+                    item.to_string(),
+                    err.to_string(),
+                ));
+            }
+        }
+    }
+
+    // Copy language-specific dependencies
+    match project.language {
+        SupportedLanguages::Typescript => {
+            copy_node_dependencies(project, &package_dir)
+                .map_err(|e| BuildError::NodeDependenciesFailed(e.to_string()))?;
+        }
+        SupportedLanguages::Python => {
+            return Err(BuildError::PythonDependenciesFailed(
+                "Python project not supported, please contact support@fiveonefour.com to get it supported".to_string(),
+            ));
+        }
+    }
+
+    // Run moose check with --write-infra-map
+    run_moose_check(&package_dir).map_err(|e| BuildError::MooseCheckFailed(e.to_string()))?;
+
+    // Create README with deployment instructions
+    create_readme(&package_dir).map_err(|e| BuildError::ReadmeFailed(e.to_string()))?;
+
+    // Create the archive
+    let archive_path = create_archive(project, &package_dir)
+        .map_err(|e| BuildError::ArchiveFailed(e.to_string()))?;
+
+    info!(
+        "Successfully created deployment package at {}",
+        archive_path.display()
+    );
+
+    Ok(archive_path)
+}
+
+/// Recursively copies files and directories from source to destination
+fn copy_recursive(source: &PathBuf, destination: &PathBuf) -> Result<(), std::io::Error> {
+    if source.is_dir() {
+        fs::create_dir_all(destination)?;
+
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let file_name = entry.file_name();
+            let dest_path = destination.join(file_name);
+
+            if entry_path.is_dir() {
+                copy_recursive(&entry_path, &dest_path)?;
+            } else {
+                fs::copy(&entry_path, &dest_path)?;
+            }
+        }
+        Ok(())
+    } else {
+        // Ensure the parent directory exists
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source, destination)?;
+        Ok(())
+    }
+}
+
+/// Copies Node.js dependencies to the package directory
+fn copy_node_dependencies(project: &Project, package_dir: &PathBuf) -> Result<(), BuildError> {
+    info!("Copying Node.js dependencies");
+
+    let node_modules_path = project.project_location.join("node_modules");
+    if !node_modules_path.exists() {
+        // Try to install dependencies if node_modules doesn't exist
+        return Err(BuildError::NodeDependenciesFailed(
+            "node_modules directory not found, please run `npm install` or your package manager of choice to install dependencies".to_string(),
+        ));
+    }
+
+    // Now copy the node_modules
+    if node_modules_path.exists() {
+        info!("Copying node_modules to package directory");
+
+        let copy_result = system::copy_directory(&node_modules_path, package_dir);
+        if let Err(err) = copy_result {
+            error!("Failed to copy node_modules to package directory: {}", err);
+            return Err(BuildError::NodeDependenciesFailed(err.to_string()));
+        }
+    } else {
+        error!("node_modules directory not found even after npm install");
+        return Err(BuildError::NodeDependenciesFailed(
+            "node_modules directory not found".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Runs moose check with --write-infra-map in the package directory
+fn run_moose_check(package_dir: &PathBuf) -> Result<(), BuildError> {
+    info!("Running moose check with --write-infra-map");
+
+    let mut cmd = Command::new("moose");
+    cmd.current_dir(package_dir);
+    cmd.args(["check", "--write-infra-map"]);
+    let output = cmd.output()?;
+    if !output.status.success() {
+        return Err(BuildError::MooseCheckFailed(
+            "moose check failed".to_string(),
+        ));
+    }
+
+    info!("Moose check completed successfully");
+    Ok(())
+}
+
+/// Creates a README file with deployment instructions
+fn create_readme(package_dir: &PathBuf) -> Result<(), BuildError> {
+    info!("Creating README with deployment instructions");
+
+    let readme_content = r#"# Moose Application Deployment Package
+
+This package contains a Moose application ready for deployment. The builds needs to run 
+on a machine that has the same os and architecture as the deployment target.
+
+## Deployment Instructions
+
+1. Extract this package to your deployment server
+2. Set up any required environment variables
+3. Run `moose prod` to start the application in production mode
+
+For more information about Moose, visit https://www.moosejs.com/
+"#;
+
+    fs::write(package_dir.join("README.md"), readme_content).map_err(|err| {
+        error!("Failed to create README file: {}", err);
+        BuildError::ReadmeFailed(err.to_string())
+    })?;
+
+    info!("README created successfully");
+    Ok(())
+}
+
+/// Creates a zip archive of the package directory
+fn create_archive(project: &Project, package_dir: &PathBuf) -> Result<PathBuf, BuildError> {
+    info!("Creating zip archive of package");
+
+    let project_name = project.name();
+    let date = Local::now().format("%Y-%m-%d");
+    let archive_name = format!("{}-{}.zip", project_name, date);
+    let internal_dir = project.internal_dir()?;
+
+    let archive_path = internal_dir.join(&archive_name);
+
+    // Use zip command to create archive silently
+    // Change directory into the packager directory first so files are at top level in the zip
+    let status = Command::new("zip")
+        .current_dir(package_dir) // Changed to package_dir instead of parent
+        .args(["-q", "-r", &archive_name, "."]) // Changed "packager" to "." to zip current directory contents
+        .status()?;
+
+    if !status.success() {
+        return Err(BuildError::ArchiveFailed("zip command failed".to_string()));
+    }
+
+    // Move the archive to the .moose directory
+    let temp_archive = package_dir.join(&archive_name);
+    if temp_archive.exists() {
+        fs::rename(&temp_archive, &archive_path)?;
+    } else {
+        return Err(BuildError::ArchiveFailed(
+            "Archive was not created correctly".to_string(),
+        ));
+    }
+
+    info!("Archive created successfully at: {:?}", archive_path);
+    Ok(archive_path)
+}

--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -28,6 +28,7 @@
 use chrono::Local;
 use log::{debug, error, info};
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -376,7 +377,7 @@ fn copy_node_dependencies(project: &Project, package_dir: &PathBuf) -> Result<()
 /// # Side Effects
 ///
 /// Runs `pip freeze --exclude-editable` in the project directory
-fn copy_python_dependencies(project: &Project, package_dir: &PathBuf) -> Result<(), BuildError> {
+fn copy_python_dependencies(project: &Project, package_dir: &Path) -> Result<(), BuildError> {
     info!("Preparing Python dependencies");
 
     // Create requirements.txt file
@@ -484,7 +485,7 @@ fn run_moose_check(package_dir: &PathBuf) -> Result<(), BuildError> {
 /// # Side Effects
 ///
 /// Creates a README.md file in the package directory
-fn create_readme(package_dir: &PathBuf) -> Result<(), BuildError> {
+fn create_readme(package_dir: &Path) -> Result<(), BuildError> {
     info!("Creating README with deployment instructions");
 
     let readme_content = r#"# Moose Application Deployment Package
@@ -532,7 +533,7 @@ For more information about Moose, visit https://www.moosejs.com/
 ///
 /// - Creates a ZIP file in the parent directory of the package directory
 /// - Moves the ZIP file to the .moose directory
-fn create_archive(project: &Project, package_dir: &PathBuf) -> Result<PathBuf, BuildError> {
+fn create_archive(project: &Project, package_dir: &Path) -> Result<PathBuf, BuildError> {
     info!("Creating zip archive of package");
 
     let project_name = project.name();

--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -32,11 +32,13 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::cli::display::with_spinner;
 use crate::framework::languages::SupportedLanguages;
 use crate::project::Project;
 use crate::project::ProjectFileError;
-use crate::utilities::constants::{APP_DIR, OLD_PROJECT_CONFIG_FILE, PROJECT_CONFIG_FILE};
+use crate::utilities::constants::PACKAGE_JSON;
+use crate::utilities::constants::SETUP_PY;
+use crate::utilities::constants::TSCONFIG_JSON;
+use crate::utilities::constants::{APP_DIR, PROJECT_CONFIG_FILE};
 use crate::utilities::system;
 use crate::utilities::system::copy_directory;
 
@@ -173,7 +175,13 @@ pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
     let project_root_path = project.project_location.clone();
 
     // Files to include in the package
-    let files_to_copy = [APP_DIR, PROJECT_CONFIG_FILE, OLD_PROJECT_CONFIG_FILE];
+    let files_to_copy = [
+        APP_DIR,
+        PROJECT_CONFIG_FILE,
+        PACKAGE_JSON,
+        SETUP_PY,
+        TSCONFIG_JSON,
+    ];
 
     for item in &files_to_copy {
         let source_path = project_root_path.join(item);
@@ -398,7 +406,7 @@ fn create_archive(project: &Project, package_dir: &Path) -> Result<PathBuf, Buil
     // Use zip command to create archive
     let status = Command::new("zip")
         .current_dir(package_dir.parent().unwrap())
-        .args(["-r", &archive_name, "packager"])
+        .args(["-q", "-r", &archive_name, "packager"])
         .status()?;
 
     if !status.success() {

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -3,8 +3,7 @@ use crate::cli::display::with_spinner;
 use crate::cli::routines::util::ensure_docker_running;
 use crate::framework::languages::SupportedLanguages;
 use crate::utilities::constants::{
-    APP_DIR, CLI_INTERNAL_VERSIONS_DIR, OLD_PROJECT_CONFIG_FILE, PACKAGE_JSON, PROJECT_CONFIG_FILE,
-    SETUP_PY, TSCONFIG_JSON,
+    APP_DIR, OLD_PROJECT_CONFIG_FILE, PACKAGE_JSON, PROJECT_CONFIG_FILE, SETUP_PY, TSCONFIG_JSON,
 };
 use crate::utilities::docker::DockerClient;
 use crate::utilities::{constants, system};
@@ -219,30 +218,6 @@ pub fn build_dockerfile(
             err,
         )
     })?;
-
-    // Copy versions folder to packager directory
-    let copy_result = system::copy_directory(
-        &internal_dir.join(CLI_INTERNAL_VERSIONS_DIR),
-        &internal_dir.join("packager"),
-    );
-    match copy_result {
-        Ok(_) => {
-            info!("Copied versions directory to packager directory");
-        }
-        Err(err) => {
-            error!(
-                "Failed to copy versions directory to packager directory: {}",
-                err
-            );
-            return Err(RoutineFailure::new(
-                Message::new(
-                    "Failed".to_string(),
-                    "to copy versions directory to packager directory".to_string(),
-                ),
-                err,
-            ));
-        }
-    }
 
     // Copy app & etc to packager directory
     let project_root_path = project.project_location.clone();


### PR DESCRIPTION
This pull request introduces a new function for building deployment packages without using Docker and updates the CLI to support this new functionality. Additionally, it makes several changes to improve the flexibility and error handling of the web server.

### New functionality:
* [`apps/framework-cli/src/cli/routines/build.rs`](diffhunk://#diff-3f227ace3a120ff6317ae024e98c9c3a16040549a735fc0c2a7a210b834ef85aR1-R291): Added the `build_package` function to create deployment packages without Docker. This includes handling various file operations, copying dependencies, running checks, and creating an archive.

### CLI updates:
* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL20-R26): Updated the `use` statements to include `with_spinner` and added a call to `build_package` within the `top_command_handler` function to bundle deployment packages. [[1]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL20-R26) [[2]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL330-R356)
* [`apps/framework-cli/src/cli/commands.rs`](diffhunk://#diff-e7f0aaaa20bae413611601b71b7dcb324e95b5d4bea41ab3c88fcb1efb4ba20fL40-R41): Modified the `Build` command to include a `docker` flag with a default value of `false`.

### Web server improvements:
* [`apps/framework-cli/src/cli/local_webserver.rs`](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL266-R266): Updated the `RouteService` struct and `router` function to handle an optional `ConfiguredProducer`, allowing for more flexible configuration based on project features. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL266-R266) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL835-R835) [[3]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL870-R886) [[4]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1157-R1161)