### PR TITLE
Handle Redis panic on Ctrl-c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
  "log",
  "notify",
  "num-traits",
+ "once_cell",
  "openssl",
  "opentelemetry 0.27.1",
  "opentelemetry-appender-log",
@@ -2690,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl"

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -110,6 +110,7 @@ url = "2.5.4"
 tempfile = "3.15.0"
 http = "1.2.0"
 prost-wkt-types = "0.6.0"
+once_cell = "1.21.1"
 
 [dev-dependencies]
 clickhouse = { version = "0.11.5", features = ["uuid", "test-util"] }

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -18,14 +18,11 @@
 ///
 /// The webserver is configurable through the `LocalWebserverConfig` struct and
 /// can be started in both development and production modes.
-use super::display::Message;
-use super::display::MessageType;
+use super::display::{with_spinner, Message, MessageType};
 use super::routines::auth::validate_auth_token;
 use super::settings::Settings;
 use crate::infrastructure::redis::redis_client::RedisClient;
 use crate::metrics::MetricEvent;
-
-use crate::cli::display::with_spinner;
 
 use crate::framework::core::infrastructure::api_endpoint::APIType;
 use crate::framework::core::infrastructure_map::Change;
@@ -1263,7 +1260,9 @@ impl Webserver {
             }
         }
 
-        shutdown(settings, &project, graceful).await;
+        // Extract Redis client for shutdown
+        let redis_client_for_shutdown = route_service.redis_client.clone();
+        shutdown(settings, &project, graceful, redis_client_for_shutdown).await;
     }
 }
 
@@ -1290,19 +1289,82 @@ fn handle_listener_err(port: u16, e: std::io::Error) -> ! {
         _ => panic!("Failed to listen to port {}: {:?}", port, e),
     }
 }
