### PR TITLE
fix: revert default config

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1077,7 +1077,7 @@ impl Webserver {
 
                                 // This is now a namespaced topic
                                 let kafka_topic =
-                                    KafkaStreamConfig::from_topic(&project.kafka_config, topic);
+                                    KafkaStreamConfig::from_topic(&project.redpanda_config, topic);
 
                                 route_table.insert(
                                     api_endpoint.path.clone(),
@@ -1124,7 +1124,7 @@ impl Webserver {
                                     .expect("Topic not found");
 
                                 let kafka_topic =
-                                    KafkaStreamConfig::from_topic(&project.kafka_config, topic);
+                                    KafkaStreamConfig::from_topic(&project.redpanda_config, topic);
 
                                 route_table.remove(&before.path);
                                 route_table.insert(
@@ -1174,7 +1174,9 @@ impl Webserver {
             .unwrap_or_else(|e| handle_listener_err(management_socket.port(), e));
 
         let producer = if project.features.streaming_engine {
-            Some(kafka::client::create_producer(project.kafka_config.clone()))
+            Some(kafka::client::create_producer(
+                project.redpanda_config.clone(),
+            ))
         } else {
             None
         };

--- a/apps/framework-cli/src/cli/routines/ls.rs
+++ b/apps/framework-cli/src/cli/routines/ls.rs
@@ -278,7 +278,7 @@ async fn add_tables_views(
 async fn get_topics(project: &Project) -> HashSet<String> {
     let topic_blacklist = HashSet::<String>::from_iter(vec!["__consumer_offsets".to_string()]);
     HashSet::<String>::from_iter(
-        kafka::client::fetch_topics(&project.kafka_config)
+        kafka::client::fetch_topics(&project.redpanda_config)
             .await
             .unwrap()
             .into_iter()
@@ -337,7 +337,7 @@ fn format_topics(
 
                     let topics_with_prefix: Vec<String> = topics_slice
                         .iter()
-                        .map(|topic| project.kafka_config.prefix_with_namespace(topic))
+                        .map(|topic| project.redpanda_config.prefix_with_namespace(topic))
                         .collect();
 
                     topics_with_prefix.join("\n")

--- a/apps/framework-cli/src/cli/routines/peek.rs
+++ b/apps/framework-cli/src/cli/routines/peek.rs
@@ -87,9 +87,9 @@ pub async fn peek(
     let table_ref: ClickHouseTable;
 
     let mut stream: BoxStream<anyhow::Result<Value>> = if topic {
-        let group_id = project.kafka_config.prefix_with_namespace("peek");
+        let group_id = project.redpanda_config.prefix_with_namespace("peek");
 
-        consumer_ref = create_consumer(&project.kafka_config, &[("group.id", &group_id)]);
+        consumer_ref = create_consumer(&project.redpanda_config, &[("group.id", &group_id)]);
         let consumer = &consumer_ref;
         let topic_versioned = format!("{}_{}", data_model_name, version_suffix);
 

--- a/apps/framework-cli/src/cli/routines/ps.rs
+++ b/apps/framework-cli/src/cli/routines/ps.rs
@@ -65,7 +65,7 @@ fn get_webserver_process(project: &Arc<Project>) -> Option<MooseProcess> {
 }
 
 fn get_redpanda_process(project: &Arc<Project>) -> Option<MooseProcess> {
-    let broker = &project.kafka_config.broker;
+    let broker = &project.redpanda_config.broker;
     let parts: Vec<&str> = broker.split(':').collect();
     if parts.len() < 2 {
         error!("Invalid broker format: {}", broker);
@@ -79,7 +79,7 @@ fn get_redpanda_process(project: &Arc<Project>) -> Option<MooseProcess> {
         }
     };
 
-    let config_string = serde_json::to_string_pretty(&project.kafka_config).unwrap();
+    let config_string = serde_json::to_string_pretty(&project.redpanda_config).unwrap();
     get_process_by_port(
         port,
         "redpanda",

--- a/apps/framework-cli/src/framework/core/code_loader.rs
+++ b/apps/framework-cli/src/framework/core/code_loader.rs
@@ -233,7 +233,7 @@ pub fn framework_object_mapper(
         None
     };
 
-    let namespace = project.kafka_config.get_namespace_prefix();
+    let namespace = project.redpanda_config.get_namespace_prefix();
     let topic = format!(
         "{}{}_{}",
         namespace,

--- a/apps/framework-cli/src/framework/core/execute.rs
+++ b/apps/framework-cli/src/framework/core/execute.rs
@@ -102,7 +102,7 @@ pub async fn execute_initial_infra_change(
     .map_err(Box::new)?;
 
     let mut syncing_processes_registry = SyncingProcessesRegistry::new(
-        project.kafka_config.clone(),
+        project.redpanda_config.clone(),
         project.clickhouse_config.clone(),
     );
     let mut process_registries = ProcessRegistries::new(project, settings);

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -260,7 +260,7 @@ mod tests {
     fn create_test_project() -> Project {
         Project {
             language: crate::framework::languages::SupportedLanguages::Typescript,
-            kafka_config: crate::infrastructure::stream::kafka::models::KafkaConfig::default(),
+            redpanda_config: crate::infrastructure::stream::kafka::models::KafkaConfig::default(),
             clickhouse_config: crate::infrastructure::olap::clickhouse::ClickHouseConfig {
                 db_name: "test".to_string(),
                 user: "test".to_string(),

--- a/apps/framework-cli/src/infrastructure/processes/functions_registry.rs
+++ b/apps/framework-cli/src/infrastructure/processes/functions_registry.rs
@@ -53,24 +53,24 @@ impl FunctionProcessRegistry {
             (Some(source_topic), Some(target_topic)) => {
                 // TODO This will need to be made generic
                 let source_topic = StreamConfig::Redpanda(KafkaStreamConfig::from_topic(
-                    &self.project.kafka_config,
+                    &self.project.redpanda_config,
                     source_topic,
                 ));
                 let target_topic = StreamConfig::Redpanda(KafkaStreamConfig::from_topic(
-                    &self.project.kafka_config,
+                    &self.project.redpanda_config,
                     target_topic,
                 ));
 
                 let child = if function_process.is_py_function_process() {
                     Ok(python::streaming::run(
-                        &self.project.kafka_config,
+                        &self.project.redpanda_config,
                         &source_topic,
                         &target_topic,
                         &function_process.executable,
                     )?)
                 } else if function_process.is_ts_function_process() {
                     Ok(typescript::streaming::run(
-                        &self.project.kafka_config,
+                        &self.project.redpanda_config,
                         &source_topic,
                         &target_topic,
                         &function_process.executable,

--- a/apps/framework-cli/src/infrastructure/stream.rs
+++ b/apps/framework-cli/src/infrastructure/stream.rs
@@ -52,7 +52,7 @@ pub fn validate_changes(
     changes: &[StreamingChange],
 ) -> Result<(), StreamingChangesError> {
     // Convert core StreamingChange to Redpanda-specific RedpandaChange
-    let kafka_changes = convert_to_kafka_changes(&project.kafka_config, changes);
+    let kafka_changes = convert_to_kafka_changes(&project.redpanda_config, changes);
 
     // Delegate to kafka client validate_changes
     kafka::client::validate_changes(&kafka_changes)?;
@@ -82,7 +82,7 @@ pub async fn execute_changes(
     changes: &[StreamingChange],
 ) -> Result<(), StreamingChangesError> {
     // Convert core StreamingChange to Redpanda-specific RedpandaChange
-    let kafka_changes = convert_to_kafka_changes(&project.kafka_config, changes);
+    let kafka_changes = convert_to_kafka_changes(&project.redpanda_config, changes);
 
     // Delegate to redpanda client execute_changes
     kafka::client::execute_changes(project, &kafka_changes).await?;

--- a/apps/framework-cli/src/infrastructure/stream/kafka/client.rs
+++ b/apps/framework-cli/src/infrastructure/stream/kafka/client.rs
@@ -140,18 +140,18 @@ pub async fn execute_changes(
         match change {
             KafkaChange::Added(topic) => {
                 info!("Creating topic: {:?}", topic.name);
-                create_topics(&project.kafka_config, vec![&topic]).await?;
+                create_topics(&project.redpanda_config, vec![&topic]).await?;
             }
 
             KafkaChange::Removed(topic) => {
                 info!("Deleting topic: {:?}", topic.name);
-                delete_topics(&project.kafka_config, vec![&topic]).await?;
+                delete_topics(&project.redpanda_config, vec![&topic]).await?;
             }
 
             KafkaChange::Updated { before, after } => {
                 if before.retention_ms != after.retention_ms {
                     info!("Updating topic: {:?} with: {:?}", before, after);
-                    update_topic_config(&project.kafka_config, &before.name, after).await?;
+                    update_topic_config(&project.redpanda_config, &before.name, after).await?;
                 }
 
                 match before.partitions.cmp(&after.partitions) {
@@ -166,7 +166,7 @@ pub async fn execute_changes(
                             "Setting partitions count for topic: {:?} with: {:?}",
                             before.name, after.partitions
                         );
-                        add_partitions(&project.kafka_config, &before.name, after.partitions)
+                        add_partitions(&project.redpanda_config, &before.name, after.partitions)
                             .await?;
                     }
                     std::cmp::Ordering::Equal => {}

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -252,7 +252,7 @@ impl Project {
             language,
             is_production: false,
             project_location: location.clone(),
-            kafka_config: KafkaConfig::default(),
+            redpanda_config: KafkaConfig::default(),
             clickhouse_config: ClickHouseConfig::default(),
             redis_config: RedisConfig::default(),
             http_server_config: LocalWebserverConfig::default(),

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -153,8 +153,8 @@ pub struct Project {
     /// Programming language used in the project
     pub language: SupportedLanguages,
     /// RedPanda streaming configuration
-    #[serde(default, alias = "redpanda_config")]
-    pub kafka_config: KafkaConfig,
+    #[serde(default, alias = "kafka_config")]
+    pub redpanda_config: KafkaConfig,
     /// ClickHouse database configuration
     pub clickhouse_config: ClickHouseConfig,
     /// HTTP server configuration for local development


### PR DESCRIPTION
This pull request includes changes to the `apps/framework-cli/src/project.rs` file to correct the alias for the `KafkaConfig` field in the `Project` struct. The most important change involves renaming the alias to ensure the correct configuration is used.

* [`apps/framework-cli/src/project.rs`](diffhunk://#diff-74c0d9db35c20148e80233c14d50f29beafdbf7093a1e1626fb5d1aedb67e012L156-R157): Changed the alias for the `KafkaConfig` field from `redpanda_config` to `kafka_config` to correct the configuration mapping.