### PR TITLE
fix: remove migration stop from syncing

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -101,7 +101,6 @@ use crate::cli::routines::openapi::openapi;
 use crate::framework::core::execute::execute_initial_infra_change;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
 use crate::infrastructure::processes::cron_registry::CronRegistry;
-use crate::infrastructure::processes::kafka_clickhouse_sync::clickhouse_writing_pause_button;
 use crate::project::Project;
 
 use super::super::metrics::Metrics;
@@ -278,11 +277,9 @@ async fn process_pubsub_message(
     } else {
         // this assumes that the leader is not doing inserts during migration
         if message.contains("<migration_start>") {
-            clickhouse_writing_pause_button().send(true)?;
-            info!("Pausing write to CH");
+            info!("Should be pausing write to CH from Kafka");
         } else if message.contains("<migration_end>") {
-            clickhouse_writing_pause_button().send(false)?;
-            info!("Resuming write to CH");
+            info!("Should be resuming write to CH from Kafka");
         } else {
             info!(
                 "<Routines> This instance is not the leader and received pubsub message: {}",

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
@@ -127,13 +127,8 @@ impl<C: ClickHouseClientTrait + 'static> Inserter<C> {
         commit_callback: OffsetCommitCallback,
     ) {
         let mut interval = time::interval(Duration::from_secs(self.flush_interval));
-        let mut pause_receiver = kafka_clickhouse_sync::clickhouse_writing_pause_listener();
 
         loop {
-            if *pause_receiver.borrow() {
-                pause_receiver.changed().await.unwrap();
-                continue;
-            }
             interval.tick().await;
 
             let mut queue = self.queue.lock().await;

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
@@ -3,7 +3,6 @@ use crate::infrastructure::olap::clickhouse::model::ClickHouseRecord;
 use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
-use crate::infrastructure::processes::kafka_clickhouse_sync;
 use log::{info, warn};
 use rdkafka::error::KafkaError;
 use std::sync::Arc;

--- a/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
+++ b/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
@@ -8,7 +8,6 @@ use rdkafka::Message;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use tokio::select;
 use tokio::task::JoinHandle;
 
 use crate::framework::core::infrastructure::table::Column;


### PR DESCRIPTION
This pull request focuses on removing the pause/resume functionality for writing to ClickHouse from Kafka. The changes span across multiple files, simplifying the codebase and removing unnecessary synchronization mechanisms.

Key changes include:

### Removal of Pause/Resume Functionality:

* [`apps/framework-cli/src/cli/routines.rs`](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL281-R282): Removed the `clickhouse_writing_pause_button` function calls and related log messages in the `process_pubsub_message` function.
* [`apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs`](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L130-L136): Removed the `pause_receiver` and related logic from the `Inserter` implementation.
* [`apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs`](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL275-L284): Removed the `SHOULD_PAUSE_WRITING_TO_CLICKHOUSE` static variable, `clickhouse_writing_pause_button`, and `clickhouse_writing_pause_listener` functions, along with their usage in the `sync_kafka_to_clickhouse` function. [[1]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL275-L284) [[2]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL294-L299) [[3]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL394-L398)

### Code Cleanup:

* [`apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs`](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL10-R10): Removed unused imports and cleaned up the `SyncingProcessesRegistry` implementation. [[1]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL10-R10) [[2]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL28-L31) [[3]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL148-R144)