### PR TITLE
chore: enable public forks to trigger the testing workflow

### DIFF
--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -2,6 +2,8 @@ name: Test Framework CLI
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - "**"

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -372,6 +372,8 @@ impl PartialInfrastructureMap {
 
                 let table = Table {
                     // In dmv1, DataModel.to_table uses version in the name
+                    // I wonder if we should change that, in the Topics, the namespace and the version are separate so that it can be
+                    // more flexible depending on the target stream.
                     name: version
                         .as_ref()
                         .map_or(partial_table.name.clone(), |version| {
@@ -569,10 +571,11 @@ impl PartialInfrastructureMap {
                     "Target table '{}' version '{:?}' not found",
                     target_table_name, target_table_version
                 );
+
                 let target_table = tables
                     .values()
                     .find(|table| {
-                        let name_matches = table.name.starts_with(target_table_name);
+                        let name_matches = *table.name == *target_table_name;
                         let version_matches = match &target_table_version {
                             Some(target_v) => table.version.as_ref() == Some(target_v),
                             None => true,

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::infrastructure::redis::redis_client::RedisClient;
 use crate::project::Project;
-use log::error;
+use log::{debug, error};
 use rdkafka::error::KafkaError;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -90,6 +90,11 @@ pub async fn plan_changes(
     };
 
     let current_infra_map = InfrastructureMap::load_from_redis(client).await?;
+
+    debug!(
+        "Current infrastructure map: {:?}",
+        serde_json::to_string(&current_infra_map)
+    );
 
     plan_changes_from_infra_map(project, &current_infra_map, &target_infra_map).await
 }


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the Test Framework CLI to include pull request events as triggers. The most important change is enabling the workflow to run on pull request events such as `opened`, `synchronize`, and `reopened`.

Trigger updates in `.github/workflows/test-framework-cli.yaml`:

* Added `pull_request` event with types `opened`, `synchronize`, and `reopened` to the workflow triggers. This ensures the workflow is executed when pull requests are created, updated, or reopened.