### PR TITLE
fix: remove is_prod filter for logs in prod

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1187,7 +1187,7 @@ async fn management_router<I: InfraMapProvider>(
     let route = get_path_without_prefix(PathBuf::from(req.uri().path()), path_prefix);
     let route = route.to_str().unwrap();
     let res = match (req.method(), route) {
-        (&hyper::Method::POST, "logs") if !is_prod => Ok(log_route(req).await),
+        (&hyper::Method::POST, "logs") => Ok(log_route(req).await),
         (&hyper::Method::POST, METRICS_LOGS_PATH) => {
             Ok(metrics_log_route(req, metrics.clone()).await)
         }


### PR DESCRIPTION
This pull request modifies the `management_router` function in `apps/framework-cli/src/cli/local_webserver.rs` to adjust route handling logic. The main change removes the environment check for the "logs" route, allowing it to be accessible in all environments.

### Route handling adjustments:
* [`apps/framework-cli/src/cli/local_webserver.rs`](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1190-R1190): Removed the `is_prod` environment condition from the "logs" route, enabling it to be processed regardless of the environment.