### PR TITLE
docs: Structure and nesting in aurora docs

### DIFF
--- a/apps/framework-docs/src/pages/aurora/_meta.tsx
+++ b/apps/framework-docs/src/pages/aurora/_meta.tsx
@@ -1,4 +1,5 @@
 import { render } from "@/components";
+import { HandMetal, BookMarked, History } from "lucide-react";
 
 const meta = {
   index: {
@@ -7,10 +8,18 @@ const meta = {
       breadcrumb: false,
     },
   },
-  quickstart: "Quickstart",
-  "cli-reference": "CLI reference",
-  "tool-reference": "Tool reference",
-  "data-collection-policy": "Data collection policy",
+  quickstart: {
+    title: "Quickstart Guides",
+    Icon: HandMetal,
+  },
+  reference: {
+    title: "Reference",
+    Icon: BookMarked,
+  },
+  "data-collection-policy": {
+    title: "Data collection policy",
+    Icon: History,
+  },
 } as const;
 
 export default render(meta);

--- a/apps/framework-docs/src/pages/aurora/index.mdx
+++ b/apps/framework-docs/src/pages/aurora/index.mdx
@@ -17,29 +17,29 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora,moose
 
 Aurora is a set of tools to make your chat, copilot or BI fluent in data engineering. Use the CLI to set up MCPs with the tools you need in the clients you use. Create new data engineering projects with a moose-managed Clickhouse based infrastructure or use these agents with your existing data infrastructure.
 
-## Quickstarts
+## Quickstart Guides
 
 <FeatureGrid>
   <FeatureCard
-    href="/aurora/quickstart#quickstart-ad-hoc-analytics-with-clickhouse-playground-or-your-own-clickhouse-database"
+    href="/aurora/quickstart/clickhouse-chat#quickstart-ad-hoc-analytics-with-clickhouse-playground-or-your-own-clickhouse-database"
     Icon={Icons.models}
-    title="Quickstart: Chat with Clickhouse + Aurora"
+    title="Chat with Clickhouse"
     description="
     "
   />
   
   <FeatureCard
-    href="/aurora/quickstart#quickstart-analytics-engineering-project-from-clickhouse-playground-or-your-own-clickhouse-database"
+    href="/aurora/quickstart/clickhouse-proj#quickstart-analytics-engineering-project-from-clickhouse-playground-or-your-own-clickhouse-database"
     Icon={Icons.ingestion}
-    title="Quickstart: Analytics engineering with Clickhous + Moose + Aurora"
+    title="Build analytics project from Clickhouse"
     description="
     "
   />
   
   <FeatureCard
-    href="/aurora/quickstart#quickstart-new-complete-local-olap-project-from-template"
+    href="/aurora/quickstart/from-template#quickstart-new-complete-local-olap-project-from-template"
     Icon={Icons.streams}
-    title="Quickstart: Deploy a full analytics backend from a template, develop with chat"
+    title="Full stack OLAP project from Template"
     description="
     "
   />

--- a/apps/framework-docs/src/pages/aurora/quickstart/_meta.tsx
+++ b/apps/framework-docs/src/pages/aurora/quickstart/_meta.tsx
@@ -1,0 +1,8 @@
+import { render } from "@/components";
+const meta = {
+  index: { title: "Quickstart Guides", display: "hidden" },
+  "clickhouse-chat": "Chat with Clickhouse",
+  "clickhouse-proj": "Build analytics project from Clickhouse",
+  "from-template": "Full stack OLAP project from Template",
+};
+export default render(meta);

