### PR TITLE
fix: escape on ctrl+c and a lot of mutexes

### DIFF
--- a/apps/framework-cli/src/cli/routines/ls.rs
+++ b/apps/framework-cli/src/cli/routines/ls.rs
@@ -49,8 +49,7 @@ pub async fn list_db(
         })
     })?;
 
-    let redis_guard = redis_client.lock().await;
-    let infra = InfrastructureMap::load_from_redis(&redis_guard)
+    let infra = InfrastructureMap::load_from_redis(&redis_client)
         .await
         // temporarily have some duplicate code with get_current_state
         .map_err(|e| {

--- a/apps/framework-cli/src/cli/routines/peek.rs
+++ b/apps/framework-cli/src/cli/routines/peek.rs
@@ -64,9 +64,7 @@ pub async fn peek(
         })
     })?;
 
-    let redis_guard = redis_client.lock().await;
-
-    let infra = InfrastructureMap::load_from_redis(&redis_guard)
+    let infra = InfrastructureMap::load_from_redis(&redis_client)
         .await
         .map_err(|_| {
             RoutineFailure::error(Message::new(

--- a/apps/framework-cli/src/infrastructure/redis/leadership.rs
+++ b/apps/framework-cli/src/infrastructure/redis/leadership.rs
@@ -95,7 +95,6 @@ impl LeadershipManager {
                 (true, false) // has_lock and not_new_acquisition
             }
             Ok(_) => {
-                log::debug!("<RedisLeadership> Failed to acquire lock: {} (already held by another instance)", lock_key);
                 (false, false) // doesn't have lock and not new acquisition
             }
             Err(e) => {

--- a/apps/framework-cli/src/metrics.rs
+++ b/apps/framework-cli/src/metrics.rs
@@ -160,7 +160,7 @@ pub struct MessagesOutCounterLabels {
 impl Metrics {
     pub fn new(
         telemetry_metadata: TelemetryMetadata,
-        redis_client: Option<Arc<Mutex<RedisClient>>>,
+        redis_client: Option<Arc<RedisClient>>,
     ) -> (Metrics, tokio::sync::mpsc::Receiver<MetricEvent>) {
         let (tx_events, rx_events) = tokio::sync::mpsc::channel(32);
         let metric_labels = match telemetry_metadata

--- a/apps/framework-cli/src/metrics_inserter.rs
+++ b/apps/framework-cli/src/metrics_inserter.rs
@@ -21,7 +21,7 @@ impl MetricsInserter {
     pub fn new(
         metric_labels: Option<serde_json::Map<String, serde_json::Value>>,
         metric_endpoints: Option<serde_json::Map<String, serde_json::Value>>,
-        redis_client: Option<Arc<Mutex<RedisClient>>>,
+        redis_client: Option<Arc<RedisClient>>,
     ) -> Self {
         let buffer = Arc::new(Mutex::new(Vec::new()));
 
@@ -46,7 +46,7 @@ async fn flush(
     buffer: BatchEvents,
     metric_labels: Option<serde_json::Map<String, serde_json::Value>>,
     metric_endpoints: Option<serde_json::Map<String, serde_json::Value>>,
-    redis_client: Option<Arc<Mutex<RedisClient>>>,
+    redis_client: Option<Arc<RedisClient>>,
 ) {
     let mut interval = time::interval(Duration::from_secs(MAX_FLUSH_INTERVAL_SECONDS));
     let client = Client::new();
@@ -168,8 +168,6 @@ async fn flush(
                 });
                 if let Ok(events_json) = serde_json::to_string(&message) {
                     redis_client
-                        .lock()
-                        .await
                         .post_queue_message(&events_json, Some("metrics"))
                         .await
                         .ok();


### PR DESCRIPTION
This pull request includes significant changes to the `apps/framework-cli/src/cli/local_webserver.rs` and `apps/framework-cli/src/cli/routines.rs` files to simplify the handling of the `RedisClient` by removing the `Mutex` wrapper. The most important changes include modifying the function signatures and logic to directly use `Arc<RedisClient>` instead of `Arc<Mutex<RedisClient>>`.

### Changes to `apps/framework-cli/src/cli/local_webserver.rs`:

* Removed the `Mutex` wrapper from `redis_client` in the `RouteService` struct and various function signatures, simplifying the code. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL270-R271) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL353-R353) [[3]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL384-R384) [[4]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL840-R839) [[5]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1649-R1632) [[6]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1695-R1679) [[7]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1772-R1751)
* Updated the `Webserver` implementation to initialize the `RedisClient` without the `Mutex` wrapper. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1208-R1211) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1221-R1224)
* Removed the Redis client shutdown logic from the `shutdown` function, as it is no longer needed without the `Mutex` wrapper. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1316-R1314) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1335-L1359)
* Added a terminal clear command using `crossterm` in the `shutdown` function for better UX.

### Changes to `apps/framework-cli/src/cli/routines.rs`:

* Removed the `Mutex` wrapper from `redis_client` in the `setup_redis_client` function and various function signatures, simplifying the code. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL204-R211) [[2]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL237-R246) [[3]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL283-R275) [[4]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL299-R295) [[5]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL323-R312) [[6]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL364-R348) [[7]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL417-L420)
* Removed unnecessary logging and error handling for acquiring and releasing the `Mutex` lock on the `RedisClient`. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL92-R97) [[2]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL449-L457) [[3]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL476-R448)