### PR TITLE
Fix aurora badge text color for light mode

### DIFF
--- a/apps/framework-docs/src/components/product-badge.tsx
+++ b/apps/framework-docs/src/components/product-badge.tsx
@@ -16,7 +16,7 @@ export function ProductBadge({
       "bg-moose-purple hover:bg-moose-purple-dark text-moose-purple-foreground",
     boreal:
       "bg-boreal-green hover:bg-boreal-green-dark text-boreal-green-foreground",
-    aurora: "bg-aurora-teal",
+    aurora: "bg-aurora-teal text-black",
     default: "",
   };
 


### PR DESCRIPTION
Trying to fix the color issue on Docs light mode