### PR TITLE
fix: fix dmv2 planning

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -543,9 +543,16 @@ pub async fn remote_plan(
     url: &Option<String>,
     token: &Option<String>,
 ) -> anyhow::Result<()> {
-    // Build the inframap from the local project
-    let primitive_map = PrimitiveMap::load(project).await?;
-    let local_infra_map = InfrastructureMap::new(project, primitive_map);
+    // Build the inframap from the local project=
+    let local_infra_map = if project.features.data_model_v2 {
+        debug!("Loading InfrastructureMap from user code (DMV2)");
+        InfrastructureMap::load_from_user_code(&project).await?
+    } else {
+        debug!("Loading InfrastructureMap from primitives");
+        let primitive_map = PrimitiveMap::load(&project).await?;
+
+        InfrastructureMap::new(&project, primitive_map)
+    };
 
     // Determine the target URL
     let target_url = match url {


### PR DESCRIPTION
This pull request includes a significant change to the `remote_plan` function in `apps/framework-cli/src/cli/routines.rs` to support a new data model version (DMV2). The most important change involves modifying how the `InfrastructureMap` is built based on the project's features.

Key changes:

* [`apps/framework-cli/src/cli/routines.rs`](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL546-R555): Updated `remote_plan` function to conditionally load the `InfrastructureMap` from user code if the project uses data model version 2 (DMV2).