### PR TITLE
chore: trigger on merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,5 +1,7 @@
 name: Format
 on:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "**"

--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
 defaults:
   run:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to include a new trigger for `merge_group` events with the `checks_requested` type. This change ensures that workflows are triggered when checks are requested for merge groups.

Updates to GitHub Actions workflows:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R8-R9): Added a `merge_group` trigger with the `checks_requested` type under the `on` section.
* [`.github/workflows/format.yaml`](diffhunk://#diff-d671e201597b1543c1a04bea8290f7427b53646c708722719872792b39760b56R3-R4): Added a `merge_group` trigger with the `checks_requested` type under the `on` section.
* [`.github/workflows/test-framework-cli.yaml`](diffhunk://#diff-3b823426133c426c409ab0bec8905fb58185ad27ffa6c316b5e2fc9c7d86ef16R7-R8): Added a `merge_group` trigger with the `checks_requested` type under the `on` section.