### PR TITLE
Refactor logging levels for improved error visibility

### DIFF
--- a/apps/framework-cli/src/cli/logger.rs
+++ b/apps/framework-cli/src/cli/logger.rs
@@ -33,7 +33,7 @@
 
 use hyper::Uri;
 use log::{error, warn};
-use log::{info, LevelFilter, Metadata, Record};
+use log::{LevelFilter, Metadata, Record};
 use opentelemetry::logs::Logger;
 use opentelemetry::KeyValue;
 use opentelemetry_appender_log::OpenTelemetryLogBridge;
@@ -157,7 +157,8 @@ fn clean_old_logs() {
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        info!(
+                        // Escalated to warn! — inability to read file metadata may indicate FS issues
+                        warn!(
                             "Failed to read modification time for {:?}. {}",
                             entry.path(),
                             e
@@ -167,7 +168,8 @@ fn clean_old_logs() {
             }
         }
     } else {
-        info!("failed to read directory")
+        // Directory unreadable: surface as warn instead of info so users notice
+        warn!("failed to read directory")
     }
 }
 

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -1,6 +1,6 @@
 use handlebars::Handlebars;
 use lazy_static::lazy_static;
-use log::{debug, error, info};
+use log::{error, info, warn};
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::from_str;
@@ -93,9 +93,9 @@ impl DockerClient {
         let output = child.wait_with_output()?;
 
         if !output.status.success() {
-            debug!("Could not list containers");
-            debug!("Error: {}", String::from_utf8_lossy(&output.stderr));
-            debug!("Output: {}", String::from_utf8_lossy(&output.stdout));
+            warn!("Could not list containers");
+            warn!("Error: {}", String::from_utf8_lossy(&output.stderr));
+            warn!("Output: {}", String::from_utf8_lossy(&output.stdout));
             return Err(std::io::Error::other("Failed to list Docker containers"));
         }
 
@@ -169,9 +169,9 @@ impl DockerClient {
         let output = child.wait_with_output()?;
 
         if !output.status.success() {
-            debug!("Could not list containers");
-            debug!("Error: {}", String::from_utf8_lossy(&output.stderr));
-            debug!("Output: {}", String::from_utf8_lossy(&output.stdout));
+            warn!("Could not list containers");
+            warn!("Error: {}", String::from_utf8_lossy(&output.stderr));
+            warn!("Output: {}", String::from_utf8_lossy(&output.stdout));
             return Err(std::io::Error::other(
                 "Failed to list Docker container names",
             ));
@@ -480,7 +480,7 @@ impl DockerClient {
         let output = child.wait_with_output()?;
 
         if !output.status.success() {
-            debug!(
+            error!(
                 "Failed to get Docker info: stdout: {}, stderr: {}",
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)


### PR DESCRIPTION
Updated across various components. Changed several `debug!` logs to `warn!` to ensure critical issues are more noticeable, particularly in Kafka message handling and Docker container listing. Additionally, updated log statements in the logger module to reflect the severity of errors encountered during log cleanup operations.

@callicles please review the Kafka log changes and comments in particular. Those may or may not be needed and can be pulled from the PR if deemed so.