### PR TITLE
fix: empty python template fix

### DIFF
--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,0 +1,5 @@
+kafka-python-ng==2.2.2
+clickhouse-connect==0.7.16
+requests==2.32.3
+moose-cli
+moose-lib

--- a/templates/python-empty/setup.py
+++ b/templates/python-empty/setup.py
@@ -1,14 +1,13 @@
 
 from setuptools import setup
+import os
+
+requirements_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
+with open(requirements_path, "r") as f:
+    requirements = f.read().splitlines()
 
 setup(
-    name='demo',
+    name='python-empty',
     version='0.0',
-    install_requires=[
-        "kafka-python-ng==2.2.2",
-        "clickhouse_connect==0.7.16",
-        "requests==2.32.3",
-        "moose-cli",
-        "moose-lib",
-    ],
+    install_requires=requirements,
 )


### PR DESCRIPTION
This pull request updates the Python project template by externalizing dependencies into a `requirements.txt` file and modifying the `setup.py` file to dynamically load dependencies from it. This change improves maintainability and aligns with best practices for Python packaging.

Dependency management improvements:

* [`templates/python-empty/requirements.txt`](diffhunk://#diff-43896c6f4ed7091d4c756f6ab12654a373c6c2d93f34e3ec1b226dcf76a36055R1-R5): Added a new `requirements.txt` file containing the project's dependencies (`kafka-python-ng==2.2.2`, `clickhouse-connect==0.7.16`, `requests==2.32.3`, `moose-cli`, `moose-lib`).
* [`templates/python-empty/setup.py`](diffhunk://#diff-a75898b918f909c7a48248b39966442faf930a16b407d108ec3aa4fd79408f03R3-R12): Updated `setup.py` to dynamically load dependencies from `requirements.txt` instead of hardcoding them in the `install_requires` field. Also renamed the project from `demo` to `python-empty`.