### PR TITLE
chore: simplify syncing code while adding backpressure

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
@@ -107,6 +107,7 @@ impl<C: ClickHouseClientTrait + 'static> Inserter<C> {
                 self.queue.push_back(Batch::default());
                 let new_batch = self.queue.back_mut().unwrap();
                 new_batch.records.push(record);
+                new_batch.update_offset(partition, offset);
             }
         }
     }

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
@@ -98,6 +98,7 @@ impl<C: ClickHouseClientTrait + 'static> Inserter<C> {
                     self.queue.push_back(Batch::default());
                     let new_batch = self.queue.back_mut().unwrap();
                     new_batch.records.push(record);
+                    new_batch.update_offset(partition, offset);
                 } else {
                     batch.records.push(record);
                     batch.update_offset(partition, offset);

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs
@@ -263,7 +263,12 @@ mod tests {
         );
 
         assert_eq!(
-            inserter.queue.front().unwrap().records.len(),
+            inserter
+                .queue
+                .front()
+                .unwrap_or(&Batch::default())
+                .records
+                .len(),
             0,
             "Batch should be empty after successful flush"
         );

--- a/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
+++ b/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
@@ -324,7 +324,7 @@ async fn sync_kafka_to_clickhouse(
     // This should also not be broken, otherwise, the subscriber will stop receiving messages
 
     loop {
-        if !inserter.is_empty() && (clock.elapsed() > flush_interval || inserter.len() >= 1) {
+        if !inserter.is_empty() && (clock.elapsed() > flush_interval || inserter.len() > 1) {
             inserter.flush().await;
             clock = Instant::now();
         }


### PR DESCRIPTION
This pull request includes several changes aimed at simplifying the `Inserter` implementation and improving the testability and performance of the `ClickHouse` inserter. The most important changes include the removal of unnecessary `Arc` and `Mutex` usage, the addition of new type aliases for better code readability, and the introduction of a manual flush mechanism in tests.

### Simplification and Performance Improvements:

* Removed `Arc` and `Mutex` from `BatchQueue` and `client` in `Inserter`, simplifying the code and reducing overhead. (`apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs`)
* Added new type aliases `PartitionOffsets` and `PartitionSizes` to improve code readability. (`apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs`)

### Testability Enhancements:

* Modified tests to use a mutable `Inserter` and removed unnecessary `Arc` usage in `MockClickHouseClient`. (`apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs`) [[1]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L187-R184) [[2]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L228-R232) [[3]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L264-R271) [[4]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L302-R293)

### Manual Flush Mechanism:

* Introduced a manual flush mechanism in tests, replacing the previous interval-based flush, to improve test reliability and control. (`apps/framework-cli/src/infrastructure/olap/clickhouse/inserter.rs`) [[1]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L228-R232) [[2]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L264-R271) [[3]](diffhunk://#diff-15f02b314e130778bd56d81e964452d161d74a8dcf48bb70f8e795b936e4daa2L302-R293)

### Kafka to ClickHouse Sync Improvements:

* Replaced interval-based flushing with a manual flush mechanism in the `sync_kafka_to_clickhouse` function, improving performance and reliability. (`apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs`) [[1]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL298-R337) [[2]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fL347-L363) [[3]](diffhunk://#diff-9548a1393387e0e1fab314dbd38bb1e9fb7453ec8314a4189049f1d5af6c8f6fR385)