### PR TITLE
chore: add integration test for consumer function

### DIFF
--- a/packages/ts-moose-lib/src/streaming-functions/runner.ts
+++ b/packages/ts-moose-lib/src/streaming-functions/runner.ts
@@ -387,7 +387,7 @@ async function loadStreamingFunctionV2(
   targetTopic?: TopicConfig,
 ) {
   const transformFunctions = await getStreamingFunctions();
-  const transformFunctionKey = `${topicNameToStreamName(sourceTopic)}_${targetTopic ? topicNameToStreamName(targetTopic) : ""}`;
+  const transformFunctionKey = `${topicNameToStreamName(sourceTopic)}_${targetTopic ? topicNameToStreamName(targetTopic) : "<no-target>"}`;
   return transformFunctions.get(transformFunctionKey);
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `apps/framework-cli-e2e/test/templates.test.ts` and `packages/ts-moose-lib/src/streaming-functions/runner.ts` files. The main updates involve adding a new utility function for verifying consumer logs and modifying the key generation for streaming functions.

### Enhancements to testing utilities:

* [`apps/framework-cli-e2e/test/templates.test.ts`](diffhunk://#diff-bf6accc02eed3b986feb4d9795a15846a17c84ae10049e00a3ad82074ae426dbR185-R208): Added a new `verifyConsumerLogs` function to the `utils` object. This function reads the consumer logs and checks for expected output strings.
* [`apps/framework-cli-e2e/test/templates.test.ts`](diffhunk://#diff-bf6accc02eed3b986feb4d9795a15846a17c84ae10049e00a3ad82074ae426dbR315-R321): Updated test cases to use the new `verifyConsumerLogs` function to validate the consumer logs after running tests. [[1]](diffhunk://#diff-bf6accc02eed3b986feb4d9795a15846a17c84ae10049e00a3ad82074ae426dbR315-R321) [[2]](diffhunk://#diff-bf6accc02eed3b986feb4d9795a15846a17c84ae10049e00a3ad82074ae426dbR469-R475)

### Improvements to streaming functions:

* [`packages/ts-moose-lib/src/streaming-functions/runner.ts`](diffhunk://#diff-5396dd97a0860033edd722235ec84d68800aed1d1cf8a95c13336d075a5cbd92L390-R390): Modified the key generation logic in `loadStreamingFunctionV2` to use "<no-target>" instead of an empty string when `targetTopic` is not provided.