### PR TITLE
fix: no script should not raise an error

### DIFF
--- a/apps/framework-cli/src/framework/python/wrappers/scripts/python_worker_wrapper/worker.py
+++ b/apps/framework-cli/src/framework/python/wrappers/scripts/python_worker_wrapper/worker.py
@@ -123,8 +123,8 @@ async def start_worker(temporal_url: str, script_dir: str, client_cert: str, cli
 
     if worker is None:
         msg = f"No scripts found to register in {script_dir}"
-        log.error(msg)
-        raise ValueError(msg)
+        log.info(msg)
+        return
 
     shutdown_task = None
 


### PR DESCRIPTION
This pull request modifies the behavior of the `start_worker` function in the `worker.py` script. The most important change is the replacement of an error-raising mechanism with a more graceful handling of cases where no scripts are found.

Error handling improvement:

* [`apps/framework-cli/src/framework/python/wrappers/scripts/python_worker_wrapper/worker.py`](diffhunk://#diff-5ad9516d1077ba2a15972b7f85444f806029433924d53caef1229e1869e6400bL126-R127): Changed the logging level from `error` to `info` and replaced the `raise ValueError` statement with a `return` to allow the function to exit gracefully when no scripts are found to register.