### PR TITLE
fix: moose check dmv2

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -262,29 +262,29 @@ async fn top_command_handler(
                     })
                 })?;
 
-            if *write_infra_map {
-                let infra_map = if project_arc.features.data_model_v2 {
-                    debug!("Loading InfrastructureMap from user code (DMV2)");
-                    InfrastructureMap::load_from_user_code(&project_arc)
-                        .await
-                        .map_err(|e| {
-                            RoutineFailure::error(Message {
-                                action: "Build".to_string(),
-                                details: format!("Failed to load InfrastructureMap: {:?}", e),
-                            })
-                        })?
-                } else {
-                    debug!("Loading InfrastructureMap from primitives");
-                    let primitive_map = PrimitiveMap::load(&project_arc).await.map_err(|e| {
+            let infra_map = if project_arc.features.data_model_v2 {
+                debug!("Loading InfrastructureMap from user code (DMV2)");
+                InfrastructureMap::load_from_user_code(&project_arc)
+                    .await
+                    .map_err(|e| {
                         RoutineFailure::error(Message {
                             action: "Build".to_string(),
-                            details: format!("Failed to load Primitives: {:?}", e),
+                            details: format!("Failed to load InfrastructureMap: {:?}", e),
                         })
-                    })?;
+                    })?
+            } else {
+                debug!("Loading InfrastructureMap from primitives");
+                let primitive_map = PrimitiveMap::load(&project_arc).await.map_err(|e| {
+                    RoutineFailure::error(Message {
+                        action: "Build".to_string(),
+                        details: format!("Failed to load Primitives: {:?}", e),
+                    })
+                })?;
 
-                    InfrastructureMap::new(&project_arc, primitive_map)
-                };
+                InfrastructureMap::new(&project_arc, primitive_map)
+            };
 
+            if *write_infra_map {
                 let json_path = project_arc
                     .internal_dir()
                     .map_err(|e| {

--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -426,7 +426,10 @@ fn copy_python_dependencies(project: &Project, package_dir: &PathBuf) -> Result<
 fn run_moose_check(package_dir: &PathBuf) -> Result<(), BuildError> {
     info!("Running moose check with --write-infra-map");
 
-    let mut cmd = Command::new("moose");
+    let mut cmd = Command::new(std::env::current_exe().map_err(|e| {
+        BuildError::MooseCheckFailed(format!("Failed to get current executable path: {}", e))
+    })?);
+
     cmd.current_dir(package_dir);
     cmd.args(["check", "--write-infra-map"]);
     let output = cmd.output()?;


### PR DESCRIPTION
This pull request includes several changes to enhance logging and error handling in the `apps/framework-cli` project. The most important changes are focused on improving the `top_command_handler` function and the `run_moose_check` function.

Enhancements to logging and error handling:

* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL248-R251): Updated the `info!` log message in the `Commands::Check` block to include the value of `write_infra_map`.
* [`apps/framework-cli/src/cli.rs`](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dR265-R286): Added detailed error handling and logging when loading the `InfrastructureMap` based on the `write_infra_map` flag.
* [`apps/framework-cli/src/cli/routines/build.rs`](diffhunk://#diff-3f227ace3a120ff6317ae024e98c9c3a16040549a735fc0c2a7a210b834ef85aL429-R432): Modified the `run_moose_check` function to use the current executable path for the `Command` and added error handling for retrieving the executable path.