### PR TITLE
fix: fork checkout running the testing workflow

### DIFF
--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - "**"
-      - "!main"
 
 defaults:
   run:
@@ -25,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Fetch main branch
         run: git fetch origin main:main
@@ -89,6 +86,9 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -119,6 +119,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: pnpm/action-setup@v4
 
@@ -163,6 +166,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: pnpm/action-setup@v4
 
@@ -207,7 +213,10 @@ jobs:
           version: "23.x"
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/test-framework-cli.yaml` to improve compatibility with pull request events and ensure the correct repository and commit are checked out during workflow runs. The most significant changes include removing the `push` trigger for non-main branches, updating the `actions/checkout` step to use the pull request's repository and commit, and upgrading the `actions/checkout` version.

### Workflow trigger updates:
* Removed the `push` trigger for all branches except `main`, leaving only `workflow_dispatch` and `pull_request` as triggers. (`[.github/workflows/test-framework-cli.yamlL7-L10](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16L7-L10)`)

### Checkout step improvements:
* Updated the `actions/checkout` step across multiple jobs to explicitly use the repository and commit from the pull request event (`github.event.pull_request.head.repo.full_name` and `github.event.pull_request.head.sha`) for better accuracy. (`[[1]](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16R24-L30)`, `[[2]](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16R89-R91)`, `[[3]](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16R122-R124)`, `[[4]](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16R169-R171)`, `[[5]](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16L210-R219)`)

### Dependency updates:
* Upgraded `actions/checkout` from `v2` to `v4` in one of the jobs for improved functionality and performance. (`[.github/workflows/test-framework-cli.yamlL210-R219](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16L210-R219)`)