### PR TITLE
MOOSE-1411: clean up for dmv2 in python

### DIFF
--- a/packages/py-moose-lib/moose_lib/__init__.py
+++ b/packages/py-moose-lib/moose_lib/__init__.py
@@ -7,3 +7,5 @@ from .commons import *
 from .tasks import *
 
 from .data_models import *
+
+from .dmv2 import *

--- a/packages/py-moose-lib/moose_lib/data_models.py
+++ b/packages/py-moose-lib/moose_lib/data_models.py
@@ -66,9 +66,9 @@ def handle_key(field_type: type) -> Tuple[bool, type]:
     return False, field_type
 
 
-def handle_annotation(t: type, md: list[any]) -> Tuple[type, list[any]]:
+def handle_annotation(t: type, md: list[Any]) -> Tuple[type, list[Any]]:
     if get_origin(t) is Annotated:
-        return handle_annotation(t.__origin__, md + t.__metadata__)
+        return handle_annotation(t.__origin__, md + t.__metadata__) # type: ignore
     if get_origin(t) is Aggregated:
         args = get_args(t)
         agg_func = args[1]
@@ -80,16 +80,18 @@ def handle_annotation(t: type, md: list[any]) -> Tuple[type, list[any]]:
 
 class Column(BaseModel):
     name: str
-    data_type: str
+    data_type: DataType
     required: bool
     unique: Literal[False]
     primary_key: bool
     annotations: list[Tuple[str, Any]] = []
 
 
-def py_type_to_column_type(t: type) -> Tuple[bool, list[any], DataType]:
+def py_type_to_column_type(t: type) -> Tuple[bool, list[Any], DataType]:
     t, md = handle_annotation(t, [])
     optional, t = handle_optional(t)
+
+    data_type: DataType
 
     if t is str:
         data_type = "String"

--- a/packages/py-moose-lib/moose_lib/dmv2-serializer.py
+++ b/packages/py-moose-lib/moose_lib/dmv2-serializer.py
@@ -1,6 +1,3 @@
-from importlib import import_module
 from .internal import load_models
-
-import_module("app.main")
 
 load_models()

--- a/packages/py-moose-lib/moose_lib/dmv2.py
+++ b/packages/py-moose-lib/moose_lib/dmv2.py
@@ -1,6 +1,7 @@
 import dataclasses
 from datetime import datetime
 from enum import Enum
+from .main import IngestionFormat
 from typing import Any, Generic, Optional, TypeVar, Callable, Union, Tuple, Annotated
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -69,12 +70,6 @@ class TypedMooseResource(BaseTypedResource, Generic[T]):
     def _set_type(self, name: str, t: type[T]):
         super()._set_type(name, t)
         self.columns = Columns[T](self._t)
-
-
-class IngestionFormat(Enum):
-    """Supported formats for data ingestion."""
-    JSON = "JSON"
-    JSON_ARRAY = "JSON_ARRAY"
 
 
 class OlapConfig(BaseModel):
@@ -168,7 +163,7 @@ class IngestConfigWithDestination[T: BaseModel]:
     format: IngestionFormat = IngestionFormat.JSON
 
 
-class DataModelConfigV2(BaseModel):
+class IngestPipelineConfig(BaseModel):
     """Configuration for creating a complete data pipeline with table, stream and ingestion."""
     table: bool | OlapConfig = True
     stream: bool | StreamConfig = True
@@ -217,7 +212,7 @@ class IngestPipeline(TypedMooseResource, Generic[T]):
             raise ValueError("Ingest API was not configured for this pipeline")
         return self.ingest_api
 
-    def __init__(self, name: str, config: DataModelConfigV2, **kwargs):
+    def __init__(self, name: str, config: IngestPipelineConfig, **kwargs):
         super().__init__()
         self._set_type(name, self._get_type(kwargs))
         if config.table:

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -1,6 +1,7 @@
+from importlib import import_module
 from typing import Literal, Optional, List, Any
 from pydantic import BaseModel, ConfigDict, AliasGenerator
-
+import json
 from .data_models import Column, _to_columns
 from moose_lib.dmv2 import _tables, _streams, _ingest_apis, _egress_apis, SqlResource, _sql_resources
 from pydantic.alias_generators import to_camel
@@ -148,61 +149,11 @@ def to_infra_map() -> dict:
     return infra_map.model_dump(by_alias=True)
 
 
-def load_models(module_path: str = None) -> dict:
+def load_models():
     """
-    Loads the data models from a specified module and returns the infrastructure configuration.
-    
-    Args:
-        module_path: Path to the module to load (can be a file path or module name).
-                    If None, looks for 'main.py' in the current directory.
-    
-    Returns:
-        A dictionary with the infrastructure configuration.
+    Loads the data models from a app/main.py and prints the infrastructure configuration.
     """
-    import importlib
-    import importlib.util
-    import os
-    import sys
-    import json
-
-    if module_path is None:
-        # Try common model definition filenames, starting with main.py
-        possible_paths = [
-            os.path.join(os.getcwd(), "main.py"),
-            os.path.join(os.getcwd(), "app", "main.py"),
-            os.path.join(os.getcwd(), "models.py"),
-            os.path.join(os.getcwd(), "data_models.py"),
-            os.path.join(os.getcwd(), "app", "models.py")
-        ]
-
-        for path in possible_paths:
-            if os.path.exists(path):
-                module_path = path
-                break
-
-        if module_path is None:
-            raise FileNotFoundError(
-                "Could not find model definitions. Please specify the module path."
-            )
-
-    # Check if it's a file path or module name
-    if os.path.exists(module_path):
-        # Load from file path
-        dir_path = os.path.dirname(os.path.abspath(module_path))
-        if dir_path not in sys.path:
-            sys.path.insert(0, dir_path)
-
-        module_name = os.path.basename(module_path).replace(".py", "")
-        spec = importlib.util.spec_from_file_location(module_name, module_path)
-        if spec and spec.loader:
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-    else:
-        # Try to import as a module name
-        try:
-            importlib.import_module(module_path)
-        except ImportError:
-            raise ImportError(f"Could not load module: {module_path}")
+    import_module("app.main")
 
     # Generate the infrastructure map
     infra_map = to_infra_map()

--- a/packages/py-moose-lib/moose_lib/main.py
+++ b/packages/py-moose-lib/moose_lib/main.py
@@ -71,7 +71,7 @@ def moose_data_model(arg: Any = None) -> Any:
     def decorator(data_class: type) -> type:
         expected_file_name = os.environ.get("MOOSE_PYTHON_DM_DUMP")
         if expected_file_name and expected_file_name == get_file(data_class):
-            output = {
+            output: dict[str, str | dict] = {
                 'class_name': data_class.__name__
             }
             if arg:


### PR DESCRIPTION
no need to write `moose_lib.dmv2`
Renamed `DataModelConfigV2` to `IngestPipelineConfig`.

misc cleanups 