### PR TITLE
reduce ts streaming max retry time

### DIFF
--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -913,8 +913,8 @@ impl InfrastructureMap {
         for (id, function_process) in &self.function_processes {
             if let Some(target_function_process) = target_map.function_processes.get(id) {
                 // In this case we don't do a comparison check because the function process is not just
-                // dependendant on changing one file, but also on its dependencies. Untill we are able to
-                // properly compare the function processes wholisticaly (File + Dependencies), we will just
+                // dependent on changing one file, but also on its dependencies. Until we are able to
+                // properly compare the function processes holistically (File + Dependencies), we will just
                 // assume that the function process has changed.
                 log::debug!("Function Process updated: {}", id);
                 function_updates += 1;

--- a/apps/framework-cli/src/infrastructure/stream/redpanda.rs
+++ b/apps/framework-cli/src/infrastructure/stream/redpanda.rs
@@ -495,13 +495,16 @@ pub fn create_subscriber(config: &RedpandaConfig, group_id: &str, topic: &str) -
         config,
         &[
             ("session.timeout.ms", "6000"),
+            // has to be longer than the clickhouse timeout
+            // otherwise the consumer will be considered failed if clickhouse takes too long
+            // this values is the default (5 minutes)
+            ("max.poll.interval.ms", "300000"),
             ("enable.partition.eof", "false"),
             ("enable.auto.commit", "true"),
             ("auto.commit.interval.ms", "1000"),
             ("enable.auto.offset.store", "false"),
             // to read records sent before subscriber is created
             ("auto.offset.reset", "earliest"),
-            // Groupid
             ("group.id", &group_id),
             ("isolation.level", "read_committed"),
         ],

--- a/packages/ts-moose-lib/src/streaming-functions/runner.ts
+++ b/packages/ts-moose-lib/src/streaming-functions/runner.ts
@@ -9,10 +9,10 @@ import { Cluster } from "../cluster-utils";
 const HOSTNAME = process.env.HOSTNAME;
 const AUTO_COMMIT_INTERVAL_MS = 5000;
 const PARTITIONS_CONSUMED_CONCURRENTLY = 3;
-const MAX_RETRIES = 5;
-const MAX_RETRY_TIME_MS = 30000;
-const MAX_RETRIES_PRODUCER = 5;
-const MAX_RETRIES_CONSUMER = 5;
+const MAX_RETRIES = 150;
+const MAX_RETRY_TIME_MS = 1000;
+const MAX_RETRIES_PRODUCER = 150;
+const MAX_RETRIES_CONSUMER = 150;
 const SESSION_TIMEOUT_CONSUMER = 30000;
 const HEARTBEAT_INTERVAL_CONSUMER = 3000;
 const RETRY_FACTOR_PRODUCER = 0.2;
@@ -623,6 +623,7 @@ export const runStreamingFunctions = async (): Promise<void> => {
         sasl: buildSaslConfig(logger, args),
         retry: {
           initialRetryTime: RETRY_INITIAL_TIME_MS,
+          maxRetryTime: MAX_RETRY_TIME_MS,
           retries: MAX_RETRIES,
         },
       });


### PR DESCRIPTION
The reduced duration is per retry (of exponential retries).
Increased count so that the total retry duration stays approximately the same.