### PR TITLE
docs: minor changes to cli ref [PRO-185]

### DIFF
--- a/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
@@ -162,39 +162,10 @@ aurora config keys <KEY>
 
 #### config tools
 
-Toggles availability of experimental MCP tools. See [Tools Reference](/aurora/reference/tool-reference) for which tools are included by default, and which can be enabled with this command.
+Toggles availability of experimental MCP tools. See [Tools Reference](/aurora/reference/tool-reference).
 
 ```bash filename="Terminal" copy
 aurora config tools
 ```
 
 Note, if you select `remote-clickhouse`, you will need to add your ClickHouse Cloud / Boreal credentials to `mcp.json`.
-
-### Coming soon
-
-#### config models
-
-[Coming Soon]. Allows you to configure which models Aurora agents use.
-
-```bash filename="Terminal" copy
-aurora config models <model-name>
-```
-
-<ArgTable
-  heading="Arguments / Flags"
-  args={[
-    {
-      name: "<model-name>",
-      description: "Model of your choice to use for agentic tool calls",
-      examples: ["claude-3-5-sonnet-20240620", "gemini-2.0-flash-exp"]
-    }
-  ]}
-/>
-
-#### login
-
-[Coming soon]. Allows you to log in to Aurora with your Boreal account. Will provide secure authentication and LLM provision.
-
-```bash filename="Terminal" copy
-aurora login
-```

--- a/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
+++ b/apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx
@@ -168,4 +168,4 @@ Toggles availability of experimental MCP tools. See [Tools Reference](/aurora/re
 aurora config tools
 ```
 
-Note, if you select `remote-clickhouse`, you will need to add your ClickHouse Cloud / Boreal credentials to `mcp.json`.
+Note: if you select `remote-clickhouse`, you will need to add your ClickHouse Cloud / Boreal credentials to `mcp.json`.


### PR DESCRIPTION
This pull request updates the CLI reference documentation for Aurora by removing sections related to features marked as "Coming Soon" and simplifying the description of experimental MCP tools.

Documentation updates:

* [`apps/framework-docs/src/pages/aurora/reference/cli-reference.mdx`](diffhunk://#diff-bf85b71967e6bcaf53db201164eedfd962aba58a67def492cb587b9de02ed517L165-L200): Removed the sections for `config models` and `login`, which were marked as "Coming Soon," along with their associated examples and argument tables. Simplified the description for `aurora config tools` by removing redundant information.