### PR TITLE
add req url to api context

### DIFF
--- a/packages/ts-connector-api/src/apiSource.test.ts
+++ b/packages/ts-connector-api/src/apiSource.test.ts
@@ -1,4 +1,9 @@
-import { APISource, isStreamResult, isSingleResult } from "./apiSource";
+import {
+  APISource,
+  isStreamResult,
+  isSingleResult,
+  APIContext,
+} from "./apiSource";
 import { expect } from "chai";
 
 interface PokemonResource {
@@ -21,7 +26,8 @@ describe("APISource", function () {
       name: "single-test",
       baseUrl: "https://pokeapi.co/api/v2",
       endpoint: "/pokemon",
-      extractItems: (response, headers) => response.results,
+      extractItems: (context: APIContext<PokemonResponse>) =>
+        context.response.results,
     });
     const connectionTest = await singleSource.testConnection();
     expect(connectionTest.success).to.be.true;
@@ -39,9 +45,11 @@ describe("APISource", function () {
       name: "pokemon-test",
       baseUrl: "https://pokeapi.co/api/v2",
       endpoint: "/pokemon",
-      extractItems: (response, headers) => response.results,
+      extractItems: (context: APIContext<PokemonResponse>) =>
+        context.response.results,
       pagination: {
-        getNextUrl: (response, headers) => response.next,
+        getNextUrl: (context: APIContext<PokemonResponse>) =>
+          context.response.next,
         maxPages: 2,
         delayBetweenRequests: 100,
         retryConfig: { maxRetries: 2, backoffMs: 500 },
@@ -69,9 +77,11 @@ describe("APISource", function () {
       name: "pokemon-stream-test",
       baseUrl: "https://pokeapi.co/api/v2",
       endpoint: "/pokemon",
-      extractItems: (response, headers) => response.results,
+      extractItems: (context: APIContext<PokemonResponse>) =>
+        context.response.results,
       pagination: {
-        getNextUrl: (response, headers) => response.next,
+        getNextUrl: (context: APIContext<PokemonResponse>) =>
+          context.response.next,
         maxPages: 2,
         delayBetweenRequests: 100,
       },


### PR DESCRIPTION
Helps build the next url:

```
pagination: {
  maxPages: 5,
  delayBetweenRequests: 200,
  getNextUrl: (context: APIContext<Cats[]>) => {
    const page = parseInt(context.responseHeaders.get("pagination-page") ?? "0") + 1;
    return `${context.requestUrl}&page=${page}`;
  },
},
```