### PR TITLE
moose ls for dmv2

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -66,6 +66,7 @@ use crate::utilities::capture::{wait_for_usage_capture, ActivityType};
 use crate::utilities::constants::{CLI_VERSION, PROJECT_NAME_ALLOW_PATTERN};
 use crate::utilities::git::is_git_repo;
 
+use crate::cli::routines::ls::ls_dmv2;
 use anyhow::Result;
 
 #[derive(Parser)]
@@ -896,6 +897,9 @@ async fn top_command_handler(
             version,
             limit,
             streaming,
+            _type,
+            name,
+            json,
         } => {
             info!("Running ls command");
 
@@ -909,7 +913,9 @@ async fn top_command_handler(
                 machine_id.clone(),
             );
 
-            let res = if *streaming {
+            let res = if project_arc.features.data_model_v2 {
+                ls_dmv2(&project_arc, _type.as_deref(), name.as_deref(), *json).await
+            } else if *streaming {
                 list_streaming(project_arc, limit).await
             } else {
                 list_db(project_arc, version, limit).await

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -3,9 +3,8 @@
 
 use std::path::PathBuf;
 
-use clap::{Args, Subcommand};
-
 use crate::framework::languages::SupportedLanguages;
+use clap::{Args, Subcommand};
 
 #[derive(Subcommand)]
 pub enum Commands {
@@ -84,16 +83,28 @@ pub enum Commands {
     /// View Moose primitives & infrastructure
     Ls {
         /// Limit output to a specific number of data models
-        #[arg(short, long, default_value = "10")]
+        #[arg(short, long, default_value = "10", hide = true)]
         limit: u16,
 
         /// View a specific version of data models & database infrastructure (default: latest)
-        #[arg(short, long)]
+        #[arg(short, long, hide = true)]
         version: Option<String>,
 
         /// View streaming topics
-        #[arg(short, long, default_value = "false")]
+        #[arg(short, long, default_value = "false", hide = true)]
         streaming: bool,
+
+        /// Filter by infrastructure type (tables, streams, ingestion, sql_resource, consumption)
+        #[arg(long)]
+        _type: Option<String>,
+
+        /// Filter by name (supports partial matching)
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Output results in JSON format
+        #[arg(long, default_value = "false")]
+        json: bool,
     },
 
     /// Opens metrics console for viewing live metrics from your moose app

--- a/apps/framework-cli/src/cli/display.rs
+++ b/apps/framework-cli/src/cli/display.rs
@@ -298,7 +298,7 @@ pub fn show_table(headers: Vec<String>, rows: Vec<Vec<String>>) {
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS);
     table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(headers.into_iter().map(|s| s.to_string()));
+    table.set_header(headers);
 
     for row in rows {
         table.add_row(row);

--- a/apps/framework-cli/src/cli/routines/ls.rs
+++ b/apps/framework-cli/src/cli/routines/ls.rs
@@ -3,12 +3,12 @@
 //! This module provides functionality to list database resources (tables, views)
 //! and streaming resources (topics) based on the project configuration.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-
 use super::{setup_redis_client, RoutineFailure, RoutineSuccess};
+use crate::framework::core::infrastructure::api_endpoint::{APIType, ApiEndpoint};
+use crate::framework::core::infrastructure::function_process::FunctionProcess;
+use crate::framework::core::infrastructure::table::Table;
+use crate::framework::core::infrastructure::topic::Topic;
+use crate::framework::core::infrastructure::topic_sync_process::TopicToTableSyncProcess;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
 use crate::{
     cli::display::{show_table, Message},
@@ -17,6 +17,13 @@ use crate::{
         stream::kafka::{self},
     },
     project::Project,
+};
+use itertools::{Either, Itertools};
+use serde::Serialize;
+use serde_json::Error;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
 };
 
 /// Lists database resources for a given project and version.
@@ -347,4 +354,327 @@ fn format_topics(
             }
         })
         .collect()
+}
+
+// dmv2:
+#[derive(Debug, Serialize)]
+pub struct TableInfo {
+    pub name: String,
+    pub schema_fields: Vec<String>,
+}
+
+impl ResourceInfo for Vec<TableInfo> {
+    fn show(&self) {
+        show_table(
+            vec!["name".to_string(), "schema_fields".to_string()],
+            self.iter()
+                .map(|t| vec![t.name.clone(), t.schema_fields.iter().join(", ")])
+                .collect(),
+        )
+    }
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+impl From<Table> for TableInfo {
+    fn from(value: Table) -> Self {
+        Self {
+            name: value.name,
+            schema_fields: value.columns.iter().map(|col| col.name.clone()).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct StreamInfo {
+    pub name: String,
+    pub schema_fields: Vec<String>,
+    pub destination: Option<String>,
+}
+
+impl StreamInfo {
+    fn from_topic(
+        value: Topic,
+        topic_to_table_sync_processes: &HashMap<String, TopicToTableSyncProcess>,
+    ) -> Self {
+        let process = topic_to_table_sync_processes
+            .values()
+            .find(|p| p.source_topic_id == value.id());
+
+        Self {
+            name: value.name,
+            schema_fields: value.columns.iter().map(|col| col.name.clone()).collect(),
+            destination: process.map(|p| p.target_table_id.to_string()),
+        }
+    }
+}
+
+impl ResourceInfo for Vec<StreamInfo> {
+    fn show(&self) {
+        show_table(
+            vec![
+                "name".to_string(),
+                "schema_fields".to_string(),
+                "destination".to_string(),
+            ],
+            self.iter()
+                .map(|s| {
+                    vec![
+                        s.name.clone(),
+                        s.schema_fields.iter().join(", "),
+                        s.destination.clone().unwrap_or_default(),
+                    ]
+                })
+                .collect(),
+        )
+    }
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct IngestionApiInfo {
+    pub name: String,
+    pub format: String,
+    pub destination: String,
+}
+
+fn to_info(endpoint: &ApiEndpoint) -> Either<IngestionApiInfo, ConsumptionApiInfo> {
+    match &endpoint.api_type {
+        APIType::INGRESS {
+            target_topic_id,
+            data_model: _,
+            format,
+        } => Either::Left(IngestionApiInfo {
+            name: endpoint.name.clone(),
+            format: format.to_string(),
+            destination: target_topic_id.clone(),
+        }),
+        APIType::EGRESS {
+            query_params,
+            output_schema: _,
+        } => Either::Right(ConsumptionApiInfo {
+            name: endpoint.name.clone(),
+            params: query_params
+                .iter()
+                .map(|param| param.name.clone())
+                .collect(),
+            path: format!("consumption/{}", endpoint.name),
+        }),
+    }
+}
+
+impl ResourceInfo for Vec<IngestionApiInfo> {
+    fn show(&self) {
+        show_table(
+            vec![
+                "name".to_string(),
+                "format".to_string(),
+                "destination".to_string(),
+            ],
+            self.iter()
+                .map(|api| {
+                    vec![
+                        api.name.clone(),
+                        api.format.clone(),
+                        api.destination.clone(),
+                    ]
+                })
+                .collect(),
+        )
+    }
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SqlResourceInfo {
+    pub name: String,
+}
+
+impl ResourceInfo for Vec<SqlResourceInfo> {
+    fn show(&self) {
+        show_table(
+            vec!["name".to_string()],
+            self.iter()
+                .map(|resource| vec![resource.name.clone()])
+                .collect(),
+        )
+    }
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConsumptionApiInfo {
+    pub name: String,
+    pub params: Vec<String>,
+    pub path: String,
+}
+
+impl ResourceInfo for Vec<ConsumptionApiInfo> {
+    fn show(&self) {
+        show_table(
+            vec!["name".to_string(), "params".to_string(), "path".to_string()],
+            self.iter()
+                .map(|api| {
+                    vec![
+                        api.name.clone(),
+                        api.params.iter().join(", "),
+                        api.path.clone(),
+                    ]
+                })
+                .collect(),
+        )
+    }
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct StreamTransformationInfo {
+    pub source: String,
+    pub destinations: Vec<String>,
+}
+
+impl ResourceInfo for Vec<StreamTransformationInfo> {
+    fn show(&self) {
+        show_table(
+            vec!["source".to_string(), "destinations".to_string()],
+            self.iter()
+                .map(|transform| {
+                    vec![
+                        transform.source.clone(),
+                        transform.destinations.iter().join(", "),
+                    ]
+                })
+                .collect(),
+        )
+    }
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+impl From<FunctionProcess> for StreamTransformationInfo {
+    fn from(value: FunctionProcess) -> Self {
+        Self {
+            source: value.source_topic_id,
+            destinations: vec![value.target_topic_id],
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResourceListing {
+    pub tables: Vec<TableInfo>,
+    pub streams: Vec<StreamInfo>,
+    pub ingestion_apis: Vec<IngestionApiInfo>,
+    pub sql_resources: Vec<SqlResourceInfo>,
+    pub consumption_apis: Vec<ConsumptionApiInfo>,
+    pub stream_transformations: Vec<StreamTransformationInfo>,
+}
+
+impl ResourceInfo for ResourceListing {
+    fn show(&self) {
+        self.tables.show();
+        self.streams.show();
+        self.ingestion_apis.show();
+        self.sql_resources.show();
+        self.consumption_apis.show();
+        self.stream_transformations.show();
+    }
+
+    fn to_json_string(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+pub async fn ls_dmv2(
+    project: &Project,
+    _type: Option<&str>,
+    name: Option<&str>,
+    json: bool,
+) -> Result<RoutineSuccess, RoutineFailure> {
+    let infra_map = InfrastructureMap::load_from_user_code(project)
+        .await
+        .map_err(|e| {
+            RoutineFailure::new(
+                Message {
+                    action: "Load".to_string(),
+                    details: "Infrastructure".to_string(),
+                },
+                e,
+            )
+        })?;
+
+    let (ingestion_apis, consumption_apis): (Vec<_>, Vec<_>) = infra_map
+        .api_endpoints
+        .values()
+        .filter(|api| name.is_none_or(|name| api.name.contains(name)))
+        .partition_map(to_info);
+    let resources = ResourceListing {
+        tables: infra_map
+            .tables
+            .into_values()
+            .filter(|api| name.is_none_or(|name| api.name.contains(name)))
+            .map(|t| t.into())
+            .collect(),
+        streams: infra_map
+            .topics
+            .into_values()
+            .filter(|api| name.is_none_or(|name| api.name.contains(name)))
+            .map(|t| StreamInfo::from_topic(t, &infra_map.topic_to_table_sync_processes))
+            .collect(),
+        ingestion_apis,
+        sql_resources: infra_map
+            .sql_resources
+            .into_values()
+            .filter(|api| name.is_none_or(|name| api.name.contains(name)))
+            .map(|resource| SqlResourceInfo {
+                name: resource.name,
+            })
+            .collect(),
+        consumption_apis,
+        stream_transformations: infra_map
+            .function_processes
+            .into_values()
+            .filter(|api| name.is_none_or(|name| api.name.contains(name)))
+            .map(|p| p.into())
+            .collect(),
+    };
+    let listing: &dyn ResourceInfo = match _type {
+        None => &resources,
+        Some("tables") => &resources.tables,
+        Some("streams") => &resources.streams,
+        Some("ingestion") => &resources.ingestion_apis,
+        Some("sql_resource") => &resources.sql_resources,
+        Some("consumption") => &resources.consumption_apis,
+        _ => {
+            return Err(RoutineFailure::error(Message::new(
+                "Unknown".to_string(),
+                "type".to_string(),
+            )))
+        }
+    };
+    if json {
+        println!("{}", listing.to_json_string().unwrap());
+    } else {
+        listing.show();
+    }
+
+    Ok(RoutineSuccess::success(Message {
+        action: "".to_string(),
+        details: "".to_string(),
+    }))
+}
+
+trait ResourceInfo {
+    fn show(&self);
+    fn to_json_string(&self) -> Result<String, serde_json::error::Error>;
 }

--- a/apps/framework-cli/src/framework/data_model/config.rs
+++ b/apps/framework-cli/src/framework/data_model/config.rs
@@ -8,6 +8,7 @@ use log::info;
 use serde::Deserialize;
 use serde::Serialize;
 use std::ffi::OsStr;
+use std::fmt::{Display, Formatter};
 
 pub type ConfigIdentifier = String;
 
@@ -17,6 +18,19 @@ pub enum EndpointIngestionFormat {
     Json,
     #[serde(alias = "JSON_ARRAY", alias = "jsonArray")]
     JsonArray,
+}
+
+impl Display for EndpointIngestionFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                EndpointIngestionFormat::Json => "JSON",
+                EndpointIngestionFormat::JsonArray => "JSON_ARRAY",
+            }
+        )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]


### PR DESCRIPTION
```
View Moose primitives & infrastructure

Usage: moose-cli ls [OPTIONS]

Options:
      --type <TYPE>  Filter by infrastructure type (tables, streams, ingestion, sql_resource, consumption)
      --name <NAME>  Filter by name (supports partial matching)
      --json         Output results in JSON format
  -h, --help         Print help
  ```