### PR TITLE
docs: add some planning docs

### DIFF
--- a/apps/framework-docs/src/pages/_meta.ts
+++ b/apps/framework-docs/src/pages/_meta.ts
@@ -22,6 +22,7 @@ export default {
   "stream-processing": "Stream Processing",
   "db-processing": "Database Processing",
   "consumption-apis": "Analytics APIs",
+  planning: "Infrastructure Planning",
   workflows: "Orchestrating Workflows",
   "metrics-console": "Monitoring Performance",
   "--Deploy--": {

--- a/apps/framework-docs/src/pages/planning.mdx
+++ b/apps/framework-docs/src/pages/planning.mdx
@@ -1,0 +1,132 @@
+import { Steps } from "nextra/components";
+import { Callout, Python, TypeScript, LanguageSwitcher, CTACard, CTACards } from "../components";
+import { BookOpen, Rocket } from "lucide-react";
+
+# Infrastructure Planning
+
+<LanguageSwitcher />
+
+Infrastructure planning in Moose works similarly to version control systems like Git, but for your infrastructure. It helps you manage and track changes to your data infrastructure with confidence.
+
+## Overview
+
+Moose's planning functionality:
+- Compares current infrastructure state with desired state
+- Generates detailed plans for infrastructure changes
+- Validates changes before applying them
+- Provides development and production workflows
+
+<Callout type="info" title="Infrastructure Components">
+Moose tracks changes across:
+- OLAP Database Tables
+- Streaming Engine Topics
+- API Endpoints
+- Background Processes
+</Callout>
+
+## Using Planning
+
+### Development Mode
+
+Development mode automatically plans and applies changes as you work:
+
+<TypeScript>
+```bash filename="Terminal" copy
+npx moose-cli dev
+```
+</TypeScript>
+
+<Python>
+```bash filename="Terminal" copy
+moose-cli dev
+```
+</Python>
+
+This will:
+1. Watch for changes in your code
+2. Automatically plan infrastructure updates
+3. Apply changes locally
+4. Provide immediate feedback
+
+### Remote Planning
+
+For production deployments, use remote planning to preview changes:
+
+<TypeScript>
+```bash filename="Terminal" copy
+npx moose-cli plan --url https://your-production-instance
+```
+</TypeScript>
+
+<Python>
+```bash filename="Terminal" copy
+moose-cli plan --url https://your-production-instance
+```
+</Python>
+
+<Callout type="warning" title="Authentication Required">
+Remote planning requires authentication. You can configure your moose server with the following steps:
+
+1. Generate a token using `moose-cli auth generate`
+2. Project config for the server check: 
+```yaml filename="moose.yaml" copy
+[authentication]
+admin_api_key = "your-hashed-token"
+```
+3. Supply the token when running `moose-cli plan`: `--token your-auth-token`
+
+</Callout>
+
+### Understanding Plan Output
+
+When you run a plan, Moose shows you what will change:
+
+```bash
+Infrastructure Changes:
+✨ New Components
+  + analytics_table (OLAP Table)
+  + metrics_topic (Streaming Topic)
+  + api/v2/metrics (API Endpoint)
+
+🔄 Modified Components
+  ~ users_table (Schema Update)
+  ~ events_topic (Config Change)
+
+❌ Removed Components
+  - deprecated_process (Background Process)
+```
+
+## Planning Workflow
+
+### 1. Development Flow
+
+During local development:
+1. Run `moose dev` to start development mode
+2. Make changes to your data models or configuration
+3. Moose automatically plans and applies changes
+4. View changes in real-time through the CLI
+
+### 2. Production Deployment Flow
+
+For production deployments:
+1. Develop and test changes locally
+2. Run remote planning against production
+3. Review planned changes
+4. Apply changes using your deployment process
+
+## Best Practices
+
+### Development
+- Use `moose dev` for local development
+- Monitor plan outputs for warnings
+
+### Production
+- Always use remote planning before deployments
+- Review changes carefully in production plans
+- Maintain proper authentication (as a default the admin endpoint will be returning 401 Unauthorized if the token is not configured)
+
+## Troubleshooting
+
+1. **Authentication Errors**
+   - Verify your authentication token
+   - Generate a new token using `moose-cli auth generate`


### PR DESCRIPTION
This pull request includes new documentation for the Infrastructure Planning feature in Moose and updates the metadata file to include this new section. The most important changes are the addition of the `planning.mdx` file and the update to the `_meta.ts` file to reference the new section.

Documentation updates:

* [`apps/framework-docs/src/pages/planning.mdx`](diffhunk://#diff-a30117585f8b050d879965c2363ed9e97629205f60e58b71c770baaea2a4845eR1-R132): Added comprehensive documentation for the Infrastructure Planning feature, including an overview, usage instructions, workflow descriptions, best practices, and troubleshooting tips.

Metadata updates:

* [`apps/framework-docs/src/pages/_meta.ts`](diffhunk://#diff-bba55741660583accd5270ca0dbb0cd70d66205dad611a775a3cde279749eb4dR25): Added a new entry for "Infrastructure Planning" to the metadata for the documentation site.