### PR TITLE
chore: move OlapTable to its own file

### DIFF
--- a/packages/ts-moose-lib/src/dmv2/index.ts
+++ b/packages/ts-moose-lib/src/dmv2/index.ts
@@ -15,38 +15,9 @@ import {
   dropView,
   populateTable,
   Sql,
-  toQuery,
   toStaticQuery,
 } from "../index";
-
-/**
- * Configuration options for an OLAP (Online Analytical Processing) table.
- * @template T The data type of the records stored in the table.
- */
-export type OlapConfig<T> = {
-  /**
-   * Specifies the fields to use for ordering data within the ClickHouse table.
-   * This is crucial for optimizing query performance, especially for ReplacingMergeTree engines.
-   */
-  orderByFields?: (keyof T & string)[];
-  /**
-   * If true, uses the ReplacingMergeTree engine for the ClickHouse table, enabling automatic deduplication based on the `orderByFields`.
-   * Equivalent to setting `engine: ClickHouseEngines.ReplacingMergeTree`.
-   * Defaults to false.
-   */
-  // equivalent to setting `engine: ClickHouseEngines.ReplacingMergeTree`
-  deduplicate?: boolean;
-  /**
-   * Specifies the ClickHouse table engine to use.
-   * Defaults to MergeTree if not specified.
-   * @see ClickHouseEngines for available options.
-   */
-  engine?: ClickHouseEngines;
-  /**
-   * An optional version string for this configuration. Can be used for tracking changes or managing deployments.
-   */
-  version?: string;
-};
+import { OlapConfig, OlapTable } from "./sdk/olapTable";
 
 /**
  * Configuration options for a data stream (e.g., a Redpanda topic).
@@ -106,43 +77,6 @@ export type IngestPipelineConfig<T> = {
   version?: string;
   metadata?: { description?: string };
 };
-
-/**
- * Represents an OLAP (Online Analytical Processing) table, typically corresponding to a ClickHouse table.
- * Provides a typed interface for interacting with the table.
- *
- * @template T The data type of the records stored in the table. The structure of T defines the table schema.
- */
-export class OlapTable<T> extends TypedBase<T, OlapConfig<T>> {
-  /** @internal */
-  public readonly kind = "OlapTable";
-
-  /**
-   * Creates a new OlapTable instance.
-   * @param name The name of the table. This name is used for the underlying ClickHouse table.
-   * @param config Optional configuration for the OLAP table.
-   */
-  constructor(name: string, config?: OlapConfig<T>);
-
-  /** @internal **/
-  constructor(
-    name: string,
-    config: OlapConfig<T>,
-    schema: IJsonSchemaCollection.IV3_1,
-    columns: Column[],
-  );
-
-  constructor(
-    name: string,
-    config?: OlapConfig<T>,
-    schema?: IJsonSchemaCollection.IV3_1,
-    columns?: Column[],
-  ) {
-    super(name, config ?? {}, schema, columns);
-
-    getMooseInternal().tables.set(name, this);
-  }
-}
 
 type ZeroOrMany<T> = T | T[] | undefined | null;
 type SyncOrAsyncTransform<T, U> = (
@@ -841,3 +775,5 @@ export class Workflow {
     getMooseInternal().workflows.set(name, this);
   }
 }
+
+export { OlapTable } from "./sdk/olapTable";

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -14,7 +14,6 @@
 import process from "process";
 import {
   IngestApi,
-  OlapTable,
   Stream,
   ConsumptionApi,
   SqlResource,
@@ -26,6 +25,7 @@ import {
 import { IJsonSchemaCollection } from "typia/src/schemas/json/IJsonSchemaCollection";
 import { Column } from "../dataModels/dataModelTypes";
 import { ConsumptionUtil } from "../index";
+import { OlapTable } from "./sdk/olapTable";
 
 /**
  * Internal registry holding all defined Moose dmv2 resources.

--- a/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
@@ -1,0 +1,71 @@
+import { IJsonSchemaCollection } from "typia";
+import { TypedBase } from "../typedBase";
+import { Column } from "../../dataModels/dataModelTypes";
+import { ClickHouseEngines } from "../../blocks/helpers";
+import { getMooseInternal } from "../internal";
+
+/**
+ * Configuration options for an OLAP (Online Analytical Processing) table.
+ * @template T The data type of the records stored in the table.
+ */
+export type OlapConfig<T> = {
+  /**
+   * Specifies the fields to use for ordering data within the ClickHouse table.
+   * This is crucial for optimizing query performance, especially for ReplacingMergeTree engines.
+   */
+  orderByFields?: (keyof T & string)[];
+  /**
+   * If true, uses the ReplacingMergeTree engine for the ClickHouse table, enabling automatic deduplication based on the `orderByFields`.
+   * Equivalent to setting `engine: ClickHouseEngines.ReplacingMergeTree`.
+   * Defaults to false.
+   */
+  // equivalent to setting `engine: ClickHouseEngines.ReplacingMergeTree`
+  deduplicate?: boolean;
+  /**
+   * Specifies the ClickHouse table engine to use.
+   * Defaults to MergeTree if not specified.
+   * @see ClickHouseEngines for available options.
+   */
+  engine?: ClickHouseEngines;
+  /**
+   * An optional version string for this configuration. Can be used for tracking changes or managing deployments.
+   */
+  version?: string;
+};
+
+/**
+ * Represents an OLAP (Online Analytical Processing) table, typically corresponding to a ClickHouse table.
+ * Provides a typed interface for interacting with the table.
+ *
+ * @template T The data type of the records stored in the table. The structure of T defines the table schema.
+ */
+export class OlapTable<T> extends TypedBase<T, OlapConfig<T>> {
+  /** @internal */
+  public readonly kind = "OlapTable";
+
+  /**
+   * Creates a new OlapTable instance.
+   * @param name The name of the table. This name is used for the underlying ClickHouse table.
+   * @param config Optional configuration for the OLAP table.
+   */
+  constructor(name: string, config?: OlapConfig<T>);
+
+  /** @internal **/
+  constructor(
+    name: string,
+    config: OlapConfig<T>,
+    schema: IJsonSchemaCollection.IV3_1,
+    columns: Column[],
+  );
+
+  constructor(
+    name: string,
+    config?: OlapConfig<T>,
+    schema?: IJsonSchemaCollection.IV3_1,
+    columns?: Column[],
+  ) {
+    super(name, config ?? {}, schema, columns);
+
+    getMooseInternal().tables.set(name, this);
+  }
+}


### PR DESCRIPTION
Realized I have way too many changes in my OlapTable PR so shipping it in small incremental bites.

This one starts the extraction of the OlapTable component in its own file