### PR TITLE
feat: update peek for dmv2

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -705,10 +705,11 @@ pub async fn top_command_handler(
             res
         }
         Commands::Peek {
-            data_model_name,
+            name,
             limit,
             file,
-            topic,
+            table: _,
+            stream,
         } => {
             info!("Running peek command");
 
@@ -722,7 +723,15 @@ pub async fn top_command_handler(
                 machine_id.clone(),
             );
 
-            let result = peek(project_arc, data_model_name, *limit, file.clone(), *topic).await;
+            // Default to table if neither table nor stream is specified
+            let is_stream = if *stream {
+                true
+            } else {
+                // Default to table (false) when neither flag is specified or table is explicitly specified
+                false
+            };
+
+            let result = peek(project_arc, name, *limit, file.clone(), is_stream).await;
 
             wait_for_usage_capture(capture_handle).await;
 

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -54,9 +54,10 @@ pub enum Commands {
         token: Option<String>,
     },
 
-    /// View some data from a data model
+    /// View some data from a table or stream
     Peek {
-        data_model_name: String,
+        /// Name of the table or stream to peek
+        name: String,
         /// Limit the number of rows to view
         #[arg(short, long, default_value = "5")]
         limit: u8,
@@ -64,9 +65,13 @@ pub enum Commands {
         #[arg(short, long)]
         file: Option<PathBuf>,
 
-        /// peek from the topic instead of the table
-        #[arg(long)]
-        topic: bool,
+        /// View data from a table
+        #[arg(short = 't', long = "table", group = "resource_type")]
+        table: bool,
+
+        /// View data from a stream/topic
+        #[arg(short = 's', long = "stream", group = "resource_type")]
+        stream: bool,
     },
     /// Starts a local development environment to build your data-intensive app or service
     Dev {},

--- a/apps/framework-docs/src/pages/moose/reference/moose-cli.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/moose-cli.mdx
@@ -97,13 +97,15 @@ moose metrics
 ```
 
 ### Peek
-View data from a data model.
+View data from a table or stream.
 ```bash
-moose peek <data_model_name> [--limit <n>] [--file <path>] [--topic]
+moose peek <name> [--limit <n>] [--file <path>] [-t|--table] [-s|--stream]
 ```
+- `<name>`: Name of the table or stream to peek
 - `--limit`: Number of rows to view (default: 5)
 - `--file`: Output to a file
-- `--topic`: Peek from topic instead of table
+- `-t, --table`: View data from a table (default if neither flag specified)
+- `-s, --stream`: View data from a stream/topic
 
 ## Generation Commands
 


### PR DESCRIPTION
This pull request refactors the `peek` command in the CLI to support peeking into both tables and streams, replacing the previous `data_model_name` and `topic` parameters with a unified `name` parameter and new flags for specifying resource types (`--table` and `--stream`). It also updates the documentation to reflect these changes.

### Command Refactoring:

* Updated the `Peek` command in `apps/framework-cli/src/cli/commands.rs` to replace `data_model_name` with `name` and added `--table` and `--stream` flags to specify the resource type. The default behavior is set to table if no flags are provided. (`[apps/framework-cli/src/cli/commands.rsL57-R74](diffhunk://#diff-e7f0aaaa20bae413611601b71b7dcb324e95b5d4bea41ab3c88fcb1efb4ba20fL57-R74)`)
* Modified the `top_command_handler` in `apps/framework-cli/src/cli.rs` to handle the new `name` parameter and determine whether to peek into a table or stream based on the flags. (`[[1]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL708-R712)`, `[[2]](diffhunk://#diff-395b4c1e79d334e05ed21f84d9ee188d69b5f680d11a84e64cd85a4d739e811dL725-R734)`)

### Routine Updates:

* Refactored the `peek` function in `apps/framework-cli/src/cli/routines/peek.rs` to use `name` instead of `data_model_name` and `is_stream` instead of `topic`. Updated logic for handling tables and streams accordingly. (`[[1]](diffhunk://#diff-0d8aa3f86a965c261fddfc379ec1b4e0356dcde6075a1375b98319f298ce07daL37-R50)`, `[[2]](diffhunk://#diff-0d8aa3f86a965c261fddfc379ec1b4e0356dcde6075a1375b98319f298ce07daL87-R94)`, `[[3]](diffhunk://#diff-0d8aa3f86a965c261fddfc379ec1b4e0356dcde6075a1375b98319f298ce07daL148-R151)`)

### Documentation Updates:

* Updated the CLI documentation in `apps/framework-docs/src/pages/moose/reference/moose-cli.mdx` to reflect the new `peek` command syntax and behavior, including the `--table` and `--stream` flags. (`[apps/framework-docs/src/pages/moose/reference/moose-cli.mdxL100-R108](diffhunk://#diff-94a5e5be9a33ae1bd5e5bde8679aca1ee44f092afff8294567823ab7f51ad49aL100-R108)`)