### PR TITLE
Add source Information to the TS serializer, move metadata to Typedbase

### DIFF
--- a/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
@@ -36,7 +36,6 @@ export interface EgressConfig<T> {
  * @template R The data type defining the expected structure of the API's response body. Defaults to `any`.
  */
 export class ConsumptionApi<T, R = any> extends TypedBase<T, EgressConfig<T>> {
-  metadata?: { description?: string };
   /** @internal The handler function that processes requests and generates responses. */
   _handler: ConsumptionHandler<T, R>;
   /** @internal The JSON schema definition for the response type R. */
@@ -46,7 +45,7 @@ export class ConsumptionApi<T, R = any> extends TypedBase<T, EgressConfig<T>> {
    * Creates a new ConsumptionApi instance.
    * @param name The name of the consumption API endpoint.
    * @param handler The function to execute when the endpoint is called. It receives validated query parameters and utility functions.
-   * @param config Optional configuration for the consumption API.
+   * @param config Optional configuration for the consumption API. The metadata property is always present and includes stackTrace.
    */
   constructor(name: string, handler: ConsumptionHandler<T, R>, config?: {});
 
@@ -69,7 +68,6 @@ export class ConsumptionApi<T, R = any> extends TypedBase<T, EgressConfig<T>> {
     responseSchema?: IJsonSchemaCollection.IV3_1,
   ) {
     super(name, config ?? {}, schema, columns);
-    this.metadata = config?.metadata;
     this._handler = handler;
     this.responseSchema = responseSchema ?? {
       version: "3.1",

--- a/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
@@ -45,7 +45,7 @@ export class ConsumptionApi<T, R = any> extends TypedBase<T, EgressConfig<T>> {
    * Creates a new ConsumptionApi instance.
    * @param name The name of the consumption API endpoint.
    * @param handler The function to execute when the endpoint is called. It receives validated query parameters and utility functions.
-   * @param config Optional configuration for the consumption API. The metadata property is always present and includes stackTrace.
+   * @param config Optional configuration for the consumption API.
    */
   constructor(name: string, handler: ConsumptionHandler<T, R>, config?: {});
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestApi.ts
@@ -28,11 +28,10 @@ export interface IngestConfig<T> {
  * @template T The data type of the records that this API endpoint accepts. The structure of T defines the expected request body schema.
  */
 export class IngestApi<T> extends TypedBase<T, IngestConfig<T>> {
-  metadata?: { description?: string };
   /**
    * Creates a new IngestApi instance.
    * @param name The name of the ingest API endpoint.
-   * @param config Configuration for the ingest API, including the destination stream.
+   * @param config Configuration for the ingest API, including the destination stream. The metadata property is always present and includes stackTrace.
    */
   constructor(name: string, config?: IngestConfig<T>);
 
@@ -51,7 +50,6 @@ export class IngestApi<T> extends TypedBase<T, IngestConfig<T>> {
     columns?: Column[],
   ) {
     super(name, config, schema, columns);
-    this.metadata = config?.metadata;
     getMooseInternal().ingestApis.set(name, this);
   }
 }

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestApi.ts
@@ -31,7 +31,7 @@ export class IngestApi<T> extends TypedBase<T, IngestConfig<T>> {
   /**
    * Creates a new IngestApi instance.
    * @param name The name of the ingest API endpoint.
-   * @param config Configuration for the ingest API, including the destination stream. The metadata property is always present and includes stackTrace.
+   * @param config Optional configuration for the ingest API.
    */
   constructor(name: string, config?: IngestConfig<T>);
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -154,7 +154,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
    * Based on the configuration, it automatically creates and links the IngestApi, Stream, and OlapTable components.
    *
    * @param name The base name for the pipeline components (e.g., "userData" could create "userData" table, "userData" stream, "userData" ingest API).
-   * @param config Configuration specifying which components (table, stream, ingest) to create and their settings. The metadata property is always present and includes stackTrace.
+   * @param config Optional configuration for the ingestion pipeline.
    *
    * @throws {Error} When ingest API is enabled but no stream is configured, since the API requires a stream destination.
    *

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -126,12 +126,6 @@ export type IngestPipelineConfig<T> = {
  */
 export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
   /**
-   * Optional metadata associated with the pipeline.
-   * Contains descriptive information about the pipeline's purpose and configuration.
-   */
-  metadata?: { description?: string };
-
-  /**
    * The OLAP table component of the pipeline, if configured.
    * Provides analytical query capabilities for the ingested data.
    * Only present when `config.table` is not `false`.
@@ -160,7 +154,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
    * Based on the configuration, it automatically creates and links the IngestApi, Stream, and OlapTable components.
    *
    * @param name The base name for the pipeline components (e.g., "userData" could create "userData" table, "userData" stream, "userData" ingest API).
-   * @param config Configuration specifying which components (table, stream, ingest) to create and their settings.
+   * @param config Configuration specifying which components (table, stream, ingest) to create and their settings. The metadata property is always present and includes stackTrace.
    *
    * @throws {Error} When ingest API is enabled but no stream is configured, since the API requires a stream destination.
    *
@@ -200,7 +194,6 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
     validators?: TypiaValidators<T>,
   ) {
     super(name, config, schema, columns, validators);
-    this.metadata = config?.metadata;
 
     // Create OLAP table if configured
     if (config.table) {

--- a/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
@@ -174,14 +174,9 @@ export interface StreamConfig<T> {
  */
 export class Stream<T> extends TypedBase<T, StreamConfig<T>> {
   /**
-   * Optional metadata for documentation and tracking purposes.
-   */
-  metadata?: { description?: string };
-
-  /**
    * Creates a new Stream instance.
    * @param name The name of the stream. This name is used for the underlying Redpanda topic.
-   * @param config Optional configuration for the stream.
+   * @param config Optional configuration for the stream. The metadata property is always present and includes stackTrace.
    */
   constructor(name: string, config?: StreamConfig<T>);
 
@@ -200,7 +195,6 @@ export class Stream<T> extends TypedBase<T, StreamConfig<T>> {
     columns?: Column[],
   ) {
     super(name, config ?? {}, schema, columns);
-    this.metadata = config?.metadata;
     getMooseInternal().streams.set(name, this);
   }
 
@@ -385,7 +379,7 @@ export class DeadLetterQueue<T> extends Stream<DeadLetterModel> {
   /**
    * Creates a new DeadLetterQueue instance.
    * @param name The name of the dead letter queue stream
-   * @param config Optional configuration for the stream
+   * @param config Optional configuration for the stream. The metadata property is always present and includes stackTrace.
    */
   constructor(name: string, config?: StreamConfig<DeadLetterModel>);
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
@@ -176,7 +176,7 @@ export class Stream<T> extends TypedBase<T, StreamConfig<T>> {
   /**
    * Creates a new Stream instance.
    * @param name The name of the stream. This name is used for the underlying Redpanda topic.
-   * @param config Optional configuration for the stream. The metadata property is always present and includes stackTrace.
+   * @param config Optional configuration for the stream.
    */
   constructor(name: string, config?: StreamConfig<T>);
 

--- a/packages/ts-moose-lib/src/dmv2/typedBase.ts
+++ b/packages/ts-moose-lib/src/dmv2/typedBase.ts
@@ -37,7 +37,7 @@ function getInstantiationFileInfo(stack?: string): {
     if (match && match[1]) {
       return {
         file: match[1],
-        line: match[0]?.match(/(\/.*\.\w+):(\d+):(\d+)/)?.[0],
+        line: match[2], // Only the line number
       };
     }
   }


### PR DESCRIPTION
I moved metadata to typed base and removed the references from the classes which extend it. 

The main value add here is the file location of where every object is instantiated.

NOTE/Caveat: Unfortunately the line #s are not accurate because of the compiler plugin.  I tried a variety of potentially low hanging fixes and none were successful. 

I am leaving the line #s in here because it may still be useful for approximation in large files, python will not have this restriction, and we may end up finding a fix and wont have to do anything special with the protobuf

https://linear.app/514/issue/AURORA-664/add-stacktrace-to-moose-metadata-objects