### PR TITLE
fix: docs worklows types are not optional

### DIFF
--- a/apps/framework-docs/src/pages/moose/building/workflows.mdx
+++ b/apps/framework-docs/src/pages/moose/building/workflows.mdx
@@ -31,7 +31,7 @@ export interface Foo {
   name: string;
 }
 
-export const task1 = new Task<Foo>("task1", {
+export const task1 = new Task<Foo, void>("task1", {
   run: async (input: Foo) => {
     const name = input.name ?? "world";
     const greeting = `hello, ${name}!`;
@@ -96,7 +96,7 @@ export interface Bar {
   counter: number;
 }
 
-export const task2 = new Task<Bar>("task2", {
+export const task2 = new Task<Bar, void>("task2", {
   run: async (input: Bar) => {
     console.log(`task2 input: ${JSON.stringify(input)}`);
   }
@@ -404,7 +404,7 @@ For more granular control over task-level errors and retries, you can configure 
 ```typescript filename="app/index.ts" {5-6} copy
 import { Task, Workflow } from "@514labs/moose-lib";
 
-export const task1 = new Task<Foo>("task1", {
+export const task1 = new Task<Foo, void>("task1", {
   run: async (input: Foo) => {},
   retries: 1,
   timeout: "5m"
@@ -448,7 +448,7 @@ When configuring retries, it's important to understand how workflow-level and ta
 ```typescript filename="app/index.ts" {5,10} copy
 import { Task, Workflow } from "@514labs/moose-lib";
 
-export const task1 = new Task<Foo>("task1", {
+export const task1 = new Task<Foo, void>("task1", {
   run: async (input: Foo) => {},
   retries: 3,
 });

--- a/packages/ts-moose-lib/src/dmv2/sdk/workflow.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/workflow.ts
@@ -75,7 +75,7 @@ export interface TaskConfig<T, R> {
  * });
  * ```
  */
-export class Task<T = null, R = null> extends TypedBase<T, TaskConfig<T, R>> {
+export class Task<T, R> extends TypedBase<T, TaskConfig<T, R>> {
   /**
    * Creates a new Task instance.
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,7 +578,7 @@ importers:
         version: 1.11.7
       '@temporalio/worker':
         specifier: ^1.11.7
-        version: 1.11.7(@swc/helpers@0.5.17)(esbuild@0.25.2)
+        version: 1.11.7(@swc/helpers@0.5.17)
       '@temporalio/workflow':
         specifier: ^1.11.7
         version: 1.11.7
@@ -10506,31 +10506,6 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@temporalio/worker@1.11.7(@swc/helpers@0.5.17)(esbuild@0.25.2)':
-    dependencies:
-      '@swc/core': 1.11.18(@swc/helpers@0.5.17)
-      '@temporalio/activity': 1.11.7
-      '@temporalio/client': 1.11.7
-      '@temporalio/common': 1.11.7
-      '@temporalio/core-bridge': 1.11.7
-      '@temporalio/proto': 1.11.7
-      '@temporalio/workflow': 1.11.7
-      abort-controller: 3.0.0
-      heap-js: 2.6.0
-      memfs: 4.17.0
-      rxjs: 7.8.2
-      source-map: 0.7.4
-      source-map-loader: 4.0.2(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2))
-      supports-color: 8.1.1
-      swc-loader: 0.2.6(@swc/core@1.11.18(@swc/helpers@0.5.17))(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2))
-      unionfs: 4.5.4
-      webpack: 5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
   '@temporalio/workflow@1.11.7':
     dependencies:
       '@temporalio/common': 1.11.7
@@ -15918,12 +15893,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@4.0.2(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)):
-    dependencies:
-      iconv-lite: 0.6.3
-      source-map-js: 1.2.1
-      webpack: 5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)
-
   source-map-loader@4.0.2(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))):
     dependencies:
       iconv-lite: 0.6.3
@@ -16122,12 +16091,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.11.18(@swc/helpers@0.5.17))(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)):
-    dependencies:
-      '@swc/core': 1.11.18(@swc/helpers@0.5.17)
-      '@swc/counter': 0.1.3
-      webpack: 5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)
-
   swc-loader@0.2.6(@swc/core@1.11.18(@swc/helpers@0.5.17))(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))):
     dependencies:
       '@swc/core': 1.11.18(@swc/helpers@0.5.17)
@@ -16232,18 +16195,6 @@ snapshots:
       - ts-node
 
   tapable@2.2.1: {}
-
-  terser-webpack-plugin@5.3.14(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 4.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.39.0
-      webpack: 5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)
-    optionalDependencies:
-      '@swc/core': 1.11.18(@swc/helpers@0.5.17)
-      esbuild: 0.25.2
 
   terser-webpack-plugin@5.3.14(@swc/core@1.11.18(@swc/helpers@0.5.17))(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))):
     dependencies:
@@ -16908,36 +16859,6 @@ snapshots:
       schema-utils: 4.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.14(@swc/core@1.11.18(@swc/helpers@0.5.17))(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17)))
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.14.1
-      browserslist: 4.24.4
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2)(webpack@5.99.4(@swc/core@1.11.18(@swc/helpers@0.5.17))(esbuild@0.25.2))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
This pull request includes updates to the Moose framework documentation and TypeScript library, along with cleanup in the `pnpm-lock.yaml` file. The most important changes include refining the `Task` class type parameters, updating examples in the documentation, and simplifying dependency definitions in the lock file.

### Moose Framework Updates

* Modified the `Task` class in `packages/ts-moose-lib/src/dmv2/sdk/workflow.ts` to make the type parameters `T` and `R` required instead of optional. This ensures more explicit type definitions for tasks.
* Updated examples in `apps/framework-docs/src/pages/moose/building/workflows.mdx` to reflect the new `Task` class signature by adding `void` as the second type parameter where no return type is specified. [[1]](diffhunk://#diff-44b358d4e9fcbdb836a54a8e3ffcf4345e6da4cd94663abfcb3081a135084842L34-R34) [[2]](diffhunk://#diff-44b358d4e9fcbdb836a54a8e3ffcf4345e6da4cd94663abfcb3081a135084842L99-R99) [[3]](diffhunk://#diff-44b358d4e9fcbdb836a54a8e3ffcf4345e6da4cd94663abfcb3081a135084842L407-R407) [[4]](diffhunk://#diff-44b358d4e9fcbdb836a54a8e3ffcf4345e6da4cd94663abfcb3081a135084842L451-R451)

### Dependency Cleanup in `pnpm-lock.yaml`

* Removed redundant references to `esbuild` in the dependency definitions for `@temporalio/worker`, `source-map-loader`, `swc-loader`, `terser-webpack-plugin`, and `webpack`. This simplifies the lock file and reduces unnecessary transitive dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL581-R581) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10509-L10533) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15921-L15926) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16125-L16130) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16236-L16247) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16918-L16947)