### PR TITLE
fix: view should create a view, not a materialized view

### DIFF
--- a/packages/ts-moose-lib/src/dmv2/index.ts
+++ b/packages/ts-moose-lib/src/dmv2/index.ts
@@ -337,7 +337,7 @@ export class View extends SqlResource {
     super(
       name,
       [
-        `CREATE MATERIALIZED VIEW IF NOT EXISTS ${name} 
+        `CREATE VIEW IF NOT EXISTS ${name} 
         AS ${selectStatement}`.trim(),
       ],
       [dropView(name)],


### PR DESCRIPTION
This pull request includes a small change to the `View` class in the `packages/ts-moose-lib/src/dmv2/index.ts` file. The change modifies the SQL statement to create a regular view instead of a materialized view.