### PR TITLE
Enhance error handling in workflow execution error messages

### DIFF
--- a/apps/framework-cli/src/cli/routines/scripts.rs
+++ b/apps/framework-cli/src/cli/routines/scripts.rs
@@ -114,7 +114,7 @@ pub async fn run_workflow(
             RoutineFailure::new(
                 Message {
                     action: "Workflow".to_string(),
-                    details: format!("Could not start workflow '{name}': {}", e),
+                    details: format!("Could not start workflow '{name}': {e}"),
                 },
                 e,
             )

--- a/apps/framework-cli/src/cli/routines/scripts.rs
+++ b/apps/framework-cli/src/cli/routines/scripts.rs
@@ -111,10 +111,18 @@ pub async fn run_workflow(
         .start(&project.temporal_config, input)
         .await
         .map_err(|e| {
+            // Remove trailing ', details: [...]' and ', metadata: ...' from error string if present
+            let mut err_str = e.to_string();
+            if let Some(idx) = err_str.find(", details: ") {
+                err_str.truncate(idx);
+            }
+            if let Some(idx) = err_str.find(", metadata: ") {
+                err_str.truncate(idx);
+            }
             RoutineFailure::new(
                 Message {
                     action: "Workflow".to_string(),
-                    details: format!("Could not start workflow '{name}': {e}\n"),
+                    details: format!("Could not start workflow '{name}': {err_str}\n"),
                 },
                 e,
             )

--- a/apps/framework-cli/src/cli/routines/scripts.rs
+++ b/apps/framework-cli/src/cli/routines/scripts.rs
@@ -111,18 +111,10 @@ pub async fn run_workflow(
         .start(&project.temporal_config, input)
         .await
         .map_err(|e| {
-            // Remove trailing ', details: [...]' and ', metadata: ...' from error string if present
-            let mut err_str = e.to_string();
-            if let Some(idx) = err_str.find(", details: ") {
-                err_str.truncate(idx);
-            }
-            if let Some(idx) = err_str.find(", metadata: ") {
-                err_str.truncate(idx);
-            }
             RoutineFailure::new(
                 Message {
                     action: "Workflow".to_string(),
-                    details: format!("Could not start workflow '{name}': {err_str}\n"),
+                    details: format!("Could not start workflow '{name}': {}", e),
                 },
                 e,
             )

--- a/apps/framework-cli/src/infrastructure/orchestration/temporal_client.rs
+++ b/apps/framework-cli/src/infrastructure/orchestration/temporal_client.rs
@@ -176,16 +176,30 @@ impl TemporalClient {
     ) -> Result<String> {
         match self {
             TemporalClient::Standard(client) => {
-                let response = client
+                match client
                     .start_workflow_execution(tonic::Request::new(request))
-                    .await?;
-                Ok(response.into_inner().run_id)
+                    .await
+                {
+                    Ok(response) => Ok(response.into_inner().run_id),
+                    Err(status) => {
+                        let concise_msg =
+                            format!("status: {:?}, message: {}", status.code(), status.message());
+                        Err(anyhow::Error::msg(concise_msg))
+                    }
+                }
             }
             TemporalClient::WithInterceptor(client) => {
-                let response = client
+                match client
                     .start_workflow_execution(tonic::Request::new(request))
-                    .await?;
-                Ok(response.into_inner().run_id)
+                    .await
+                {
+                    Ok(response) => Ok(response.into_inner().run_id),
+                    Err(status) => {
+                        let concise_msg =
+                            format!("status: {:?}, message: {}", status.code(), status.message());
+                        Err(anyhow::Error::msg(concise_msg))
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
The user will now see only the concise error message, e.g. Could not start workflow 'dog-fact-ingest': status: AlreadyExists, message: Workflow execution is already running. WorkflowId: dog-fact-ingest, RunId: ...