### PR TITLE
fixes for python

### DIFF
--- a/templates/live-heartrate-leaderboard/template.config.toml
+++ b/templates/live-heartrate-leaderboard/template.config.toml
@@ -16,6 +16,6 @@ post_install_print = """
 
 
 🚀 Run streamlit:
-	$ streamlit run app/streamlit_app.py
+    $ streamlit run app/streamlit_app.py
 """
 default_aurora_telemetry="comprehensive"


### PR DESCRIPTION
the config directory is not found in the published lib (probably because of missing init file)
e2e test did not catch it because we test by install from the repo