--- a/apps/framework-docs/src/pages/aurora/quickstart/clickhouse-chat.mdx
+++ b/apps/framework-docs/src/pages/aurora/quickstart/clickhouse-chat.mdx
@@ -1,0 +1,63 @@
+import { FeatureCard, FeatureGrid, Icons, Callout } from "@/components";
+import { Steps } from "nextra/components";
+
+## Quickstart: Ad hoc analytics with Clickhouse Playground or your own Clickhouse database
+
+This will walk you through using Aurora CLI to connect Aurora MCP tools to your Clickhouse database, allowing you to chat with your data in your client of choice. We'll use the Clickhouse Playground as our example database, but you can use any Clickhouse database.
+
+<Callout type="info" title="Prerequisites">
+- **OS**: macOS or Linux (WSL supported for Windows)
+- **Node**: [version 20+](https://nodejs.org/en/download) (LTS recommended)
+- **Client**: [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download) or [Windsurf](https://windsurf.ai/download). For this particular use-case, we recommend Claude Desktop.
+</Callout>
+
+<Steps>
+### Install Aurora CLI
+
+```bash filename="Terminal" copy
+bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora
+```
+
+### Configure your Aurora MCP
+
+```bash filename="Terminal" copy
+aurora connect clickhouse --connection-string "clickhouse://explorer:@play.clickhouse.com:443/default" --mcp cursor-project
+```
+
+This will configure the [Clickhouse MCP tools](https://docs.fiveonefour.com/aurora/tool-reference#remote-clickhouse) to read data from Clickhouse's Playground, but you can point this at any Clickhouse database. It sets up the MCP in Claude Desktop, but you can change this with the `--mcp` flag.
+
+### Chat
+
+Open your Claude Desktop client. 
+
+You can check that the MCP is correctly configured by looking at `claude > settings > developer > aurora`. It should say "running".
+
+You can can also look at `search and tools` beneath the chat window, you should see `aurora` in the list of MCPs—if you click into it, you should see the tools that are enabled.
+
+We recommend starting the chat with a context setting question like "tell me about the data I have available to me in Clickhouse".
+
+</Steps>
+
+## Other Quickstart Guides
+
+<FeatureGrid>
+  
+  <FeatureCard
+    href="/aurora/quickstart/clickhouse-proj#quickstart-analytics-engineering-project-from-clickhouse-playground-or-your-own-clickhouse-database"
+    Icon={Icons.ingestion}
+    title="Build analytics project from Clickhouse"
+    description="
+    Mirror of your production Clickhouse OLAP stack locally—new data/analytics engineering created in chat with Aurora MCP.
+    "
+  />
+  
+  <FeatureCard
+    href="/aurora/quickstart/from-template#quickstart-new-complete-local-olap-project-from-template"
+    Icon={Icons.streams}
+    title="Full stack OLAP project from Template"
+    description="
+    Create a full local OLAP dev environment with one command. Data primitives in ts or py. Aurora MCP tools for creating new primitives.
+    "
+  />
+
+</FeatureGrid> 

--- a/apps/framework-docs/src/pages/aurora/quickstart/clickhouse-proj.mdx
+++ b/apps/framework-docs/src/pages/aurora/quickstart/clickhouse-proj.mdx
@@ -1,0 +1,131 @@
+import { FeatureCard, FeatureGrid, Icons, Callout } from "@/components";
+import { Steps } from "nextra/components";
+
+## Quickstart: Analytics engineering project from Clickhouse Playground or your own Clickhouse database
+
+This will walk you through creating a new local Moose project reflecting the structure of your Clickhouse database. It will allow you to add data to your local dev environment from your remote Clickhouse database, and use Aurora MCP tools to enrich your project with metadata, or create new Moose primitives that you can use in your project (e.g.egress APIs). We'll use the Clickhouse Playground as our example database, but you can use any Clickhouse database.
+
+<Callout type="info" title="Prerequisites">
+- **OS**: macOS or Linux (WSL supported for Windows)
+- **Docker Desktop/Engine**: [24.0.0+](https://docs.docker.com/get-started/get-docker/)
+- **Node**: [version 20+](https://nodejs.org/en/download) (LTS recommended)
+- **Anthropic API Key**: [Get one here](https://docs.anthropic.com/en/docs/initial-setup)
+- **Client**: [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download) or [Windsurf](https://windsurf.ai/download). For this particular use-case, we recommend Claude Desktop.
+</Callout>
+
+<Steps>
+### Install Moose and Aurora CLIs
+
+```bash filename="Terminal" copy
+bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,aurora
+```
+
+We'll be using generative MCP tools here, so make sure you add your Anthropic API key in install. If you installed without adding it, you can add it later with `aurora config keys anthropic <your-api-key>`. If you need to create one, see: https://docs.anthropic.com/en/docs/initial-setup.
+
+### Create a new Moose project from your Clickhouse database
+
+```aurora init my_project_name --from-remote 'clickhouse://explorer:@play.clickhouse.com:443/default' --language python --mcp cursor-project```
+
+This will create a new Moose project from your Clickhouse database. [See Moose docs](https://docs.fiveonefour.com/moose) for more information about the project structure, and how it spins up your local development environment (including a local Clickhouse database).
+
+The new project is called "my_project_name" and is created in the current directory. the string after `--from-remote` is the connection string to your Clickhouse database, structured as `clickhouse://<username>:<password>@<host>:<port>/<database>` (note, the Clickhouse Playground has no password).
+
+### Install dependencies and run the dev server
+
+Before you can run Moose's local dev server, Docker Desktop must be running.
+
+Navigate into the project directory:
+
+```bash filename="Terminal" copy
+cd my_project_name
+```
+
+Install the dependencies: 
+
+```bash filename="Terminal" copy
+npm i
+```
+
+Run the dev server:
+
+```bash filename="Terminal" copy
+moose dev
+```
+
+### Get sample data
+
+```bash filename="Terminal" copy
+moose seed from-remote-clickhouse clickhouse://explorer:@play.clickhouse.com:443/default --rows 200
+```
+
+This will seed your local Clickhouse database with 200 rows of sample data from your remote Clickhouse database—here, the Clickhouse Playground. You can change the number of rows with the `--rows` flag.
+
+This will improve the context provided to Aurora's MCP tools, and make it easier to validate analytic engineering tasks.
+
+### Set up your Client
+
+The `aurora init` command above configured Cursor to use Aurora MCP tools. You can check this by opening Cursor and looking at `cursor > settings > cursor settings > MCP` menu. You should see `aurora` in the list of MCPs, alongside a list of tools. 
+
+You may need to enable the MCP. Once you do so, you should see a green 🟢 status indicator next to it.
+
+If you would like to use a different client, you can use the following command from within the project directory:
+
+```bash filename="Termainal" copy
+aurora setup --mcp <host>
+```
+
+### Enrich project with metadata [coming soon]
+
+Since we have a Moose project with sample data and some metadata, we can use this to create more metadata! 
+
+If we ask our client "Can you add a description to each Moose primitive in this project?", the LLM will use the `write_metadata` tool to add a description to each Moose primitive.
+
+```TypeScript filename="my_project_name/index.ts"
+const acPipeline = new IngestPipeline<AircraftTrackingProcessed>(
+    "AircraftTrackingProcessed",
+    {
+      table: true,
+      stream: true,
+      ingest: false,
+      metadata: {
+          description: "Pipeline for ingesting raw aircraft data" } // new description field!
+      }
+    
+);
+```
+
+### Chat with your data
+
+You can also now just chat with your client about your data! Try asking "Look at my MTA data in clickhouse, tell me about the trains that ran in the last 24 hours."
+
+The client will use `read_moose_project`, `read_clickhouse_tables` and maybe `read_production_clickhouse` to answer your question.
+
+### Create new Egress APIs with Aurora MCP tools
+
+If you find a thread that you find interesting enough to want to productionize, try asking the client "can you create an egress API to furnish that data?"
+
+The client will use `create_egress_api` and `test_egress_api` to create an egress API primitives in Moose, that will automatically deploy in your local dev environment when you save.
+
+</Steps>
+## Other Quickstart Guides
+
+<FeatureGrid>
+  <FeatureCard
+    href="/aurora/quickstart/clickhouse-chat#quickstart-ad-hoc-analytics-with-clickhouse-playground-or-your-own-clickhouse-database"
+    Icon={Icons.models}
+    title="Chat with Clickhouse"
+    description="
+    Connect your LLM client to a Clickhouse database and chat with your data. 
+    "
+  />
+  
+  <FeatureCard
+    href="/aurora/quickstart/from-template#quickstart-new-complete-local-olap-project-from-template"
+    Icon={Icons.streams}
+    title="Full stack OLAP project from Template"
+    description="
+    Create a full local OLAP dev environment with one command. Data primitives in ts or py. Aurora MCP tools for creating new primitives.
+    "
+  />
+
+</FeatureGrid> 

--- a/apps/framework-docs/src/pages/aurora/quickstart/from-template.mdx
+++ b/apps/framework-docs/src/pages/aurora/quickstart/from-template.mdx
@@ -1,0 +1,123 @@
+import { FeatureCard, FeatureGrid, Icons, Callout } from "@/components";
+import { Steps } from "nextra/components";
+
+## Quickstart: New complete local OLAP project from template
+
+This will get you started with a Moose data engineering project ingesting Aircraft Transponder data that you can use to learn about Aurora's Analytics Engineering MCP toolset.
+
+<Callout type="info" title="Prerequisites">
+- **OS**: macOS or Linux (WSL supported for Windows)
+- **Docker Desktop/Engine**: [24.0.0+](https://docs.docker.com/get-started/get-docker/)
+- **Node**: [version 20+](https://nodejs.org/en/download) (LTS recommended)
+- **Anthropic API Key**: [Get one here](https://docs.anthropic.com/en/docs/initial-setup)
+- **Client**: [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download) or [Windsurf](https://windsurf.ai/download). For this particular use-case, we recommend Claude Desktop.
+</Callout>
+
+<Steps>
+
+### Install Aurora and Moose CLIs
+
+```bash filename="Terminal" copy
+bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora,moose
+```
+
+We'll be using generative MCP tools here, so make sure you add your Anthropic API key in install. If you installed without adding it, you can add it later with `aurora config keys anthropic <your-api-key>`.  If you need to create one, see: https://docs.anthropic.com/en/docs/initial-setup.
+
+
+### Create a new Moose project from the ADS-B template
+
+```bash filename="Terminal" copy
+aurora init <project-name> ads-b
+```
+
+This will create a new Moose project using the ADS-B template to gather ADS-B (aircraft transponder) data that you can use to explore Aurora's MCP offerings. By default, it will create the project configured for use with Cursor (by creating `~/.cursor/mcp.config`), but if you would like to use Claude Desktop, append `--mcp claude-desktop`.
+
+If you want to create an empty project, and build your own Data Models and ingestion, try `aurora init <project-name> typescript-empty` or `aurora init <project-name> python-empty`
+
+### Install dependencies and run the dev server
+
+Navigate into the created project directory: 
+
+```bash filename="Terminal" copy
+cd <project-name>
+```
+
+Install the dependencies: 
+
+```bash filename="Terminal" copy
+npm i
+```
+
+Run the dev server:
+
+```bash filename="Terminal" copy
+moose dev
+```
+
+### Set up your client: open Cursor and Enable the MCPs
+
+Then open your code editor (e.g. by `cursor .`).
+
+Cursor should prompt you to enable the MCP. If it doesn't, go to `cursor > settings > cursor settings > MCP` and enable the MCP called "aurora". Note, the tools will not all work until the dev server is run locally! Note, you might need to refresh the MCP until its status indicator shows 🟢.
+
+### Start Ingesting Data
+
+Run the command to start ingesting data with the configured ingest scripts: `moose workflow run military_aircraft_tracking`
+
+You should start to see hundreds of live datapoints ingesting instantly!
+
+### Enrich project with metadata [coming soon]
+
+Since we have a Moose project with sample data and some metadata, we can use this to create more metadata! 
+
+If we ask our client "Can you add a description to each Moose primitive in this project?", the LLM will use the `write_metadata` tool to add a description to each Moose primitive.
+
+```TypeScript filename="my_project_name/index.ts"
+const acPipeline = new IngestPipeline<AircraftTrackingProcessed>(
+    "AircraftTrackingProcessed",
+    {
+      table: true,
+      stream: true,
+      ingest: false,
+      metadata: {
+          description: "Pipeline for ingesting raw aircraft data" } // new description field!
+      }
+    
+);
+```
+
+### Chat with your data
+
+You can also now just chat with your client about your data! Try asking "What aircraft are listed in the data I have available."
+
+The client will use `read_moose_project`, `read_clickhouse_tables` and maybe `read_production_clickhouse` to answer your question.
+
+### Create new Egress APIs with Aurora MCP tools
+
+If you find a thread that you find interesting enough to want to productionize, try asking the client "can you create an egress API to furnish that data?"
+
+The client will use `create_egress_api` and `test_egress_api` to create an egress API primitives in Moose, that will automatically deploy in your local dev environment when you save.
+
+</Steps>
+
+## Other Quickstart Guides
+<FeatureGrid>
+  <FeatureCard
+    href="/aurora/quickstart/clickhouse-chat#quickstart-ad-hoc-analytics-with-clickhouse-playground-or-your-own-clickhouse-database"
+    Icon={Icons.models}
+    title="Chat with Clickhouse"
+    description="
+    Connect your LLM client to a Clickhouse database and chat with your data. 
+    "
+  />
+  
+  <FeatureCard
+    href="/aurora/quickstart/clickhouse-proj#quickstart-analytics-engineering-project-from-clickhouse-playground-or-your-own-clickhouse-database"
+    Icon={Icons.ingestion}
+    title="Build analytics project from Clickhouse"
+    description="
+    Mirror of your production Clickhouse OLAP stack locally—new data/analytics engineering created in chat with Aurora MCP.
+    "
+  />
+
+</FeatureGrid> 

--- a/apps/framework-docs/src/pages/aurora/quickstart/index.mdx
+++ b/apps/framework-docs/src/pages/aurora/quickstart/index.mdx
@@ -1,0 +1,60 @@
+---
+title: Quickstart
+description: Quickstart guide for Aurora
+---
+
+import { Callout } from "@/components";
+import { Tabs, Steps, Card, FileTree } from "nextra/components";
+import {
+  CTACard,
+  CTACards,
+  ZoomImg,
+  ChipButton,
+  Columns,
+  Column,
+  FeatureCard,
+  FeatureGrid,
+  BulletPointsCard,
+  QnABullets,
+  CheckmarkBullets,
+  Icons,
+} from "@/components";
+
+# Aurora Quickstart Guides
+
+Aurora exposes tools to your LLM client for reading, exploring, and building on Clickhouse data—locally or in production. Go from remote Clickhouse to natural language queries, metadata, and egress APIs in minutes. These quickstarts will show you how to get started with ad-hoc analytics on your Clickhouse project, create your own local dev environment that you can build on with Aurora MCP tools, and deploy a full analytics backend from a template.
+
+```bash filename="Terminal" copy
+bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,aurora
+```
+
+<FeatureGrid>
+  <FeatureCard
+    href="/aurora/quickstart/clickhouse-chat#quickstart-ad-hoc-analytics-with-clickhouse-playground-or-your-own-clickhouse-database"
+    Icon={Icons.models}
+    title="Chat with Clickhouse"
+    description="
+    Connect your LLM client to a Clickhouse database and chat with your data. 
+    "
+  />
+  
+  <FeatureCard
+    href="/aurora/quickstart/clickhouse-proj#quickstart-analytics-engineering-project-from-clickhouse-playground-or-your-own-clickhouse-database"
+    Icon={Icons.ingestion}
+    title="Build analytics project from Clickhouse"
+    description="
+    Mirror of your production Clickhouse OLAP stack locally—new data/analytics engineering created in chat with Aurora MCP.
+    "
+  />
+  
+  <FeatureCard
+    href="/aurora/quickstart/from-template#quickstart-new-complete-local-olap-project-from-template"
+    Icon={Icons.streams}
+    title="Full stack OLAP project from Template"
+    description="
+    Create a full local OLAP dev environment with one command. Data primitives in ts or py. Aurora MCP tools for creating new primitives.
+    "
+  />
+
+</FeatureGrid>
+

--- a/apps/framework-docs/src/pages/aurora/reference/_meta.tsx
+++ b/apps/framework-docs/src/pages/aurora/reference/_meta.tsx
@@ -1,0 +1,6 @@
+import { render } from "@/components";
+const meta = {
+  "cli-reference": "CLI reference",
+  "tool-reference": "Tool reference",
+};
+export default render(meta);

--- a/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
@@ -7,8 +7,8 @@ description: CLI Reference for Aurora
 
 ## Install CLI
 
-```
-bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora,moose
+```bash filename="Terminal" copy
+bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora
 ```
 
 ## Commands

--- a/apps/framework-docs/src/pages/aurora/reference/tool-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/tool-reference.mdx
@@ -7,7 +7,7 @@ description: MCP tools and external tools for Aurora
 
 Aurora CLI can allow you to use various Aurora MCP tool-sets, as well as install and configure certain external tools. The command `aurora config tools` allows you to configure the tools you want to use. These tools are additive, select the tools you wish to use (if certain tools have dependencies, they will be enabled automatically).
 
-## Read tools `read-only` 
+## Read tools
 Tools needed to read the Moose project and its associated infrastructure. These are enabled by default. Toggle `read-only` in `aurora config tools` to enable manually.
 
 - `read_moose_project`


### PR DESCRIPTION
This pull request restructures the Aurora documentation by introducing reorganizing the Quickstart guides into individual pages, and updating navigation and content to improve clarity and usability. The changes include the addition of icons for better visual representation, the creation of dedicated pages for specific Quickstart guides, and the removal of the old consolidated Quickstart page.
