### PR TITLE
cleanup workflow list cmd

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -25,7 +25,7 @@ use routines::metrics_console::run_console;
 use routines::peek::peek;
 use routines::ps::show_processes;
 use routines::scripts::{
-    get_workflow_status, init_workflow, list_workflows, pause_workflow, run_workflow,
+    get_workflow_status, init_workflow, list_workflows_history, pause_workflow, run_workflow,
     terminate_workflow, unpause_workflow,
 };
 use routines::templates::list_available_templates;
@@ -681,6 +681,7 @@ pub async fn top_command_handler(
                 Some(WorkflowCommands::Init { .. }) => ActivityType::WorkflowInitCommand,
                 Some(WorkflowCommands::Run { .. }) => ActivityType::WorkflowRunCommand,
                 Some(WorkflowCommands::List { .. }) => ActivityType::WorkflowListCommand,
+                Some(WorkflowCommands::History { .. }) => ActivityType::WorkflowListCommand,
                 Some(WorkflowCommands::Resume { .. }) => ActivityType::WorkflowResumeCommand,
                 Some(WorkflowCommands::Terminate { .. }) => ActivityType::WorkflowTerminateCommand,
                 Some(WorkflowCommands::Pause { .. }) => ActivityType::WorkflowPauseCommand,
@@ -703,11 +704,14 @@ pub async fn top_command_handler(
                 Some(WorkflowCommands::Run { name, input }) => {
                     run_workflow(&project, name, input.clone()).await
                 }
-                Some(WorkflowCommands::List {
+                Some(WorkflowCommands::List { json }) => {
+                    ls_dmv2(&project, Some("workflows"), None, *json).await
+                }
+                Some(WorkflowCommands::History {
                     status,
                     limit,
                     json,
-                }) => list_workflows(&project, status.clone(), *limit, *json).await,
+                }) => list_workflows_history(&project, status.clone(), *limit, *json).await,
                 Some(WorkflowCommands::Resume { .. }) => Err(RoutineFailure::error(Message {
                     action: "Workflow Resume".to_string(),
                     details: "Not implemented yet".to_string(),

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -215,8 +215,14 @@ pub enum WorkflowCommands {
         #[arg(long)]
         from: String,
     },
-    /// List running workflows
+    /// List registered workflows
     List {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show workflow history
+    History {
         /// Filter workflows by status (running, completed, failed)
         #[arg(short, long)]
         status: Option<String>,

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -22,7 +22,7 @@ use super::display::{
     with_spinner_completion, with_spinner_completion_async, Message, MessageType,
 };
 use super::routines::auth::validate_auth_token;
-use super::routines::scripts::{get_workflow_list, terminate_all_workflows};
+use super::routines::scripts::{get_workflow_history, terminate_all_workflows};
 use super::settings::Settings;
 use crate::infrastructure::redis::redis_client::RedisClient;
 use crate::infrastructure::stream::kafka::models::KafkaStreamConfig;
@@ -383,7 +383,7 @@ async fn workflows_list_route(
 
     let limit = query_params.limit.unwrap_or(10).min(1000);
 
-    match get_workflow_list(&project, query_params.status, limit).await {
+    match get_workflow_history(&project, query_params.status, limit).await {
         Ok(workflows) => {
             let json_string =
                 serde_json::to_string(&workflows).unwrap_or_else(|_| "[]".to_string());

--- a/apps/framework-cli/src/cli/routines/scripts.rs
+++ b/apps/framework-cli/src/cli/routines/scripts.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use crate::cli::display::{show_table, Message, MessageType};
+use crate::cli::display::{show_table, Message};
 use crate::cli::routines::{RoutineFailure, RoutineSuccess};
 use crate::framework::core::infrastructure_map::InfrastructureMap;
 use crate::framework::scripts::Workflow;
@@ -39,25 +39,7 @@ impl WorkflowInfo {
     }
 
     fn display_as_json(workflows: Vec<WorkflowInfo>) {
-        let json_output: Vec<serde_json::Value> = workflows
-            .into_iter()
-            .map(|w| {
-                serde_json::json!({
-                    "workflow_name": w.name,
-                    "run_id": w.run_id,
-                    "status": w.status,
-                    "started_at": w.started_at,
-                    "duration": w.duration
-                })
-            })
-            .collect();
-
-        show_message!(MessageType::Info, {
-            Message {
-                action: "Workflows".to_string(),
-                details: format!("\n{}", serde_json::to_string_pretty(&json_output).unwrap()),
-            }
-        });
+        println!("{}", serde_json::to_string_pretty(&workflows).unwrap());
     }
 
     fn display_as_table(workflows: Vec<WorkflowInfo>) {
@@ -67,7 +49,7 @@ impl WorkflowInfo {
             .collect();
 
         show_table(
-            "Workflows".to_string(),
+            "History".to_string(),
             vec![
                 "Workflow Name".to_string(),
                 "Run ID".to_string(),
@@ -240,7 +222,7 @@ pub async fn run_workflow(
     }))
 }
 
-pub async fn get_workflow_list(
+pub async fn get_workflow_history(
     project: &Project,
     status: Option<String>,
     limit: u32,
@@ -327,19 +309,19 @@ pub async fn get_workflow_list(
     Ok(workflows)
 }
 
-pub async fn list_workflows(
+pub async fn list_workflows_history(
     project: &Project,
     status: Option<String>,
     limit: u32,
     json: bool,
 ) -> Result<RoutineSuccess, RoutineFailure> {
-    let workflows = get_workflow_list(project, status, limit).await?;
+    let workflows = get_workflow_history(project, status, limit).await?;
 
     WorkflowInfo::display_list(workflows, json);
 
     Ok(RoutineSuccess::success(Message::new(
-        "Workflows".to_string(),
-        "Listed\n".to_string(),
+        "".to_string(),
+        "".to_string(),
     )))
 }
 

--- a/apps/framework-cli/src/framework/scripts.rs
+++ b/apps/framework-cli/src/framework/scripts.rs
@@ -118,6 +118,14 @@ impl Workflow {
         })
     }
 
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn config(&self) -> &WorkflowConfig {
+        &self.config
+    }
+
     /// Initialize a new workflow with a list of scripts
     pub fn init(project: &Project, name: &str, scripts: &[String]) -> Result<(), anyhow::Error> {
         let scripts_dir = project.scripts_dir();

--- a/apps/framework-docs/src/pages/moose/reference/moose-cli.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/moose-cli.mdx
@@ -127,7 +127,8 @@ Available workflow commands:
 - `init <name> [--tasks <task-list>] [--task <task>...]`: Initialize a new workflow
 - `run <name> [--input <json>]`: Run a workflow
 - `resume <name> --from <task>`: Resume a workflow from a specific task
-- `list [--status <status>] [--limit <n>]`: List workflows
+- `list [--json]`: List registered workflows
+- `history [--status <status>] [--limit <n>] [--json]`: Show workflow history
 - `terminate <name>`: Terminate a workflow
 - `pause <name>`: Pause a workflow
 - `unpause <name>`: Unpause a workflow


### PR DESCRIPTION
Previously:
- `moose ls` was not showing registered workflows
- `moose workflow list` was only showing workflow history

Now:
- `moose ls` includes registered workflows
- `moose workflow list` does the same thing as `moose ls --type workflows`
- `moose workflow history` shows the history