-async fn shutdown(settings: &Settings, project: &Project, graceful: GracefulShutdown) -> ! {
+async fn shutdown(
+    settings: &Settings,
+    project: &Project,
+    graceful: GracefulShutdown,
+    redis_client: Arc<Mutex<RedisClient>>,
+) -> ! {
+    // First, initiate the graceful shutdown of HTTP connections
+    let shutdown_future = graceful.shutdown();
+
+    // Wait for connections to close with a timeout
     tokio::select! {
-            _ = graceful.shutdown() => {
-                info!("all connections gracefully closed");
-            },
-            _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
-                warn!("timed out wait for all connections to close");
+        _ = shutdown_future => {
+            info!("all connections gracefully closed");
+        },
+        _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+            warn!("timed out wait for all connections to close");
         }
     }
 
+    // Ensure any Redis-using tasks are stopped
+    info!("Stopping any tasks that might be using Redis");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Shutdown Redis client that was passed
+    info!("Shutting down Redis client connections");
+
+    // First attempt: Try to properly shut down the Redis client
+    match tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        if let Ok(mut client) = redis_client.try_lock() {
+            match client.shutdown().await {
+                Ok(_) => info!("Redis client shutdown completed successfully"),
+                Err(err) => warn!("Error during Redis client shutdown: {:?}", err),
+            }
+        } else {
+            warn!("Could not acquire lock on Redis client for shutdown");
+        }
+    })
+    .await
+    {
+        Ok(_) => info!("Redis shutdown completed within timeout"),
+        Err(_) => warn!("Redis shutdown timed out, proceeding with application shutdown"),
+    }
+
+    // Important: Drop our reference to the Redis client to ensure it's fully cleaned up
+    // before we start stopping containers
+    info!("Dropping Redis client reference");
+    drop(redis_client);
+
+    // Add a small delay to ensure any background tasks have a chance to clean up
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Shutdown the Docker containers if needed
     if !project.is_production {
-        if std::env::var("MOOSE_SKIP_CONTAINER_SHUTDOWN").is_err() {
+        let should_skip_shutdown = match std::env::var("MOOSE_SKIP_CONTAINER_SHUTDOWN") {
+            Ok(val) => {
+                // Consider values like "0", "false", "no" as false (don't skip)
+                let val = val.to_lowercase();
+                val == "1" || val == "true" || val == "yes"
+            }
+            Err(_) => false, // Variable not set, don't skip
+        };
+
+        if !should_skip_shutdown {
+            // Create docker client with a fresh settings reference
             let docker = DockerClient::new(settings);
+            info!("Starting container shutdown process");
+
+            // First display a clear message to the user
+            super::display::show_message_wrapper(
+                MessageType::Highlight,
+                Message {
+                    action: "Shutdown".to_string(),
+                    details: "Stopping containers...".to_string(),
+                },
+            );
+
             with_spinner(
                 "Stopping containers",
                 || {
@@ -1310,10 +1372,26 @@ async fn shutdown(settings: &Settings, project: &Project, graceful: GracefulShut
                 },
                 true,
             );
+
+            super::display::show_message_wrapper(
+                MessageType::Success,
+                Message {
+                    action: "Shutdown".to_string(),
+                    details: "All containers stopped successfully".to_string(),
+                },
+            );
+
+            info!("Container shutdown complete");
         } else {
-            info!("Skipping container shutdown due to MOOSE_SKIP_CONTAINER_SHUTDOWN environment variable");
+            info!("Skipping container shutdown due to MOOSE_SKIP_CONTAINER_SHUTDOWN=true");
         }
     }
+
+    // Final delay before exit to ensure any remaining tasks complete
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Exit the process cleanly
+    info!("Exiting application");
     std::process::exit(0);
 }
 

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -89,13 +89,13 @@
 use crate::cli::local_webserver::RouteMeta;
 use crate::framework::core::plan_validator;
 use crate::infrastructure::redis::redis_client::RedisClient;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
-use tokio::time::{interval, sleep, Duration};
+use tokio::time::{interval, Duration};
 
 use crate::cli::routines::openapi::openapi;
 use crate::framework::core::execute::execute_initial_infra_change;
@@ -448,9 +448,13 @@ pub async fn start_development_mode(
         )
         .await;
 
-    {
-        let mut redis_client = redis_client.lock().await;
-        let _ = redis_client.stop_periodic_tasks().await;
+    // Ensure Redis client is properly shutdown to avoid panic when the app is terminated
+    info!("Shutting down Redis client");
+    let mut redis_client_guard = redis_client.lock().await;
+    if let Err(err) = redis_client_guard.shutdown().await {
+        warn!("Error shutting down Redis client: {:?}", err);
+    } else {
+        info!("Redis client shutdown completed successfully");
     }
 
     Ok(())
@@ -541,9 +545,13 @@ pub async fn start_production_mode(
         )
         .await;
 
-    {
-        let mut redis_client = redis_client.lock().await;
-        let _ = redis_client.stop_periodic_tasks().await;
+    // Ensure Redis client is properly shutdown to avoid panic when the app is terminated
+    info!("Shutting down Redis client");
+    let mut redis_client_guard = redis_client.lock().await;
+    if let Err(err) = redis_client_guard.shutdown().await {
+        warn!("Error shutting down Redis client: {:?}", err);
+    } else {
+        info!("Redis client shutdown completed successfully");
     }
 
     Ok(())
@@ -666,25 +674,73 @@ pub async fn remote_plan(
 }
 
 fn spawn_connection_monitor(redis_client: Arc<Mutex<RedisClient>>) {
-    tokio::spawn(async move {
-        loop {
-            let handle = {
-                let client = redis_client.lock().await;
-                client.start_connection_monitor()
-            };
-            match handle.await {
-                Ok(_) => {
-                    info!("Connection monitor exited gracefully");
-                    break;
+    // Create a watch channel for signaling shutdown
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+
+    // Store the shutdown sender in a static variable that can be accessed during application shutdown
+    // This is intentionally leaking memory, but it's fine for a shutdown handler
+    static SHUTDOWN_SENDERS: once_cell::sync::Lazy<
+        std::sync::Mutex<Vec<tokio::sync::watch::Sender<bool>>>,
+    > = once_cell::sync::Lazy::new(|| std::sync::Mutex::new(Vec::new()));
+
+    // Add our sender to the list
+    if let Ok(mut senders) = SHUTDOWN_SENDERS.lock() {
+        senders.push(shutdown_tx.clone());
+    }
+
+    // Register a Ctrl+C handler that will trigger all monitors to shut down
+    static INIT_CTRL_C: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if !INIT_CTRL_C.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        // Only register once
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                info!("Connection monitor received termination signal");
+
+                // Signal all monitors to shut down
+                if let Ok(senders) = SHUTDOWN_SENDERS.lock() {
+                    for sender in senders.iter() {
+                        let _ = sender.send(true);
+                    }
                 }
-                Err(err) => {
-                    error!(
-                        "Connection monitor panicked: {:#?}. Restarting in 1 second...",
-                        err
-                    );
-                    sleep(Duration::from_secs(1)).await;
+
+                // Small delay to allow monitors to process the shutdown signal
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        });
+    }
+
+    // Use a weak reference to avoid keeping the Redis client alive if everything else has dropped it
+    let weak_client = Arc::downgrade(&redis_client);
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    // Upgrade the weak reference to ensure the Redis client is still alive
+                    if let Some(redis_client) = weak_client.upgrade() {
+                        // Only check connection if we can get the lock without blocking
+                        if let Ok(mut client) = redis_client.try_lock() {
+                            if let Err(err) = client.check_connection().await {
+                                warn!("Error checking Redis connection: {:?}", err);
+                            }
+                        }
+                    } else {
+                        // Redis client has been dropped, we should exit
+                        info!("Redis client no longer exists, stopping connection monitor");
+                        break;
+                    }
+                }
+                result = shutdown_rx.changed() => {
+                    if result.is_ok() && *shutdown_rx.borrow() {
+                        info!("Shutting down connection monitor");
+                        break;
+                    }
                 }
             }
         }
+
+        info!("Connection monitor shutdown complete");
     });
 }

--- a/apps/framework-cli/src/infrastructure/redis/connection.rs
+++ b/apps/framework-cli/src/infrastructure/redis/connection.rs
@@ -267,4 +267,24 @@ impl ConnectionManagerWrapper {
             }
         }
     }
