### PR TITLE
Moose / Aurora docs updates for Moose MCP

### DIFF
--- a/apps/framework-docs/src/components/contact-card.tsx
+++ b/apps/framework-docs/src/components/contact-card.tsx
@@ -10,7 +10,7 @@ interface ContactCardProps {
   ctaLabel: string;
   Icon?: React.ElementType;
   className?: string;
-  variant?: "default" | "gradient" | "aurora";
+  variant?: "moose" | "aurora";
 }
 
 export function ContactCard({
@@ -20,7 +20,7 @@ export function ContactCard({
   ctaLabel,
   Icon,
   className = "",
-  variant = "default",
+  variant = "moose",
 }: ContactCardProps) {
   return (
     <Card

--- a/apps/framework-docs/src/components/contact.tsx
+++ b/apps/framework-docs/src/components/contact.tsx
@@ -3,18 +3,24 @@ import { ContactCards, ContactCard } from "./contact-card";
 import { paths } from "@/lib/paths";
 import { Heading, HeadingLevel } from "./typography";
 
-export function Contact() {
+interface ContactProps {
+  showHeading?: boolean;
+}
+
+export function Contact({ showHeading = true }: ContactProps) {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Heading level={HeadingLevel.l3} className="text-primary">
-          Learning & Community Resources
-        </Heading>
-        <p className="text-muted-foreground text-sm">
-          Get help, learn, contribute, and stay connected with the Moose
-          community
-        </p>
-      </div>
+      {showHeading && (
+        <div className="space-y-2">
+          <Heading level={HeadingLevel.l3} className="text-primary">
+            Learning & Community Resources
+          </Heading>
+          <p className="text-muted-foreground text-sm">
+            Get help, learn, contribute, and stay connected with the Moose
+            community
+          </p>
+        </div>
+      )}
 
       <ContactCards columns={3}>
         <ContactCard

--- a/apps/framework-docs/src/components/contact.tsx
+++ b/apps/framework-docs/src/components/contact.tsx
@@ -1,65 +1,56 @@
 import { Icons } from "./icons";
 import { ContactCards, ContactCard } from "./contact-card";
 import { paths } from "@/lib/paths";
-import { Heading, HeadingLevel } from "./typography";
+import React from "react";
 
 interface ContactProps {
-  showHeading?: boolean;
+  variant?: "moose" | "aurora";
 }
 
-export function Contact({ showHeading = true }: ContactProps) {
+export function Contact({ variant = "moose" }: ContactProps) {
   return (
-    <div className="space-y-6">
-      {showHeading && (
-        <div className="space-y-2">
-          <Heading level={HeadingLevel.l3} className="text-primary">
-            Learning & Community Resources
-          </Heading>
-          <p className="text-muted-foreground text-sm">
-            Get help, learn, contribute, and stay connected with the Moose
-            community
-          </p>
-        </div>
+    <ContactCards columns={3}>
+      {React.Children.map(
+        [
+          <ContactCard
+            title="Contribute"
+            description="Check out the code, contribute to Moose, and report issues"
+            ctaLink={paths.github}
+            ctaLabel="Contribute"
+            Icon={Icons.github}
+          />,
+          <ContactCard
+            title="Join Our Community"
+            description="Connect with developers and get help with your projects"
+            ctaLink={paths.slack}
+            ctaLabel="Join Slack"
+            Icon={Icons.slack}
+          />,
+          <ContactCard
+            title="Talk to Us"
+            description="Contact the Moose maintainers for support and feedback"
+            ctaLink={paths.calendly}
+            ctaLabel="Schedule a Call"
+            Icon={Icons.contact}
+          />,
+          <ContactCard
+            title="Learn & Watch"
+            description="Video tutorials, demos, and deep-dives into Moose features"
+            ctaLink={paths.youtube}
+            ctaLabel="Watch Tutorials"
+            Icon={Icons.youtube}
+          />,
+
+          <ContactCard
+            title="Follow Us on X"
+            description="Follow us on X for the latest news and updates"
+            ctaLink={paths.twitter}
+            ctaLabel="Follow Us"
+            Icon={Icons.twitter}
+          />,
+        ],
+        (child) => React.cloneElement(child, { variant }),
       )}
-
-      <ContactCards columns={3}>
-        <ContactCard
-          title="Contribute"
-          description="Check out the code, contribute to Moose, and report issues"
-          ctaLink={paths.github}
-          ctaLabel="Contribute"
-          Icon={Icons.github}
-        />
-        <ContactCard
-          title="Join Our Community"
-          description="Connect with developers and get help with your projects"
-          ctaLink={paths.slack}
-          ctaLabel="Join Slack"
-          Icon={Icons.slack}
-        />
-        <ContactCard
-          title="Talk to Us"
-          description="Contact the Moose maintainers for support and feedback"
-          ctaLink={paths.calendly}
-          ctaLabel="Schedule a Call"
-          Icon={Icons.contact}
-        />
-        <ContactCard
-          title="Learn & Watch"
-          description="Video tutorials, demos, and deep-dives into Moose features"
-          ctaLink={paths.youtube}
-          ctaLabel="Watch Tutorials"
-          Icon={Icons.youtube}
-        />
-
-        <ContactCard
-          title="Follow Us on X"
-          description="Follow us on X for the latest news and updates"
-          ctaLink={paths.twitter}
-          ctaLabel="Follow Us"
-          Icon={Icons.twitter}
-        />
-      </ContactCards>
-    </div>
+    </ContactCards>
   );
 }

--- a/apps/framework-docs/src/components/contact.tsx
+++ b/apps/framework-docs/src/components/contact.tsx
@@ -18,18 +18,18 @@ export function Contact() {
 
       <ContactCards columns={3}>
         <ContactCard
+          title="Contribute"
+          description="Check out the code, contribute to Moose, and report issues"
+          ctaLink={paths.github}
+          ctaLabel="Contribute"
+          Icon={Icons.github}
+        />
+        <ContactCard
           title="Join Our Community"
           description="Connect with developers and get help with your projects"
           ctaLink={paths.slack}
           ctaLabel="Join Slack"
           Icon={Icons.slack}
-        />
-        <ContactCard
-          title="Learn & Watch"
-          description="Video tutorials, demos, and deep-dives into Moose features"
-          ctaLink={paths.youtube}
-          ctaLabel="Watch Tutorials"
-          Icon={Icons.youtube}
         />
         <ContactCard
           title="Talk to Us"
@@ -39,12 +39,13 @@ export function Contact() {
           Icon={Icons.contact}
         />
         <ContactCard
-          title="Contribute"
-          description="Check out the code, contribute to Moose, and report issues"
-          ctaLink={paths.github}
-          ctaLabel="Contribute"
-          Icon={Icons.github}
+          title="Learn & Watch"
+          description="Video tutorials, demos, and deep-dives into Moose features"
+          ctaLink={paths.youtube}
+          ctaLabel="Watch Tutorials"
+          Icon={Icons.youtube}
         />
+
         <ContactCard
           title="Follow Us on X"
           description="Follow us on X for the latest news and updates"

--- a/apps/framework-docs/src/pages/aurora/index.mdx
+++ b/apps/framework-docs/src/pages/aurora/index.mdx
@@ -275,32 +275,6 @@ Aurora offers a comprehensive suite of MCP tools and agents designed to streamli
   </div>
 </div>
 
-## Getting Involved / Giving Feedback / Community
+## Learning & Community Resources
 
-<CTACards columns={3}>
-  <CTACard
-    title="Join our Slack"
-    description="Join our community, we'd love to hear from you!"
-    ctaLink="https://cal.com/team/514/talk-to-eng"
-    ctaLabel="Talk to the Team"
-    Icon={Icons.contact}
-    variant="aurora"
-  />
-  <CTACard
-    title="Talk to the Aurora Team"
-    description="We're always looking to improve Moose and would love to hear from you!"
-    ctaLink="https://cal.com/team/514/talk-to-eng"
-    ctaLabel="Talk to the Team"
-    Icon={Icons.contact}
-    variant="aurora"
-  />
-  <CTACard
-    title="GitHub"
-    description="Star, check out the code, and contribute on GitHub"
-    ctaLink="https://github.com/514-labs/moose"
-    ctaLabel="GitHub"
-    Icon={Icons.github}
-    variant="aurora"
-  />
-
-</CTACards>
+<Contact showHeading={false} />

--- a/apps/framework-docs/src/pages/aurora/index.mdx
+++ b/apps/framework-docs/src/pages/aurora/index.mdx
@@ -3,7 +3,7 @@ title: Aurora - Automated Data Engineering
 description: AI-powered tools and agents exposed through an easy to configure MCP server for data engineering and infrastructure
 ---
 
-import { FeatureGrid, FeatureCard, Icons, BulletPointsCard, CTACards, CTACard, Contact } from "@/components";
+import { FeatureGrid, FeatureCard, Icons, BulletPointsCard, Contact } from "@/components";
 import { Tabs, Steps, Card, FileTree } from "nextra/components";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";

--- a/apps/framework-docs/src/pages/aurora/index.mdx
+++ b/apps/framework-docs/src/pages/aurora/index.mdx
@@ -277,4 +277,4 @@ Aurora offers a comprehensive suite of MCP tools and agents designed to streamli
 
 ## Learning & Community Resources
 
-<Contact showHeading={false} />
+<Contact variant="aurora" />

--- a/apps/framework-docs/src/pages/aurora/index.mdx
+++ b/apps/framework-docs/src/pages/aurora/index.mdx
@@ -3,7 +3,7 @@ title: Aurora - Automated Data Engineering
 description: AI-powered tools and agents exposed through an easy to configure MCP server for data engineering and infrastructure
 ---
 
-import { FeatureGrid, FeatureCard, Icons, BulletPointsCard, CTACards, CTACard } from "@/components";
+import { FeatureGrid, FeatureCard, Icons, BulletPointsCard, CTACards, CTACard, Contact } from "@/components";
 import { Tabs, Steps, Card, FileTree } from "nextra/components";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";

--- a/apps/framework-docs/src/pages/index.mdx
+++ b/apps/framework-docs/src/pages/index.mdx
@@ -60,4 +60,6 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,aurora
   />
 </CTACards>
 
-<Contact />
+### Learning & Community Resources
+
+<Contact showHeading={false} />

--- a/apps/framework-docs/src/pages/index.mdx
+++ b/apps/framework-docs/src/pages/index.mdx
@@ -62,4 +62,4 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,aurora
 
 ### Learning & Community Resources
 
-<Contact showHeading={false} />
+<Contact />

--- a/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
@@ -467,4 +467,6 @@ host_port = 18123
 </Tabs>
 </ToggleBlock>
 
+## Learning & Community Resources
+
 <Contact />

--- a/apps/framework-docs/src/pages/moose/index.mdx
+++ b/apps/framework-docs/src/pages/moose/index.mdx
@@ -483,4 +483,4 @@ Moose is ideal for a wide range of data-intensive applications, from real-time a
 
 ## Learning & Community Resources
 
-<Contact showHeading={false} />
+<Contact />

--- a/apps/framework-docs/src/pages/moose/index.mdx
+++ b/apps/framework-docs/src/pages/moose/index.mdx
@@ -481,4 +481,6 @@ Moose is ideal for a wide range of data-intensive applications, from real-time a
 
 ---
 
-<Contact />
+## Learning & Community Resources
+
+<Contact showHeading={false} />

--- a/apps/framework-docs/src/pages/templates.mdx
+++ b/apps/framework-docs/src/pages/templates.mdx
@@ -125,4 +125,6 @@ moose template list
 
 See the [templates repository](https://github.com/514-labs/moose/tree/main/templates) for source code and additional templates.
 
+### Learning & Community Resources
+
 <Contact />


### PR DESCRIPTION
# Contact component
`Contact` component now has a default on optional header; turn it off if you want to explicitly include the header in the TOC. Required because our docs platform only sees MD headers, not HTML headers.

e.g. manually add header -> it is shown in TOC
```md
### Learning & Community Resources

<Contact showHeading={false} />
```

e.g. don't manually add header -> header is rendered, but not in TOC
```md
<Contact />
```