### PR TITLE
docs: add minimum requirements to the docs

### DIFF
--- a/apps/framework-docs/src/pages/moose/reference/_meta.tsx
+++ b/apps/framework-docs/src/pages/moose/reference/_meta.tsx
@@ -4,6 +4,7 @@ const meta = {
   "ts-moose-lib": "TypeScript API Reference",
   "py-moose-lib": "Python API Reference",
   "moose-cli": "CLI Reference",
+  "minimum-requirements": "Minimum Requirements",
   troubleshooting: "Troubleshooting",
   "metrics-console": "Metrics Console",
 };

--- a/apps/framework-docs/src/pages/moose/reference/minimum-requirements.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/minimum-requirements.mdx
@@ -9,7 +9,7 @@ The development setup has higher requirements because Moose runs locally along w
     -   Windows with Linux subsystem (Ubuntu preferred)
     -   Linux (Debian 10+, Ubuntu 18.10+, Fedora 29+, CentOS/RHEL 8+)
     -   Mac OS 13+
--   **Runtime:** Python 3.12+ or Node.js 20+, and Docker
+-   **Runtime:** Python 3.12+ or Node.js 20+, and Docker 24.0.0+
 
 ## Production Setup
 
@@ -22,4 +22,4 @@ The production setup has lower requirements, as external components (Redpanda, C
     -   Windows with Linux subsystem (Ubuntu preferred)
     -   Linux (Debian 10+, Ubuntu 18.10+, Fedora 29+, CentOS/RHEL 8+)
     -   Mac OS 13+
--   **Runtime:** Python 3.12+ or Node.js 20+, and Docker 
+-   **Runtime:** Python 3.12+ or Node.js 20+

--- a/apps/framework-docs/src/pages/moose/reference/minimum-requirements.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/minimum-requirements.mdx
@@ -1,0 +1,25 @@
+## Development Setup
+
+The development setup has higher requirements because Moose runs locally along with all its dependencies (Redpanda, ClickHouse, Temporal, Redis).
+
+-   **CPU:** 12 cores
+-   **Memory:** 18GB
+-   **Disk:** >500GB SSD
+-   **OS:**
+    -   Windows with Linux subsystem (Ubuntu preferred)
+    -   Linux (Debian 10+, Ubuntu 18.10+, Fedora 29+, CentOS/RHEL 8+)
+    -   Mac OS 13+
+-   **Runtime:** Python 3.12+ or Node.js 20+, and Docker
+
+## Production Setup
+
+The production setup has lower requirements, as external components (Redpanda, ClickHouse, Redis, and Temporal) are assumed to be deployed separately.
+
+-   **CPU:** 1vCPU
+-   **Memory:** 6GB
+-   **Disk:** >30GB SSD
+-   **OS:**
+    -   Windows with Linux subsystem (Ubuntu preferred)
+    -   Linux (Debian 10+, Ubuntu 18.10+, Fedora 29+, CentOS/RHEL 8+)
+    -   Mac OS 13+
+-   **Runtime:** Python 3.12+ or Node.js 20+, and Docker 


### PR DESCRIPTION
This pull request adds a new "Minimum Requirements" section to the Moose documentation, detailing both development and production setup requirements. It also updates the metadata file to include this new section.

### Documentation Updates:

* [`apps/framework-docs/src/pages/moose/reference/minimum-requirements.mdx`](diffhunk://#diff-26bc9434227283057300aedba79375b377c86776f9cbe2d2efdaad2df8c51e45R1-R25): Added a new "Minimum Requirements" page outlining system requirements for both development and production setups, including CPU, memory, disk, OS, and runtime specifications.

### Metadata Updates:

* [`apps/framework-docs/src/pages/moose/reference/_meta.tsx`](diffhunk://#diff-72567ac62ba1a7aa48392c60c70b4f096ff0fb45531b50adced601ed60e0c351R7): Added an entry for "Minimum Requirements" to the metadata object to include the new documentation page.