+
+    /// Gracefully shuts down Redis connections by sending QUIT commands.
+    ///
+    /// This method should be called as part of the application shutdown sequence
+    /// to ensure Redis connections are properly terminated.
+    pub async fn shutdown(&self) {
+        log::info!("<RedisConnection> Shutting down Redis connections");
+
+        // Send QUIT command to both connection managers
+        let mut conn = self.connection.clone();
+        let mut pub_sub = self.pub_sub.clone();
+
+        let _ = redis::cmd("QUIT").query_async::<_, ()>(&mut conn).await;
+        let _ = redis::cmd("QUIT").query_async::<_, ()>(&mut pub_sub).await;
+
+        // Mark the connection as disconnected
+        self.state.store(false, Ordering::SeqCst);
+
+        log::info!("<RedisConnection> Redis connections shutdown complete");
+    }
 }


### PR DESCRIPTION
This PR addresses a panic that occurs when the application is terminated via Ctrl+C. This happens because the Redis multiplexed connection driver is unexpectedly terminated while the application is still trying to use it.

Implemented graceful shutdown for Redis client and CLI signal handling

- Added `once_cell` dependency (version 1.21.1) to `Cargo.toml` and updated its entry in `Cargo.lock`.
- Improved the CLI shutdown process to gracefully handle Redis connections and Docker container shutdowns.
- Introduced a new `shutdown` method in `RedisClient` for proper cleanup during application termination.
- Enhanced logging for shutdown events and added error handling for Redis client shutdown.
- Updated connection monitoring to ensure Redis client is properly managed during application exit.