### PR TITLE
add pnpm lock and cargo lock files to triggering event for tests

### DIFF
--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -42,6 +42,8 @@ jobs:
             "^templates/python/"
             "^templates/typescript/"
             "^packages/"
+            "Cargo.lock"
+            "pnpm-lock.yaml"
           )
 
           # Join patterns with | for grep


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/test-framework-cli.yaml` file. The change adds `Cargo.lock` and `pnpm-lock.yaml` to the list of patterns in the `jobs:` section.

* [`.github/workflows/test-framework-cli.yaml`](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16R45-R46): Added `Cargo.lock` and `pnpm-lock.yaml` to the list of patterns.