### PR TITLE
Update ts-moose-lib.mdx

### DIFF
--- a/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
@@ -3,8 +3,6 @@ title: TypeScript Moose Lib Reference
 description: TypeScript Moose Lib Reference
 ---
 
-import { LanguageSwitcher, TypeScript, Python } from "@/components";
-
 # API Reference
 
 <LanguageSwitcher />


### PR DESCRIPTION
Language switcher does not work, and is not needed, since there are separate pages for TS and Python.