### PR TITLE
docs: component for CLI reference [AURORA-588]

### DIFF
--- a/apps/framework-docs/src/components/command-doc-card.tsx
+++ b/apps/framework-docs/src/components/command-doc-card.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface CommandMetadata {
+  name: string;
+  value: string | React.ReactNode;
+}
+
+interface CommandDocCardProps {
+  title: string;
+  description: string;
+  className?: string;
+}
+
+export function CommandDocCard({
+  title,
+  description,
+  className = "",
+}: CommandDocCardProps) {
+  // Example content for aurora init
+  const command =
+    "aurora init <project-name> <template-name> <--mcp <host>> <--location <location>>";
+  const metadata: CommandMetadata[] = [
+    {
+      name: "Description",
+      value:
+        "Creates a data engineering project with Moose, with Aurora MCP preconfigured.",
+    },
+    { name: "<project-name>", value: "Name of your application (Required)" },
+    {
+      name: "<template-name>",
+      value:
+        "Template to base your app on (e.g. typescript-empty, ads-b) (Required)",
+    },
+    {
+      name: "--mcp",
+      value: "Which MCP host to use (Optional, e.g. cursor-project)",
+    },
+    { name: "--location", value: "Location of your app or service (Optional)" },
+    {
+      name: "--no-fail-already-exists",
+      value: "Allow rerun if location exists (Optional)",
+    },
+  ];
+  const [copied, setCopied] = React.useState(false);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-4">
+          <pre className="bg-muted rounded px-3 py-2 text-sm overflow-x-auto flex-1">
+            {command}
+          </pre>
+          <Button size="sm" variant="outline" onClick={handleCopy}>
+            {copied ? "Copied!" : "Copy"}
+          </Button>
+        </div>
+        <div className="w-full overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <tbody>
+              {metadata.map((meta) => (
+                <tr
+                  key={meta.name}
+                  className="border-b last:border-0 align-top"
+                >
+                  <td className="py-1 pr-4 align-top whitespace-nowrap font-semibold">
+                    {meta.name}
+                  </td>
+                  <td className="py-1 pr-4 align-top">{meta.value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/framework-docs/src/components/command-doc-card.tsx
+++ b/apps/framework-docs/src/components/command-doc-card.tsx
@@ -3,52 +3,39 @@ import {
   Card,
   CardHeader,
   CardContent,
-  CardTitle,
   CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
 interface CommandMetadata {
   name: string;
-  value: string | React.ReactNode;
+  value?: string | React.ReactNode;
+  description?: string;
+  required?: boolean;
+  example?: string;
 }
 
 interface CommandDocCardProps {
   title: string;
   description: string;
+  command: string;
+  parameters: CommandMetadata[];
   className?: string;
+  /**
+   * Semantic heading level for the title (e.g., 'h2', 'h3', 'h4').
+   * Defaults to 'h3'. Used for TOC integration.
+   */
+  headingLevel?: "h2" | "h3" | "h4" | "h5";
 }
 
 export function CommandDocCard({
   title,
   description,
+  command,
+  parameters = [],
   className = "",
+  headingLevel = "h3",
 }: CommandDocCardProps) {
-  // Example content for aurora init
-  const command =
-    "aurora init <project-name> <template-name> <--mcp <host>> <--location <location>>";
-  const metadata: CommandMetadata[] = [
-    {
-      name: "Description",
-      value:
-        "Creates a data engineering project with Moose, with Aurora MCP preconfigured.",
-    },
-    { name: "<project-name>", value: "Name of your application (Required)" },
-    {
-      name: "<template-name>",
-      value:
-        "Template to base your app on (e.g. typescript-empty, ads-b) (Required)",
-    },
-    {
-      name: "--mcp",
-      value: "Which MCP host to use (Optional, e.g. cursor-project)",
-    },
-    { name: "--location", value: "Location of your app or service (Optional)" },
-    {
-      name: "--no-fail-already-exists",
-      value: "Allow rerun if location exists (Optional)",
-    },
-  ];
   const [copied, setCopied] = React.useState(false);
   const handleCopy = () => {
     navigator.clipboard.writeText(command);
@@ -56,13 +43,27 @@ export function CommandDocCard({
     setTimeout(() => setCopied(false), 1200);
   };
 
+  const HeadingTag = headingLevel;
+  const headingId = title.toLowerCase().replace(/\s+/g, "-");
+
   return (
     <Card className={className}>
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
+        <HeadingTag
+          id={headingId}
+          className="scroll-mt-24 text-lg font-semibold tracking-tight flex items-center gap-2"
+        >
+          <a href={`#${headingId}`} className="hover:underline text-inherit">
+            {title}
+          </a>
+        </HeadingTag>
       </CardHeader>
       <CardContent>
+        {description && (
+          <div className="mb-4 text-muted-foreground text-sm leading-relaxed">
+            {description}
+          </div>
+        )}
         <div className="flex items-center gap-2 mb-4">
           <pre className="bg-muted rounded px-3 py-2 text-sm overflow-x-auto flex-1">
             {command}
@@ -74,17 +75,35 @@ export function CommandDocCard({
         <div className="w-full overflow-x-auto">
           <table className="w-full text-sm border-collapse">
             <tbody>
-              {metadata.map((meta) => (
-                <tr
-                  key={meta.name}
-                  className="border-b last:border-0 align-top"
-                >
-                  <td className="py-1 pr-4 align-top whitespace-nowrap font-semibold">
-                    {meta.name}
-                  </td>
-                  <td className="py-1 pr-4 align-top">{meta.value}</td>
-                </tr>
-              ))}
+              {parameters
+                .filter((meta) => meta.name !== "Description")
+                .map((meta) => (
+                  <tr
+                    key={meta.name}
+                    className="border-b last:border-0 align-top"
+                  >
+                    <td className="py-1 pr-4 align-top whitespace-nowrap font-semibold">
+                      <code className="px-1.5 py-0.5 rounded bg-muted text-primary font-mono text-xs">
+                        {meta.name}
+                      </code>
+                    </td>
+                    <td className="py-1 pr-4 align-top">
+                      {meta.description || meta.value}{" "}
+                      <span
+                        className={
+                          meta.required ?
+                            "ml-2 inline-block px-2 py-0.5 rounded-full bg-green-100 text-green-800 text-xs font-medium"
+                          : "ml-2 inline-block px-2 py-0.5 rounded-full bg-gray-100 text-gray-800 text-xs font-medium"
+                        }
+                      >
+                        {meta.required ? "Required" : "Optional"}
+                      </span>
+                    </td>
+                    <td className="py-1 pr-4 align-top">
+                      {meta.example ? `e.g. ${meta.example}` : ""}
+                    </td>
+                  </tr>
+                ))}
             </tbody>
           </table>
         </div>

--- a/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
@@ -3,6 +3,9 @@ title: CLI Reference
 description: CLI Reference for Aurora
 ---
 
+import { CommandDocCard } from "@/components/command-doc-card";
+
+
 # CLI Reference
 
 ## Install CLI
@@ -15,24 +18,19 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora
 
 ### init
 
-Creates a data engineering project with Moose, with Aurora MCP preconfigured.
-
-```
-aurora init <project-name> <template-name> <--mcp <host>> <--location <location>> 
-```
-
-- `<name>`: name of your application
-- `--mcp <host>`: Choice of which MCP host to [default: `cursor-project`] [possible values: `claude-desktop`, `cursor-global`, `cursor-project`, `windsurf-global`]
-- `--location <location>`: Location of your app or service. The default is the name of the project.
-- `--no-fail-already-exists`: By default, the init command fails if `location` exists, to prevent accidental reruns. This flag disables the check.
-
-- If creating a new project:
-    - `<template-name>`: the template you are basing your application on. Choose from an empty project (e.g. `typescript-empty`, a default project `typescript` or a pre-built project `ads-b`).
-    - `--from-remote <connection-string>`: If you are creating a project from a pre-existing Clickhouse database, use this flag. Do not use a template.
-
-- If creating a project from a pre-existing Clickhouse database:
-    - `--from-remote <connection-string>`: The connection string to your Clickhouse database.
-    - `--language <language>`: The language of your application. [possible values] `typescript` or `python`].
+<CommandDocCard
+  title="Aurora Init"
+  description="Creates a data engineering project with Moose, with Aurora MCP preconfigured."
+  command={`aurora init <project-name> <template-name> <--mcp <host>> <--location <location>>`}
+  parameters={[
+    { name: "<project-name>", description: "Name of your application", required: true },
+    { name: "<template-name>", description: "Template to base your app on (e.g. typescript-empty, ads-b)", required: true },
+    { name: "--mcp", description: "Which MCP host to use", required: false, example: "cursor-project" },
+    { name: "--location", description: "Location of your app or service", required: false },
+    { name: "--no-fail-already-exists", description: "Allow rerun if location exists", required: false },
+    // ...add more as needed
+  ]}
+/>
 
 ### connect
 

--- a/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
@@ -16,86 +16,101 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) aurora
 
 ## Commands
 
-### init
-
 <CommandDocCard
-  title="Aurora Init"
+  title="init"
+  headingLevel="h3"
   description="Creates a data engineering project with Moose, with Aurora MCP preconfigured."
   command={`aurora init <project-name> <template-name> <--mcp <host>> <--location <location>>`}
   parameters={[
     { name: "<project-name>", description: "Name of your application", required: true },
-    { name: "<template-name>", description: "Template to base your app on (e.g. typescript-empty, ads-b)", required: true },
-    { name: "--mcp", description: "Which MCP host to use", required: false, example: "cursor-project" },
+    { name: "<template-name>", description: "Template to base your app on", required: true, example: "typescript-empty, ads-b"  },
+    { name: "--mcp", description: "Which MCP host to use", required: false, },
     { name: "--location", description: "Location of your app or service", required: false },
     { name: "--no-fail-already-exists", description: "Allow rerun if location exists", required: false },
-    // ...add more as needed
   ]}
+  className="mb-8"
 />
 
-### connect
+<CommandDocCard
+  title="connect"
+  headingLevel="h3"
+  description="Connects to an existing data source. Currently only clickhouse is supported."
+  command={`aurora connect clickhouse <--connection-string <connection-string>> <--mcp <host>>`}
+  parameters={[
+    {
+      name: "--connection-string",
+      description: "The connection string to your Clickhouse database.",
+      required: true,
+      example: "clickhouse://user:pass@host:port/db"
+    },
+    {
+      name: "--mcp",
+      description: "Choice of which MCP host to use",
+      required: false,
+      example: "cursor-project (default), claude-desktop, cursor-global, windsurf-global"
+    }
+  ]}
+  className="mb-8"
+/>
 
-Connects to an existing data source. Currently only `clickhouse` is supported.
+<CommandDocCard
+  title="setup"
+  headingLevel="h3"
+  description="Takes an existing data engineering project built with Moose and configures Aurora MCP for it."
+  command={`aurora setup [path] <--mcp <host>>`}
+  parameters={[
+    { name: "[path]", description: "Path to the Moose project (defaults to current directory)", required: false },
+    { name: "--mcp", description: "Choice of which MCP host to use", required: false, example: "cursor-project (default) claude-desktop, cursor-global, windsurf-global" },
+  ]}
+  className="mb-8"
+/>
 
-```
-aurora connect clickhouse <--connection-string <connection-string>> <--mcp <claude-desktop>>
-```
+### Config
 
-- `--connection-string <connection-string>`: The connection string to your Clickhouse database.
-- `--mcp <host>`: Choice of which MCP host to [default: `cursor-project`] [possible values: `claude-desktop`, `cursor-global`, `cursor-project`, `windsurf-global`]
+<CommandDocCard
+  title="config focus"
+  headingLevel="h4"
+  description="List Aurora configured projects, allows selection of project globally configured hosts are 'focused' on. No more than one Moose Project may be run at a time."
+  command={`aurora config focus`}
+  parameters={[]}
+  className="mb-8"
+/>
 
-### setup
+<CommandDocCard
+  title="config keys"
+  headingLevel="h4"
+  description="Updates all MCP files for projects listed in ~/.aurora/aurora-config.toml to use updated API key."
+  command={`aurora config keys <KEY>`}
+  parameters={[
+    { name: "<KEY>", description: "Your Anthropic API key.", required: true },
+  ]}
+  className="mb-8"
+/>
 
-Takes an existing data engineering project build with Moose and configures Aurora MCP for it.
+<CommandDocCard
+  title="config tools"
+  headingLevel="h4"
+  description="Toggles availability of experimental MCP tools. See Tools documentation for which tools are in 'standard' and which are added in the 'experimental' sets. Note: if you select 'boreal-experimental', you will need to add your ClickHouse Cloud / Boreal credentials to mcp.json."
+  command={`aurora config tools`}
+  className="mb-8"
+/>
 
-```
-aurora setup [path] <--mcp <host>>
-```
+### Coming Soon
 
-- Path to the Moose project (defaults to current directory)
-- `-mcp <host>`: Choice of which MCP host to [default: `cursor-project`] [possible values: `claude-desktop`, `cursor-global`, `cursor-project`, `windsurf-global`]
+<CommandDocCard
+  title="login"
+  headingLevel="h4"
+  description="[Coming soon]. Allows you to log in to Aurora with your Boreal account. Will provide secure authentication and LLM provision."
+  command={`aurora login`}
+  parameters={[]}
+  className="mb-8"
+/>
 
-### config
-
-Configure Aurora settings
-
-### config focus
-
-List Aurora configured projects, allows selection of project globally configured hosts are "focused" on. No more than one Moose Project may be run at a time.
-
-```
-aurora config focus
-```
-
-### config keys
-
-Updates all MCP files for projects listed in ~/.aurora/aurora-config.toml to use updated API key.
-
-```
-aurora config keys <KEY>
-```
-
-- `<KEY>`: Your Anthropic API key. If you don't have an Anthropic API key, see the Anthropic initial setup guide: https://docs.anthropic.com/en/docs/initial-setup
-
-### config models
-
-[Coming Soon]. Allows you to configure which models Aurora agents use.
-
-### config tools
-
-Toggles availability of experimental MCP tools. See Tools documentation for which tools are in `standard` and which are added in the `experimental` sets.
-
-```
-aurora config tools [EXPERIMENTAL_PREFERENCE]
-```
-
-- `[EXPERIMENTAL_PREFERENCE]`: Preference for experimental tools. 
-
-Note, if you select `boreal-experimental`, you will need to add your ClickHouse Cloud / Boreal credentials to `mcp.json`.
-
-### login
-
-[Coming soon]. Allows you to log in to Aurora with your Boreal account. Will provide secure authentication and LLM provision.
-
-```
-aurora login
-```
+<CommandDocCard
+  title="config models"
+  headingLevel="h4"
+  description="[Coming Soon]. Allows you to configure which models Aurora agents use."
+  command={`aurora config models`}
+  parameters={[]}
+  className="mb-8"
+/>

--- a/apps/framework-docs/src/pages/aurora/reference/tool-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/tool-reference.mdx
@@ -3,7 +3,7 @@ title: Tool Reference
 description: MCP tools and external tools for Aurora
 ---
 
-# Tool Reference
+# Tools Reference
 
 Aurora CLI can allow you to use various Aurora MCP tool-sets, as well as install and configure certain external tools. The command `aurora config tools` allows you to configure the tools you want to use. These tools are additive, select the tools you wish to use (if certain tools have dependencies, they will be enabled automatically).
 


### PR DESCRIPTION
This pull request introduces a new `CommandDocCard` component to streamline the documentation of CLI commands in Aurora's framework documentation. It replaces manual markdown-based command descriptions with reusable, interactive components, improving readability and maintainability. Additionally, minor updates were made to the structure and formatting of related pages.

### New Component Integration:
* [`apps/framework-docs/src/components/command-doc-card.tsx`](diffhunk://#diff-9bdc52cfc40276d30d7a97b11946412f9591bc0200b37d5672c7fca116ee1269R1-R113): Added the `CommandDocCard` component to encapsulate command metadata, including title, description, parameters, and examples. It features a copy-to-clipboard functionality for commands and dynamic heading levels for better integration with the table of contents.

### Documentation Refactor:
* [`apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx`](diffhunk://#diff-bf85b71967e6bcaf53db201164eedfd962aba58a67def492cb587b9de02ed517L16-R116): Replaced markdown-based CLI command descriptions with instances of the `CommandDocCard` component for commands like `init`, `connect`, `setup`, and others. This improves consistency and usability across the CLI reference page.
* [`apps/framework-docs/src/pages/aurora/reference/tool-reference.mdx`](diffhunk://#diff-c2f97a9a6eee7a8757355478a41dd623778e9ef0a33f40ed1ce823c71e41275bL6-R6): Updated the page title from "Tool Reference" to "Tools Reference" for better alignment with content focus.