### PR TITLE
fix: clean up script for releases

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -582,16 +582,30 @@ jobs:
         run: |
           expect << EOF
           spawn pypi-cleanup -u 514 -p moose-cli -d 100 -r ".*" --do-it --yes
-          expect "Authentication code:"
-          send "$PYPI_OTP\r"
-          expect eof
+          expect {
+            "Authentication code:" {
+              send "$PYPI_OTP\r"
+              exp_continue
+            }
+            "No releases were found" {
+              # Nothing to do, this is fine
+            }
+            eof
+          }
           EOF
 
           expect << EOF
           spawn pypi-cleanup -u 514 -p moose-lib -d 100 -r ".*" --do-it --yes
-          expect "Authentication code:" 
-          send "$PYPI_OTP\r"
-          expect eof
+          expect {
+            "Authentication code:" {
+              send "$PYPI_OTP\r"
+              exp_continue
+            }
+            "No releases were found" {
+              # Nothing to do, this is fine
+            }
+            eof
+          }
           EOF
 
         env:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release-cli.yaml` file to improve the handling of the `pypi-cleanup` command by adding conditional checks for different outputs. The most important change is the addition of conditional handling for the "No releases were found" message.

Improvements to workflow:

* [`.github/workflows/release-cli.yaml`](diffhunk://#diff-499c73a2f13eb6f53b0606fab451145e22009c29aac1e2834c960009e4641dc1L585-R608): Added conditional handling for the "No releases were found" message in the `pypi-cleanup` command to ensure the script continues running even when no releases are found.