### PR TITLE
Updated moose config documentation regarding telemetry

### DIFF
--- a/apps/framework-docs/src/pages/moose/reference/configuration.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/configuration.mdx
@@ -12,7 +12,14 @@ language = "Typescript"
 # Map of supported old versions and their locations (Default: {})
 # supported_old_versions = { "0.1.0" = "path/to/old/version" }
 
-
+#Telemetry configuration for usage tracking and metrics
+[telemetry]
+# Whether telemetry collection is enabled
+enabled = true
+# Whether to export metrics to external systems
+export_metrics
+# Flag indicating if the user is a Moose developer
+is_moose_developer
 
 # Redpanda streaming configuration (also aliased as `kafka_config`)
 [redpanda_config]


### PR DESCRIPTION
This pull request introduces a new telemetry configuration section in the Moose framework documentation. The changes add options for enabling telemetry, exporting metrics, and identifying Moose developers.

### Documentation updates:
* [`apps/framework-docs/src/pages/moose/reference/configuration.mdx`](diffhunk://#diff-a32a20b002312cb4603ab6bbc8192d087ba39be0c3ae2644b994f93146f30bf6L15-R22): Added a `[telemetry]` section with options for enabling telemetry, exporting metrics, and specifying if the user is a Moose developer.