### PR TITLE
add on error handler to prevent crashing node process

### DIFF
--- a/packages/ts-moose-lib/src/commons.ts
+++ b/packages/ts-moose-lib/src/commons.ts
@@ -73,7 +73,11 @@ export const cliLog: (log: CliLogData) => void = (log) => {
     port: 5001,
     method: "POST",
     path: "/logs",
-  }); // no callback, fire and forget
+  });
+
+  req.on("error", (err: Error) => {
+    console.log(`Error ${err.name} sending CLI log.`, err.message);
+  });
 
   req.write(JSON.stringify({ message_type: "Info", ...log }));
   req.end();

--- a/packages/ts-moose-lib/src/streaming-functions/runner.ts
+++ b/packages/ts-moose-lib/src/streaming-functions/runner.ts
@@ -30,7 +30,7 @@ const KAFKAJS_BYTE_MESSAGE_OVERHEAD = 500;
 /**
  * Data structure for metrics logging containing counts and metadata
  */
-type CliLogData = {
+type MetricsData = {
   count_in: number;
   count_out: number;
   bytes: number;
@@ -137,12 +137,19 @@ const buildSaslConfig = (
 /**
  * Logs metrics data to HTTP endpoint
  */
-export const metricsLog: (log: CliLogData) => void = (log) => {
+export const metricsLog: (log: MetricsData) => void = (log) => {
   const req = http.request({
     port: 5001,
     method: "POST",
     path: "/metrics-logs",
-  }); // no callback, fire and forget
+  });
+
+  req.on("error", (err: Error) => {
+    console.log(
+      `Error ${err.name} sending metrics to management port.`,
+      err.message,
+    );
+  });
 
   req.write(JSON.stringify({ ...log }));
   req.end();


### PR DESCRIPTION
when there's existing data in the kafka source topic
the streaming function runs
and tries to let moose know the progress metrics

when moose is not fully up
the http request failed and crashed the process