### PR TITLE
fix: olap diff

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -2106,7 +2106,11 @@ async fn admin_plan_route(
     };
 
     // Calculate the changes between the submitted infrastructure map and the current one
-    let changes = current_infra_map.diff(&plan_request.infra_map);
+    // Use ClickHouse-specific strategy for table diffing
+    let clickhouse_strategy =
+        crate::infrastructure::olap::clickhouse::diff_strategy::ClickHouseTableDiffStrategy;
+    let changes =
+        current_infra_map.diff_with_table_strategy(&plan_request.infra_map, &clickhouse_strategy);
 
     // Prepare the response
     let response = PlanResponse {

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -707,7 +707,7 @@ pub async fn remote_refresh(
             .values()
             .find(|t| t.name == table.name)
         {
-            match InfrastructureMap::diff_table(table, local_table) {
+            match InfrastructureMap::simple_table_diff(table, local_table) {
                 None => {
                     debug!("Found matching table: {}", table.name);
                     tables_to_integrate.push(table.name.clone());

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -777,482 +777,8 @@ impl InfrastructureMap {
     /// # Returns
     /// An `InfraChanges` object containing all detected changes
     pub fn diff(&self, target_map: &InfrastructureMap) -> InfraChanges {
-        let mut changes = InfraChanges::default();
-
-        // =================================================================
-        //                              Topics
-        // =================================================================
-        log::info!("Analyzing changes in Topics...");
-        let mut topic_updates = 0;
-        let mut topic_removals = 0;
-        let mut topic_additions = 0;
-
-        for (id, topic) in &self.topics {
-            if let Some(target_topic) = target_map.topics.get(id) {
-                if topic != target_topic {
-                    // Respect lifecycle: ExternallyManaged topics are never modified
-                    if target_topic.life_cycle == LifeCycle::ExternallyManaged {
-                        log::debug!(
-                            "Topic '{}' has changes but is externally managed - skipping update",
-                            topic.name
-                        );
-                    } else {
-                        log::debug!("Topic updated: {} ({})", topic.name, id);
-                        topic_updates += 1;
-                        changes
-                            .streaming_engine_changes
-                            .push(StreamingChange::Topic(Change::<Topic>::Updated {
-                                before: Box::new(topic.clone()),
-                                after: Box::new(target_topic.clone()),
-                            }));
-                    }
-                }
-            } else {
-                // Respect lifecycle: DeletionProtected and ExternallyManaged topics are never removed
-                match topic.life_cycle {
-                    LifeCycle::FullyManaged => {
-                        log::debug!("Topic removed: {} ({})", topic.name, id);
-                        topic_removals += 1;
-                        changes
-                            .streaming_engine_changes
-                            .push(StreamingChange::Topic(Change::<Topic>::Removed(Box::new(
-                                topic.clone(),
-                            ))));
-                    }
-                    LifeCycle::DeletionProtected => {
-                        log::debug!(
-                            "Topic '{}' marked for removal but is deletion-protected - skipping removal",
-                            topic.name
-                        );
-                    }
-                    LifeCycle::ExternallyManaged => {
-                        log::debug!(
-                            "Topic '{}' marked for removal but is externally managed - skipping removal",
-                            topic.name
-                        );
-                    }
-                }
-            }
-        }
-
-        for (id, topic) in &target_map.topics {
-            if !self.topics.contains_key(id) {
-                // Respect lifecycle: ExternallyManaged topics are never added automatically
-                if topic.life_cycle == LifeCycle::ExternallyManaged {
-                    log::debug!(
-                        "Topic '{}' marked for addition but is externally managed - skipping addition",
-                        topic.name
-                    );
-                } else {
-                    log::debug!("Topic added: {} ({})", topic.name, id);
-                    topic_additions += 1;
-                    changes
-                        .streaming_engine_changes
-                        .push(StreamingChange::Topic(Change::<Topic>::Added(Box::new(
-                            topic.clone(),
-                        ))));
-                }
-            }
-        }
-
-        log::info!(
-            "Topic changes: {} added, {} removed, {} updated",
-            topic_additions,
-            topic_removals,
-            topic_updates
-        );
-
-        // =================================================================
-        //                              API Endpoints
-        // =================================================================
-        log::info!("Analyzing changes in API Endpoints...");
-        let mut api_updates = 0;
-        let mut api_removals = 0;
-        let mut api_additions = 0;
-
-        for (id, api_endpoint) in &self.api_endpoints {
-            if let Some(target_api_endpoint) = target_map.api_endpoints.get(id) {
-                if api_endpoint != target_api_endpoint {
-                    log::debug!("API Endpoint updated: {}", id);
-                    api_updates += 1;
-                    changes.api_changes.push(ApiChange::ApiEndpoint(
-                        Change::<ApiEndpoint>::Updated {
-                            before: Box::new(api_endpoint.clone()),
-                            after: Box::new(target_api_endpoint.clone()),
-                        },
-                    ));
-                }
-            } else {
-                log::debug!("API Endpoint removed: {}", id);
-                api_removals += 1;
-                changes
-                    .api_changes
-                    .push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Removed(
-                        Box::new(api_endpoint.clone()),
-                    )));
-            }
-        }
-
-        for (id, api_endpoint) in &target_map.api_endpoints {
-            if !self.api_endpoints.contains_key(id) {
-                log::debug!("API Endpoint added: {}", id);
-                api_additions += 1;
-                changes
-                    .api_changes
-                    .push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Added(
-                        Box::new(api_endpoint.clone()),
-                    )));
-            }
-        }
-
-        log::info!(
-            "API Endpoint changes: {} added, {} removed, {} updated",
-            api_additions,
-            api_removals,
-            api_updates
-        );
-
-        // =================================================================
-        //                              Tables
-        // =================================================================
-        log::info!("Analyzing changes in Tables...");
-        let olap_changes_len_before = changes.olap_changes.len();
-        Self::diff_tables(&self.tables, &target_map.tables, &mut changes.olap_changes);
-        let table_changes = changes.olap_changes.len() - olap_changes_len_before;
-        log::info!("Table changes detected: {}", table_changes);
-
-        // =================================================================
-        //                              Views
-        // =================================================================
-        log::info!("Analyzing changes in Views...");
-        let mut view_updates = 0;
-        let mut view_removals = 0;
-        let mut view_additions = 0;
-
-        for (id, view) in &self.views {
-            if let Some(target_view) = target_map.views.get(id) {
-                if view != target_view {
-                    log::debug!("View updated: {}", view.name);
-                    view_updates += 1;
-                    changes
-                        .olap_changes
-                        .push(OlapChange::View(Change::<View>::Updated {
-                            before: Box::new(view.clone()),
-                            after: Box::new(target_view.clone()),
-                        }));
-                }
-            } else {
-                log::debug!("View removed: {}", view.name);
-                view_removals += 1;
-                changes
-                    .olap_changes
-                    .push(OlapChange::View(Change::<View>::Removed(Box::new(
-                        view.clone(),
-                    ))));
-            }
-        }
-
-        for (id, view) in &target_map.views {
-            if !self.views.contains_key(id) {
-                log::debug!("View added: {}", view.name);
-                view_additions += 1;
-                changes
-                    .olap_changes
-                    .push(OlapChange::View(Change::<View>::Added(Box::new(
-                        view.clone(),
-                    ))));
-            }
-        }
-
-        log::info!(
-            "View changes: {} added, {} removed, {} updated",
-            view_additions,
-            view_removals,
-            view_updates
-        );
-
-        // =================================================================
-        //                              SQL Resources
-        // =================================================================
-        Self::diff_sql_resources(
-            &self.sql_resources,
-            &target_map.sql_resources,
-            &mut changes.olap_changes,
-        );
-
-        // =================================================================
-        //                              Topic to Table Sync Processes
-        // =================================================================
-        log::info!("Analyzing changes in Topic to Table Sync Processes...");
-        let mut t2t_sync_updates = 0;
-        let mut t2t_sync_removals = 0;
-        let mut t2t_sync_additions = 0;
-
-        for (id, topic_to_table_sync_process) in &self.topic_to_table_sync_processes {
-            if let Some(target_topic_to_table_sync_process) =
-                target_map.topic_to_table_sync_processes.get(id)
-            {
-                if topic_to_table_sync_process != target_topic_to_table_sync_process {
-                    log::debug!("Topic to Table Sync Process updated: {}", id);
-                    t2t_sync_updates += 1;
-                    changes
-                        .processes_changes
-                        .push(ProcessChange::TopicToTableSyncProcess(Change::<
-                            TopicToTableSyncProcess,
-                        >::Updated {
-                            before: Box::new(topic_to_table_sync_process.clone()),
-                            after: Box::new(target_topic_to_table_sync_process.clone()),
-                        }));
-                }
-            } else {
-                log::debug!("Topic to Table Sync Process removed: {}", id);
-                t2t_sync_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTableSyncProcess(Change::<
-                        TopicToTableSyncProcess,
-                    >::Removed(
-                        Box::new(topic_to_table_sync_process.clone()),
-                    )));
-            }
-        }
-
-        for (id, topic_to_table_sync_process) in &target_map.topic_to_table_sync_processes {
-            if !self.topic_to_table_sync_processes.contains_key(id) {
-                log::debug!("Topic to Table Sync Process added: {}", id);
-                t2t_sync_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTableSyncProcess(Change::<
-                        TopicToTableSyncProcess,
-                    >::Added(
-                        Box::new(topic_to_table_sync_process.clone()),
-                    )));
-            }
-        }
-
-        log::info!(
-            "Topic to Table Sync Process changes: {} added, {} removed, {} updated",
-            t2t_sync_additions,
-            t2t_sync_removals,
-            t2t_sync_updates
-        );
-
-        // =================================================================
-        //                              Topic to Topic Sync Processes
-        // =================================================================
-        log::info!("Analyzing changes in Topic to Topic Sync Processes...");
-        let mut t2t_topic_sync_updates = 0;
-        let mut t2t_topic_sync_removals = 0;
-        let mut t2t_topic_sync_additions = 0;
-
-        for (id, topic_to_topic_sync_process) in &self.topic_to_topic_sync_processes {
-            if let Some(target_topic_to_topic_sync_process) =
-                target_map.topic_to_topic_sync_processes.get(id)
-            {
-                if topic_to_topic_sync_process != target_topic_to_topic_sync_process {
-                    log::debug!("Topic to Topic Sync Process updated: {}", id);
-                    t2t_topic_sync_updates += 1;
-                    changes
-                        .processes_changes
-                        .push(ProcessChange::TopicToTopicSyncProcess(Change::<
-                            TopicToTopicSyncProcess,
-                        >::Updated {
-                            before: Box::new(topic_to_topic_sync_process.clone()),
-                            after: Box::new(target_topic_to_topic_sync_process.clone()),
-                        }));
-                }
-            } else {
-                log::debug!("Topic to Topic Sync Process removed: {}", id);
-                t2t_topic_sync_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTopicSyncProcess(Change::<
-                        TopicToTopicSyncProcess,
-                    >::Removed(
-                        Box::new(topic_to_topic_sync_process.clone()),
-                    )));
-            }
-        }
-
-        for (id, topic_to_topic_sync_process) in &target_map.topic_to_topic_sync_processes {
-            if !self.topic_to_topic_sync_processes.contains_key(id) {
-                log::debug!("Topic to Topic Sync Process added: {}", id);
-                t2t_topic_sync_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTopicSyncProcess(Change::<
-                        TopicToTopicSyncProcess,
-                    >::Added(
-                        Box::new(topic_to_topic_sync_process.clone()),
-                    )));
-            }
-        }
-
-        log::info!(
-            "Topic to Topic Sync Process changes: {} added, {} removed, {} updated",
-            t2t_topic_sync_additions,
-            t2t_topic_sync_removals,
-            t2t_topic_sync_updates
-        );
-
-        // =================================================================
-        //                             Function Processes
-        // =================================================================
-        log::info!("Analyzing changes in Function Processes...");
-        let mut function_updates = 0;
-        let mut function_removals = 0;
-        let mut function_additions = 0;
-
-        for (id, function_process) in &self.function_processes {
-            if let Some(target_function_process) = target_map.function_processes.get(id) {
-                // In this case we don't do a comparison check because the function process is not just
-                // dependent on changing one file, but also on its dependencies. Until we are able to
-                // properly compare the function processes holistically (File + Dependencies), we will just
-                // assume that the function process has changed.
-                log::debug!("Function Process updated: {}", id);
-                function_updates += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::FunctionProcess(
-                        Change::<FunctionProcess>::Updated {
-                            before: Box::new(function_process.clone()),
-                            after: Box::new(target_function_process.clone()),
-                        },
-                    ));
-            } else {
-                log::debug!("Function Process removed: {}", id);
-                function_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::FunctionProcess(
-                        Change::<FunctionProcess>::Removed(Box::new(function_process.clone())),
-                    ));
-            }
-        }
-
-        for (id, function_process) in &target_map.function_processes {
-            if !self.function_processes.contains_key(id) {
-                log::debug!("Function Process added: {}", id);
-                function_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::FunctionProcess(
-                        Change::<FunctionProcess>::Added(Box::new(function_process.clone())),
-                    ));
-            }
-        }
-
-        log::info!(
-            "Function Process changes: {} added, {} removed, {} updated",
-            function_additions,
-            function_removals,
-            function_updates
-        );
-
-        // =================================================================
-        //                             Blocks Processes
-        // =================================================================
-        log::info!("Analyzing changes in OLAP Processes...");
-
-        // Until we refactor to have multiple processes, we will consider that we need to restart
-        // the process all the times and the blocks changes all the time.
-        // Once we do the other refactor, we will be able to compare the changes and only restart
-        // the process if there are changes
-
-        // currently we assume there is always a change and restart the processes
-        log::debug!("OLAP Process updated (assumed for now)");
-        changes.processes_changes.push(ProcessChange::OlapProcess(
-            Change::<OlapProcess>::Updated {
-                before: Box::new(OlapProcess {}),
-                after: Box::new(OlapProcess {}),
-            },
-        ));
-
-        // =================================================================
-        //                          Consumption Process
-        // =================================================================
-        log::info!("Analyzing changes in Consumption API Web Server...");
-
-        // We are currently not tracking individual consumption endpoints, so we will just restart
-        // the consumption web server when something changed. we might want to change that in the future
-        // to be able to only make changes when something in the dependency tree of a consumption api has
-        // changed.
-        log::debug!("Consumption API Web Server updated (assumed for now)");
-        changes
-            .processes_changes
-            .push(ProcessChange::ConsumptionApiWebServer(Change::<
-                ConsumptionApiWebServer,
-            >::Updated {
-                before: Box::new(ConsumptionApiWebServer {}),
-                after: Box::new(ConsumptionApiWebServer {}),
-            }));
-
-        // =================================================================
-        //                      Orchestration Workers
-        // =================================================================
-        log::info!("Analyzing changes in Orchestration Workers...");
-        let mut worker_updates = 0;
-        let mut worker_removals = 0;
-        let mut worker_additions = 0;
-
-        for (id, orchestration_worker) in &self.orchestration_workers {
-            if let Some(target_orchestration_worker) = target_map.orchestration_workers.get(id) {
-                // Until we track individual files changes, we want workers to be restarted for every change
-                log::debug!("Orchestration Worker updated: {}", id);
-                worker_updates += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::OrchestrationWorker(Change::<
-                        OrchestrationWorker,
-                    >::Updated {
-                        before: Box::new(orchestration_worker.clone()),
-                        after: Box::new(target_orchestration_worker.clone()),
-                    }));
-            } else {
-                log::debug!("Orchestration Worker removed: {}", id);
-                worker_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::OrchestrationWorker(Change::<
-                        OrchestrationWorker,
-                    >::Removed(
-                        Box::new(orchestration_worker.clone()),
-                    )));
-            }
-        }
-
-        for (id, orchestration_worker) in &target_map.orchestration_workers {
-            if !self.orchestration_workers.contains_key(id) {
-                log::debug!("Orchestration Worker added: {}", id);
-                worker_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::OrchestrationWorker(Change::<
-                        OrchestrationWorker,
-                    >::Added(
-                        Box::new(orchestration_worker.clone()),
-                    )));
-            }
-        }
-
-        log::info!(
-            "Orchestration Worker changes: {} added, {} removed, {} updated",
-            worker_additions,
-            worker_removals,
-            worker_updates
-        );
-
-        // Summarize total changes
-        log::info!(
-            "Total changes: {} OLAP, {} Process, {} API, {} Streaming",
-            changes.olap_changes.len(),
-            changes.processes_changes.len(),
-            changes.api_changes.len(),
-            changes.streaming_engine_changes.len()
-        );
-
-        changes
+        let default_strategy = DefaultTableDiffStrategy;
+        self.diff_with_table_strategy(target_map, &default_strategy)
     }
 
     /// Compares this infrastructure map with a target map using a custom table diff strategy
@@ -1275,16 +801,85 @@ impl InfrastructureMap {
     ) -> InfraChanges {
         let mut changes = InfraChanges::default();
 
-        // =================================================================
-        //                              Topics
-        // =================================================================
+        // Topics
+        Self::diff_topics(
+            &self.topics,
+            &target_map.topics,
+            &mut changes.streaming_engine_changes,
+        );
+
+        // API Endpoints
+        Self::diff_api_endpoints(
+            &self.api_endpoints,
+            &target_map.api_endpoints,
+            &mut changes.api_changes,
+        );
+
+        // Tables (using custom strategy)
+        log::info!("Analyzing changes in Tables...");
+        let olap_changes_len_before = changes.olap_changes.len();
+        Self::diff_tables_with_strategy(
+            &self.tables,
+            &target_map.tables,
+            &mut changes.olap_changes,
+            table_diff_strategy,
+        );
+        let table_changes = changes.olap_changes.len() - olap_changes_len_before;
+        log::info!("Table changes detected: {}", table_changes);
+
+        // Views
+        Self::diff_views(&self.views, &target_map.views, &mut changes.olap_changes);
+
+        // SQL Resources
+        log::info!("Analyzing changes in SQL Resources...");
+        let olap_changes_len_before = changes.olap_changes.len();
+        Self::diff_sql_resources(
+            &self.sql_resources,
+            &target_map.sql_resources,
+            &mut changes.olap_changes,
+        );
+        let sql_resource_changes = changes.olap_changes.len() - olap_changes_len_before;
+        log::info!("SQL Resource changes detected: {}", sql_resource_changes);
+
+        // All process types
+        self.diff_all_processes(target_map, &mut changes.processes_changes);
+
+        // Summary
+        log::info!(
+            "Total changes detected - OLAP: {}, Processes: {}, API: {}, Streaming: {}",
+            changes.olap_changes.len(),
+            changes.processes_changes.len(),
+            changes.api_changes.len(),
+            changes.streaming_engine_changes.len()
+        );
+
+        changes
+    }
+
+    /// Compare topics between two infrastructure maps and compute the differences
+    ///
+    /// This method identifies added, removed, and updated topics by comparing
+    /// the source and target topic maps, respecting lifecycle constraints.
+    ///
+    /// # Arguments
+    /// * `self_topics` - HashMap of source topics to compare from
+    /// * `target_topics` - HashMap of target topics to compare against
+    /// * `streaming_changes` - Mutable vector to collect the identified changes
+    ///
+    /// # Returns
+    /// A tuple of (additions, removals, updates) counts
+    fn diff_topics(
+        self_topics: &HashMap<String, Topic>,
+        target_topics: &HashMap<String, Topic>,
+        streaming_changes: &mut Vec<StreamingChange>,
+    ) -> (usize, usize, usize) {
         log::info!("Analyzing changes in Topics...");
         let mut topic_updates = 0;
         let mut topic_removals = 0;
         let mut topic_additions = 0;
 
-        for (id, topic) in &self.topics {
-            if let Some(target_topic) = target_map.topics.get(id) {
+        for (id, topic) in self_topics {
+            if let Some(target_topic) = target_topics.get(id) {
                 if topic != target_topic {
                     // Respect lifecycle: ExternallyManaged topics are never modified
                     if target_topic.life_cycle == LifeCycle::ExternallyManaged {
@@ -1295,12 +890,10 @@ impl InfrastructureMap {
                     } else {
                         log::debug!("Topic updated: {} ({})", topic.name, id);
                         topic_updates += 1;
-                        changes
-                            .streaming_engine_changes
-                            .push(StreamingChange::Topic(Change::<Topic>::Updated {
-                                before: Box::new(topic.clone()),
-                                after: Box::new(target_topic.clone()),
-                            }));
+                        streaming_changes.push(StreamingChange::Topic(Change::<Topic>::Updated {
+                            before: Box::new(topic.clone()),
+                            after: Box::new(target_topic.clone()),
+                        }));
                     }
                 }
             } else {
@@ -1309,11 +902,9 @@ impl InfrastructureMap {
                     LifeCycle::FullyManaged => {
                         log::debug!("Topic removed: {} ({})", topic.name, id);
                         topic_removals += 1;
-                        changes
-                            .streaming_engine_changes
-                            .push(StreamingChange::Topic(Change::<Topic>::Removed(Box::new(
-                                topic.clone(),
-                            ))));
+                        streaming_changes.push(StreamingChange::Topic(Change::<Topic>::Removed(
+                            Box::new(topic.clone()),
+                        )));
                     }
                     LifeCycle::DeletionProtected => {
                         log::debug!(
@@ -1331,8 +922,8 @@ impl InfrastructureMap {
             }
         }
 
-        for (id, topic) in &target_map.topics {
-            if !self.topics.contains_key(id) {
+        for (id, topic) in target_topics {
+            if !self_topics.contains_key(id) {
                 // Respect lifecycle: ExternallyManaged topics are never added automatically
                 if topic.life_cycle == LifeCycle::ExternallyManaged {
                     log::debug!(
@@ -1342,11 +933,9 @@ impl InfrastructureMap {
                 } else {
                     log::debug!("Topic added: {} ({})", topic.name, id);
                     topic_additions += 1;
-                    changes
-                        .streaming_engine_changes
-                        .push(StreamingChange::Topic(Change::<Topic>::Added(Box::new(
-                            topic.clone(),
-                        ))));
+                    streaming_changes.push(StreamingChange::Topic(Change::<Topic>::Added(
+                        Box::new(topic.clone()),
+                    )));
                 }
             }
         }
@@ -1358,110 +947,116 @@ impl InfrastructureMap {
             topic_updates
         );
 
-        // =================================================================
-        //                              API Endpoints
-        // =================================================================
-        log::info!("Analyzing changes in API Endpoints...");
-        let mut api_updates = 0;
-        let mut api_removals = 0;
-        let mut api_additions = 0;
+        (topic_additions, topic_removals, topic_updates)
+    }
 
-        for (id, api_endpoint) in &self.api_endpoints {
-            if let Some(target_api_endpoint) = target_map.api_endpoints.get(id) {
-                if api_endpoint != target_api_endpoint {
+    /// Compare API endpoints between two infrastructure maps and compute the differences
+    ///
+    /// This method identifies added, removed, and updated API endpoints by comparing
+    /// the source and target endpoint maps.
+    ///
+    /// # Arguments
+    /// * `self_endpoints` - HashMap of source API endpoints to compare from
+    /// * `target_endpoints` - HashMap of target API endpoints to compare against
+    /// * `api_changes` - Mutable vector to collect the identified changes
+    ///
+    /// # Returns
+    /// A tuple of (additions, removals, updates) counts
+    fn diff_api_endpoints(
+        self_endpoints: &HashMap<String, ApiEndpoint>,
+        target_endpoints: &HashMap<String, ApiEndpoint>,
+        api_changes: &mut Vec<ApiChange>,
+    ) -> (usize, usize, usize) {
+        log::info!("Analyzing changes in API Endpoints...");
+        let mut endpoint_updates = 0;
+        let mut endpoint_removals = 0;
+        let mut endpoint_additions = 0;
+
+        for (id, endpoint) in self_endpoints {
+            if let Some(target_endpoint) = target_endpoints.get(id) {
+                if endpoint != target_endpoint {
                     log::debug!("API Endpoint updated: {}", id);
-                    api_updates += 1;
-                    changes.api_changes.push(ApiChange::ApiEndpoint(
-                        Change::<ApiEndpoint>::Updated {
-                            before: Box::new(api_endpoint.clone()),
-                            after: Box::new(target_api_endpoint.clone()),
-                        },
-                    ));
+                    endpoint_updates += 1;
+                    api_changes.push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Updated {
+                        before: Box::new(endpoint.clone()),
+                        after: Box::new(target_endpoint.clone()),
+                    }));
                 }
             } else {
                 log::debug!("API Endpoint removed: {}", id);
-                api_removals += 1;
-                changes
-                    .api_changes
-                    .push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Removed(
-                        Box::new(api_endpoint.clone()),
-                    )));
+                endpoint_removals += 1;
+                api_changes.push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Removed(
+                    Box::new(endpoint.clone()),
+                )));
             }
         }
 
-        for (id, api_endpoint) in &target_map.api_endpoints {
-            if !self.api_endpoints.contains_key(id) {
+        for (id, endpoint) in target_endpoints {
+            if !self_endpoints.contains_key(id) {
                 log::debug!("API Endpoint added: {}", id);
-                api_additions += 1;
-                changes
-                    .api_changes
-                    .push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Added(
-                        Box::new(api_endpoint.clone()),
-                    )));
+                endpoint_additions += 1;
+                api_changes.push(ApiChange::ApiEndpoint(Change::<ApiEndpoint>::Added(
+                    Box::new(endpoint.clone()),
+                )));
             }
         }
 
         log::info!(
             "API Endpoint changes: {} added, {} removed, {} updated",
-            api_additions,
-            api_removals,
-            api_updates
+            endpoint_additions,
+            endpoint_removals,
+            endpoint_updates
         );
 
-        // =================================================================
-        //                              Tables
-        // =================================================================
-        log::info!("Analyzing changes in Tables...");
-        let olap_changes_len_before = changes.olap_changes.len();
-        Self::diff_tables_with_strategy(
-            &self.tables,
-            &target_map.tables,
-            &mut changes.olap_changes,
-            table_diff_strategy,
-        );
-        let table_changes = changes.olap_changes.len() - olap_changes_len_before;
-        log::info!("Table changes detected: {}", table_changes);
+        (endpoint_additions, endpoint_removals, endpoint_updates)
+    }
 
-        // =================================================================
-        //                              Views
-        // =================================================================
+    /// Compare views between two infrastructure maps and compute the differences
+    ///
+    /// This method identifies added, removed, and updated views by comparing
+    /// the source and target view maps.
+    ///
+    /// # Arguments
+    /// * `self_views` - HashMap of source views to compare from
+    /// * `target_views` - HashMap of target views to compare against
+    /// * `olap_changes` - Mutable vector to collect the identified changes
+    ///
+    /// # Returns
+    /// A tuple of (additions, removals, updates) counts
+    fn diff_views(
+        self_views: &HashMap<String, View>,
+        target_views: &HashMap<String, View>,
+        olap_changes: &mut Vec<OlapChange>,
+    ) -> (usize, usize, usize) {
         log::info!("Analyzing changes in Views...");
         let mut view_updates = 0;
         let mut view_removals = 0;
         let mut view_additions = 0;
 
-        for (id, view) in &self.views {
-            if let Some(target_view) = target_map.views.get(id) {
+        // Check for updates and removals
+        for (id, view) in self_views {
+            if let Some(target_view) = target_views.get(id) {
                 if view != target_view {
-                    log::debug!("View updated: {}", view.name);
+                    log::debug!("View updated: {} ({})", view.name, id);
                     view_updates += 1;
-                    changes
-                        .olap_changes
-                        .push(OlapChange::View(Change::<View>::Updated {
-                            before: Box::new(view.clone()),
-                            after: Box::new(target_view.clone()),
-                        }));
+                    olap_changes.push(OlapChange::View(Change::Updated {
+                        before: Box::new(view.clone()),
+                        after: Box::new(target_view.clone()),
+                    }));
                 }
             } else {
-                log::debug!("View removed: {}", view.name);
+                log::debug!("View removed: {} ({})", view.name, id);
                 view_removals += 1;
-                changes
-                    .olap_changes
-                    .push(OlapChange::View(Change::<View>::Removed(Box::new(
-                        view.clone(),
-                    ))));
+                olap_changes.push(OlapChange::View(Change::Removed(Box::new(view.clone()))));
             }
         }
 
-        for (id, view) in &target_map.views {
-            if !self.views.contains_key(id) {
-                log::debug!("View added: {}", view.name);
+        // Check for additions
+        for (id, view) in target_views {
+            if !self_views.contains_key(id) {
+                log::debug!("View added: {} ({})", view.name, id);
                 view_additions += 1;
-                changes
-                    .olap_changes
-                    .push(OlapChange::View(Change::<View>::Added(Box::new(
-                        view.clone(),
-                    ))));
+                olap_changes.push(OlapChange::View(Change::Added(Box::new(view.clone()))));
             }
         }
 
@@ -1472,268 +1067,308 @@ impl InfrastructureMap {
             view_updates
         );
 
-        // =================================================================
-        //                              SQL Resources
-        // =================================================================
-        Self::diff_sql_resources(
-            &self.sql_resources,
-            &target_map.sql_resources,
-            &mut changes.olap_changes,
+        (view_additions, view_removals, view_updates)
+    }
+
+    /// Diff all process-related changes between two infrastructure maps
+    ///
+    /// This orchestrates diffing for all process types by calling specialized functions
+    fn diff_all_processes(
+        &self,
+        target_map: &InfrastructureMap,
+        process_changes: &mut Vec<ProcessChange>,
+    ) {
+        Self::diff_topic_to_table_sync_processes(
+            &self.topic_to_table_sync_processes,
+            &target_map.topic_to_table_sync_processes,
+            process_changes,
         );
 
-        // =================================================================
-        //                              Topic to Table Sync Processes
-        // =================================================================
-        log::info!("Analyzing changes in Topic to Table Sync Processes...");
-        let mut t2t_sync_updates = 0;
-        let mut t2t_sync_removals = 0;
-        let mut t2t_sync_additions = 0;
+        Self::diff_topic_to_topic_sync_processes(
+            &self.topic_to_topic_sync_processes,
+            &target_map.topic_to_topic_sync_processes,
+            process_changes,
+        );
 
-        for (id, topic_to_table_sync_process) in &self.topic_to_table_sync_processes {
-            if let Some(target_topic_to_table_sync_process) =
-                target_map.topic_to_table_sync_processes.get(id)
-            {
-                if topic_to_table_sync_process != target_topic_to_table_sync_process {
-                    log::debug!("Topic to Table Sync Process updated: {}", id);
-                    t2t_sync_updates += 1;
-                    changes
-                        .processes_changes
-                        .push(ProcessChange::TopicToTableSyncProcess(Change::<
-                            TopicToTableSyncProcess,
-                        >::Updated {
-                            before: Box::new(topic_to_table_sync_process.clone()),
-                            after: Box::new(target_topic_to_table_sync_process.clone()),
-                        }));
+        Self::diff_function_processes(
+            &self.function_processes,
+            &target_map.function_processes,
+            process_changes,
+        );
+
+        Self::diff_olap_processes(
+            &self.block_db_processes,
+            &target_map.block_db_processes,
+            process_changes,
+        );
+
+        Self::diff_consumption_api_processes(
+            &self.consumption_api_web_server,
+            &target_map.consumption_api_web_server,
+            process_changes,
+        );
+
+        Self::diff_orchestration_workers(
+            &self.orchestration_workers,
+            &target_map.orchestration_workers,
+            process_changes,
+        );
+    }
+
+    /// Compare TopicToTableSyncProcess changes between two infrastructure maps
+    fn diff_topic_to_table_sync_processes(
+        self_processes: &HashMap<String, TopicToTableSyncProcess>,
+        target_processes: &HashMap<String, TopicToTableSyncProcess>,
+        process_changes: &mut Vec<ProcessChange>,
+    ) -> (usize, usize, usize) {
+        log::info!("Analyzing changes in Topic-to-Table Sync Processes...");
+        let mut process_updates = 0;
+        let mut process_removals = 0;
+        let mut process_additions = 0;
+
+        for (id, process) in self_processes {
+            if let Some(target_process) = target_processes.get(id) {
+                if process != target_process {
+                    log::debug!("TopicToTableSyncProcess updated: {}", id);
+                    process_updates += 1;
+                    process_changes.push(ProcessChange::TopicToTableSyncProcess(Change::<
+                        TopicToTableSyncProcess,
+                    >::Updated {
+                        before: Box::new(process.clone()),
+                        after: Box::new(target_process.clone()),
+                    }));
                 }
             } else {
-                log::debug!("Topic to Table Sync Process removed: {}", id);
-                t2t_sync_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTableSyncProcess(Change::<
-                        TopicToTableSyncProcess,
-                    >::Removed(
-                        Box::new(topic_to_table_sync_process.clone()),
-                    )));
+                log::debug!("TopicToTableSyncProcess removed: {}", id);
+                process_removals += 1;
+                process_changes.push(ProcessChange::TopicToTableSyncProcess(Change::<
+                    TopicToTableSyncProcess,
+                >::Removed(
+                    Box::new(process.clone()),
+                )));
             }
         }
 
-        for (id, topic_to_table_sync_process) in &target_map.topic_to_table_sync_processes {
-            if !self.topic_to_table_sync_processes.contains_key(id) {
-                log::debug!("Topic to Table Sync Process added: {}", id);
-                t2t_sync_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTableSyncProcess(Change::<
-                        TopicToTableSyncProcess,
-                    >::Added(
-                        Box::new(topic_to_table_sync_process.clone()),
-                    )));
+        for (id, process) in target_processes {
+            if !self_processes.contains_key(id) {
+                log::debug!("TopicToTableSyncProcess added: {}", id);
+                process_additions += 1;
+                process_changes.push(ProcessChange::TopicToTableSyncProcess(Change::<
+                    TopicToTableSyncProcess,
+                >::Added(
+                    Box::new(process.clone()),
+                )));
             }
         }
 
         log::info!(
-            "Topic to Table Sync Process changes: {} added, {} removed, {} updated",
-            t2t_sync_additions,
-            t2t_sync_removals,
-            t2t_sync_updates
+            "Topic-to-Table Sync Process changes: {} added, {} removed, {} updated",
+            process_additions,
+            process_removals,
+            process_updates
         );
 
-        // =================================================================
-        //                              Topic to Topic Sync Processes
-        // =================================================================
-        log::info!("Analyzing changes in Topic to Topic Sync Processes...");
-        let mut t2t_topic_sync_updates = 0;
-        let mut t2t_topic_sync_removals = 0;
-        let mut t2t_topic_sync_additions = 0;
+        (process_additions, process_removals, process_updates)
+    }
 
-        for (id, topic_to_topic_sync_process) in &self.topic_to_topic_sync_processes {
-            if let Some(target_topic_to_topic_sync_process) =
-                target_map.topic_to_topic_sync_processes.get(id)
-            {
-                if topic_to_topic_sync_process != target_topic_to_topic_sync_process {
-                    log::debug!("Topic to Topic Sync Process updated: {}", id);
-                    t2t_topic_sync_updates += 1;
-                    changes
-                        .processes_changes
-                        .push(ProcessChange::TopicToTopicSyncProcess(Change::<
-                            TopicToTopicSyncProcess,
-                        >::Updated {
-                            before: Box::new(topic_to_topic_sync_process.clone()),
-                            after: Box::new(target_topic_to_topic_sync_process.clone()),
-                        }));
+    /// Compare TopicToTopicSyncProcess changes between two infrastructure maps
+    fn diff_topic_to_topic_sync_processes(
+        self_processes: &HashMap<String, TopicToTopicSyncProcess>,
+        target_processes: &HashMap<String, TopicToTopicSyncProcess>,
+        process_changes: &mut Vec<ProcessChange>,
+    ) -> (usize, usize, usize) {
+        log::info!("Analyzing changes in Topic-to-Topic Sync Processes...");
+        let mut process_updates = 0;
+        let mut process_removals = 0;
+        let mut process_additions = 0;
+
+        for (id, process) in self_processes {
+            if let Some(target_process) = target_processes.get(id) {
+                if process != target_process {
+                    log::debug!("TopicToTopicSyncProcess updated: {}", id);
+                    process_updates += 1;
+                    process_changes.push(ProcessChange::TopicToTopicSyncProcess(Change::<
+                        TopicToTopicSyncProcess,
+                    >::Updated {
+                        before: Box::new(process.clone()),
+                        after: Box::new(target_process.clone()),
+                    }));
                 }
             } else {
-                log::debug!("Topic to Topic Sync Process removed: {}", id);
-                t2t_topic_sync_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTopicSyncProcess(Change::<
-                        TopicToTopicSyncProcess,
-                    >::Removed(
-                        Box::new(topic_to_topic_sync_process.clone()),
-                    )));
+                log::debug!("TopicToTopicSyncProcess removed: {}", id);
+                process_removals += 1;
+                process_changes.push(ProcessChange::TopicToTopicSyncProcess(Change::<
+                    TopicToTopicSyncProcess,
+                >::Removed(
+                    Box::new(process.clone()),
+                )));
             }
         }
 
-        for (id, topic_to_topic_sync_process) in &target_map.topic_to_topic_sync_processes {
-            if !self.topic_to_topic_sync_processes.contains_key(id) {
-                log::debug!("Topic to Topic Sync Process added: {}", id);
-                t2t_topic_sync_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::TopicToTopicSyncProcess(Change::<
-                        TopicToTopicSyncProcess,
-                    >::Added(
-                        Box::new(topic_to_topic_sync_process.clone()),
-                    )));
+        for (id, process) in target_processes {
+            if !self_processes.contains_key(id) {
+                log::debug!("TopicToTopicSyncProcess added: {}", id);
+                process_additions += 1;
+                process_changes.push(ProcessChange::TopicToTopicSyncProcess(Change::<
+                    TopicToTopicSyncProcess,
+                >::Added(
+                    Box::new(process.clone()),
+                )));
             }
         }
 
         log::info!(
-            "Topic to Topic Sync Process changes: {} added, {} removed, {} updated",
-            t2t_topic_sync_additions,
-            t2t_topic_sync_removals,
-            t2t_topic_sync_updates
+            "Topic-to-Topic Sync Process changes: {} added, {} removed, {} updated",
+            process_additions,
+            process_removals,
+            process_updates
         );
 
-        // =================================================================
-        //                             Function Processes
-        // =================================================================
+        (process_additions, process_removals, process_updates)
+    }
+
+    /// Compare FunctionProcess changes between two infrastructure maps
+    fn diff_function_processes(
+        self_processes: &HashMap<String, FunctionProcess>,
+        target_processes: &HashMap<String, FunctionProcess>,
+        process_changes: &mut Vec<ProcessChange>,
+    ) -> (usize, usize, usize) {
         log::info!("Analyzing changes in Function Processes...");
-        let mut function_updates = 0;
-        let mut function_removals = 0;
-        let mut function_additions = 0;
+        let mut process_updates = 0;
+        let mut process_removals = 0;
+        let mut process_additions = 0;
 
-        for (id, function_process) in &self.function_processes {
-            if let Some(target_function_process) = target_map.function_processes.get(id) {
-                // In this case we don't do a comparison check because the function process is not just
-                // dependent on changing one file, but also on its dependencies. Until we are able to
-                // properly compare the function processes holistically (File + Dependencies), we will just
-                // assume that the function process has changed.
-                log::debug!("Function Process updated: {}", id);
-                function_updates += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::FunctionProcess(
-                        Change::<FunctionProcess>::Updated {
-                            before: Box::new(function_process.clone()),
-                            after: Box::new(target_function_process.clone()),
-                        },
-                    ));
+        for (id, process) in self_processes {
+            if let Some(target_process) = target_processes.get(id) {
+                // Always treat function processes as updated if they exist in both maps
+                // This ensures function code changes are always redeployed
+                log::debug!("FunctionProcess updated (forced): {}", id);
+                process_updates += 1;
+                process_changes.push(ProcessChange::FunctionProcess(
+                    Change::<FunctionProcess>::Updated {
+                        before: Box::new(process.clone()),
+                        after: Box::new(target_process.clone()),
+                    },
+                ));
             } else {
-                log::debug!("Function Process removed: {}", id);
-                function_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::FunctionProcess(
-                        Change::<FunctionProcess>::Removed(Box::new(function_process.clone())),
-                    ));
+                log::debug!("FunctionProcess removed: {}", id);
+                process_removals += 1;
+                process_changes.push(ProcessChange::FunctionProcess(
+                    Change::<FunctionProcess>::Removed(Box::new(process.clone())),
+                ));
             }
         }
 
-        for (id, function_process) in &target_map.function_processes {
-            if !self.function_processes.contains_key(id) {
-                log::debug!("Function Process added: {}", id);
-                function_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::FunctionProcess(
-                        Change::<FunctionProcess>::Added(Box::new(function_process.clone())),
-                    ));
+        for (id, process) in target_processes {
+            if !self_processes.contains_key(id) {
+                log::debug!("FunctionProcess added: {}", id);
+                process_additions += 1;
+                process_changes.push(ProcessChange::FunctionProcess(
+                    Change::<FunctionProcess>::Added(Box::new(process.clone())),
+                ));
             }
         }
 
         log::info!(
             "Function Process changes: {} added, {} removed, {} updated",
-            function_additions,
-            function_removals,
-            function_updates
+            process_additions,
+            process_removals,
+            process_updates
         );
 
-        // =================================================================
-        //                             Blocks Processes
-        // =================================================================
-        log::info!("Analyzing changes in OLAP Processes...");
+        (process_additions, process_removals, process_updates)
+    }
 
-        // Until we refactor to have multiple processes, we will consider that we need to restart
-        // the process all the times and the blocks changes all the time.
-        // Once we do the other refactor, we will be able to compare the changes and only restart
-        // the process if there are changes
+    /// Compare OLAP process changes between two infrastructure maps
+    fn diff_olap_processes(
+        self_process: &OlapProcess,
+        target_process: &OlapProcess,
+        process_changes: &mut Vec<ProcessChange>,
+    ) {
+        log::info!("Analyzing changes in OLAP processes...");
 
-        // currently we assume there is always a change and restart the processes
+        // Currently we assume there is always a change and restart the processes
+        // TODO: Once we refactor to have multiple processes, we should compare actual changes
         log::debug!("OLAP Process updated (assumed for now)");
-        changes.processes_changes.push(ProcessChange::OlapProcess(
-            Change::<OlapProcess>::Updated {
-                before: Box::new(OlapProcess {}),
-                after: Box::new(OlapProcess {}),
-            },
-        ));
+        process_changes.push(ProcessChange::OlapProcess(Change::<OlapProcess>::Updated {
+            before: Box::new(self_process.clone()),
+            after: Box::new(target_process.clone()),
+        }));
+    }
 
-        // =================================================================
-        //                          Consumption Process
-        // =================================================================
-        log::info!("Analyzing changes in Consumption API Web Server...");
+    /// Compare Consumption API process changes between two infrastructure maps
+    fn diff_consumption_api_processes(
+        self_process: &ConsumptionApiWebServer,
+        target_process: &ConsumptionApiWebServer,
+        process_changes: &mut Vec<ProcessChange>,
+    ) {
+        log::info!("Analyzing changes in Consumption API processes...");
 
         // We are currently not tracking individual consumption endpoints, so we will just restart
-        // the consumption web server when something changed. we might want to change that in the future
-        // to be able to only make changes when something in the dependency tree of a consumption api has
-        // changed.
+        // the consumption web server when something changed
         log::debug!("Consumption API Web Server updated (assumed for now)");
-        changes
-            .processes_changes
-            .push(ProcessChange::ConsumptionApiWebServer(Change::<
-                ConsumptionApiWebServer,
-            >::Updated {
-                before: Box::new(ConsumptionApiWebServer {}),
-                after: Box::new(ConsumptionApiWebServer {}),
-            }));
+        process_changes.push(ProcessChange::ConsumptionApiWebServer(Change::<
+            ConsumptionApiWebServer,
+        >::Updated {
+            before: Box::new(self_process.clone()),
+            after: Box::new(target_process.clone()),
+        }));
+    }
 
-        // =================================================================
-        //                      Orchestration Workers
-        // =================================================================
+    /// Compare OrchestrationWorker changes between two infrastructure maps
+    fn diff_orchestration_workers(
+        self_workers: &HashMap<String, OrchestrationWorker>,
+        target_workers: &HashMap<String, OrchestrationWorker>,
+        process_changes: &mut Vec<ProcessChange>,
+    ) -> (usize, usize, usize) {
         log::info!("Analyzing changes in Orchestration Workers...");
         let mut worker_updates = 0;
         let mut worker_removals = 0;
         let mut worker_additions = 0;
 
-        for (id, orchestration_worker) in &self.orchestration_workers {
-            if let Some(target_orchestration_worker) = target_map.orchestration_workers.get(id) {
-                // Until we track individual files changes, we want workers to be restarted for every change
-                log::debug!("Orchestration Worker updated: {}", id);
+        for (id, worker) in self_workers {
+            if let Some(target_worker) = target_workers.get(id) {
+                // Always treat workers as updated to ensure redeployment
+                log::debug!(
+                    "OrchestrationWorker updated (forced): {} ({})",
+                    id,
+                    worker.supported_language
+                );
                 worker_updates += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::OrchestrationWorker(Change::<
-                        OrchestrationWorker,
-                    >::Updated {
-                        before: Box::new(orchestration_worker.clone()),
-                        after: Box::new(target_orchestration_worker.clone()),
-                    }));
+                process_changes.push(ProcessChange::OrchestrationWorker(Change::<
+                    OrchestrationWorker,
+                >::Updated {
+                    before: Box::new(worker.clone()),
+                    after: Box::new(target_worker.clone()),
+                }));
             } else {
-                log::debug!("Orchestration Worker removed: {}", id);
+                log::debug!(
+                    "OrchestrationWorker removed: {} ({})",
+                    id,
+                    worker.supported_language
+                );
                 worker_removals += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::OrchestrationWorker(Change::<
-                        OrchestrationWorker,
-                    >::Removed(
-                        Box::new(orchestration_worker.clone()),
-                    )));
+                process_changes.push(ProcessChange::OrchestrationWorker(Change::<
+                    OrchestrationWorker,
+                >::Removed(
+                    Box::new(worker.clone()),
+                )));
             }
         }
 
-        for (id, orchestration_worker) in &target_map.orchestration_workers {
-            if !self.orchestration_workers.contains_key(id) {
-                log::debug!("Orchestration Worker added: {}", id);
+        for (id, worker) in target_workers {
+            if !self_workers.contains_key(id) {
+                log::debug!(
+                    "OrchestrationWorker added: {} ({})",
+                    id,
+                    worker.supported_language
+                );
                 worker_additions += 1;
-                changes
-                    .processes_changes
-                    .push(ProcessChange::OrchestrationWorker(Change::<
-                        OrchestrationWorker,
-                    >::Added(
-                        Box::new(orchestration_worker.clone()),
-                    )));
+                process_changes.push(ProcessChange::OrchestrationWorker(Change::<
+                    OrchestrationWorker,
+                >::Added(
+                    Box::new(worker.clone()),
+                )));
             }
         }
 
@@ -1744,16 +1379,7 @@ impl InfrastructureMap {
             worker_updates
         );
 
-        // Summarize total changes
-        log::info!(
-            "Total changes: {} OLAP, {} Process, {} API, {} Streaming",
-            changes.olap_changes.len(),
-            changes.processes_changes.len(),
-            changes.api_changes.len(),
-            changes.streaming_engine_changes.len()
-        );
-
-        changes
+        (worker_additions, worker_removals, worker_updates)
     }
 
     /// Compare SQL resources between two infrastructure maps and compute the differences
@@ -1935,8 +1561,11 @@ impl InfrastructureMap {
                                 order_by_change,
                             );
 
-                            table_updates += strategy_changes.len();
-                            olap_changes.extend(strategy_changes);
+                            // Only count as a table update if the strategy returned actual operations
+                            if !strategy_changes.is_empty() {
+                                table_updates += 1;
+                                olap_changes.extend(strategy_changes);
+                            }
                         }
                     }
                 }

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -19,6 +19,7 @@ use crate::framework::core::infrastructure_map::{
     InfraChanges, InfrastructureMap, OlapChange, TableChange,
 };
 use crate::framework::core::primitive_map::PrimitiveMap;
+use crate::infrastructure::olap::clickhouse::diff_strategy::ClickHouseTableDiffStrategy;
 use crate::infrastructure::olap::OlapOperations;
 use crate::infrastructure::{olap::clickhouse, redis::redis_client::RedisClient};
 use crate::project::Project;
@@ -264,10 +265,11 @@ pub async fn plan_changes(
             .unwrap_or("Could not serialize reconciled infrastructure map".to_string())
     );
 
-    // Use the reconciled map for diffing
+    // Use the reconciled map for diffing with ClickHouse-specific strategy
+    let clickhouse_strategy = ClickHouseTableDiffStrategy;
     let plan = InfraPlan {
         target_infra_map: target_infra_map.clone(),
-        changes: reconciled_map.diff(&target_infra_map),
+        changes: reconciled_map.diff_with_table_strategy(&target_infra_map, &clickhouse_strategy),
     };
 
     // Validate that OLAP is enabled if OLAP changes are required

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
@@ -55,6 +55,7 @@ use crate::project::Project;
 
 pub mod client;
 pub mod config;
+pub mod diff_strategy;
 pub mod errors;
 pub mod inserter;
 pub mod mapper;

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/diff_strategy.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/diff_strategy.rs
@@ -169,8 +169,8 @@ mod tests {
         let after = create_test_table("test", vec!["id".to_string()], true);
 
         let order_by_change = OrderByChange {
-            before: vec![],
-            after: vec![],
+            before: before.order_by.clone(),
+            after: after.order_by.clone(),
         };
 
         let changes = strategy.diff_table_update(&before, &after, vec![], order_by_change);
@@ -207,8 +207,8 @@ mod tests {
         }];
 
         let order_by_change = OrderByChange {
-            before: vec![],
-            after: vec![],
+            before: before.order_by.clone(),
+            after: after.order_by.clone(),
         };
 
         let changes = strategy.diff_table_update(&before, &after, column_changes, order_by_change);

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/diff_strategy.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/diff_strategy.rs
@@ -1,0 +1,214 @@
+//! ClickHouse-specific table diffing strategy
+//!
+//! This module implements the TableDiffStrategy for ClickHouse, handling the database's
+//! specific limitations around schema changes. ClickHouse has restrictions on certain
+//! ALTER TABLE operations, particularly around ORDER BY and primary key changes.
+
+use crate::framework::core::infrastructure::table::Table;
+use crate::framework::core::infrastructure_map::{
+    ColumnChange, OlapChange, OrderByChange, TableChange, TableDiffStrategy,
+};
+
+/// ClickHouse-specific table diff strategy
+///
+/// ClickHouse has several limitations that require drop+create operations instead of ALTER:
+/// - Cannot change ORDER BY clause via ALTER TABLE
+/// - Cannot change primary key structure via ALTER TABLE
+/// - Some column type changes are not supported
+///
+/// This strategy identifies these cases and converts table updates into drop+create operations
+/// so that users see the actual operations that will be performed.
+pub struct ClickHouseTableDiffStrategy;
+
+impl TableDiffStrategy for ClickHouseTableDiffStrategy {
+    fn diff_table_update(
+        &self,
+        before: &Table,
+        after: &Table,
+        column_changes: Vec<ColumnChange>,
+        order_by_change: OrderByChange,
+    ) -> Vec<OlapChange> {
+        // Check if ORDER BY has changed
+        let order_by_changed =
+            !order_by_change.before.is_empty() || !order_by_change.after.is_empty();
+        if order_by_changed {
+            log::debug!(
+                "ClickHouse: ORDER BY changed for table '{}', requiring drop+create",
+                before.name
+            );
+            return vec![
+                OlapChange::Table(TableChange::Removed(before.clone())),
+                OlapChange::Table(TableChange::Added(after.clone())),
+            ];
+        }
+
+        // Check if primary key structure has changed
+        let before_primary_keys = before.primary_key_columns();
+        let after_primary_keys = after.primary_key_columns();
+        if before_primary_keys != after_primary_keys {
+            log::debug!(
+                "ClickHouse: Primary key structure changed for table '{}', requiring drop+create",
+                before.name
+            );
+            return vec![
+                OlapChange::Table(TableChange::Removed(before.clone())),
+                OlapChange::Table(TableChange::Added(after.clone())),
+            ];
+        }
+
+        // Check if deduplication setting changed (affects engine)
+        if before.deduplicate != after.deduplicate {
+            log::debug!(
+                "ClickHouse: Deduplication setting changed for table '{}', requiring drop+create",
+                before.name
+            );
+            return vec![
+                OlapChange::Table(TableChange::Removed(before.clone())),
+                OlapChange::Table(TableChange::Added(after.clone())),
+            ];
+        }
+
+        // For other changes, ClickHouse can handle them via ALTER TABLE
+        // Return the standard table update change
+        vec![OlapChange::Table(TableChange::Updated {
+            name: before.name.clone(),
+            column_changes,
+            order_by_change,
+            before: before.clone(),
+            after: after.clone(),
+        })]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::framework::core::infrastructure::table::{Column, ColumnType};
+    use crate::framework::core::infrastructure_map::{PrimitiveSignature, PrimitiveTypes};
+    use crate::framework::core::partial_infrastructure_map::LifeCycle;
+    use crate::framework::versions::Version;
+
+    fn create_test_table(name: &str, order_by: Vec<String>, deduplicate: bool) -> Table {
+        Table {
+            name: name.to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: ColumnType::String,
+                    required: true,
+                    unique: false,
+                    primary_key: true,
+                    default: None,
+                    annotations: vec![],
+                },
+                Column {
+                    name: "timestamp".to_string(),
+                    data_type: ColumnType::String,
+                    required: true,
+                    unique: false,
+                    primary_key: false,
+                    default: None,
+                    annotations: vec![],
+                },
+            ],
+            order_by,
+            deduplicate,
+            engine: None,
+            version: Some(Version::from_string("1.0.0".to_string())),
+            source_primitive: PrimitiveSignature {
+                name: "test".to_string(),
+                primitive_type: PrimitiveTypes::DataModel,
+            },
+            metadata: None,
+            life_cycle: LifeCycle::FullyManaged,
+        }
+    }
+
+    #[test]
+    fn test_order_by_change_requires_drop_create() {
+        let strategy = ClickHouseTableDiffStrategy;
+
+        let before = create_test_table("test", vec!["id".to_string()], false);
+        let after = create_test_table(
+            "test",
+            vec!["id".to_string(), "timestamp".to_string()],
+            false,
+        );
+
+        let order_by_change = OrderByChange {
+            before: vec!["id".to_string()],
+            after: vec!["id".to_string(), "timestamp".to_string()],
+        };
+
+        let changes = strategy.diff_table_update(&before, &after, vec![], order_by_change);
+
+        assert_eq!(changes.len(), 2);
+        assert!(matches!(
+            changes[0],
+            OlapChange::Table(TableChange::Removed(_))
+        ));
+        assert!(matches!(
+            changes[1],
+            OlapChange::Table(TableChange::Added(_))
+        ));
+    }
+
+    #[test]
+    fn test_deduplication_change_requires_drop_create() {
+        let strategy = ClickHouseTableDiffStrategy;
+
+        let before = create_test_table("test", vec!["id".to_string()], false);
+        let after = create_test_table("test", vec!["id".to_string()], true);
+
+        let order_by_change = OrderByChange {
+            before: vec![],
+            after: vec![],
+        };
+
+        let changes = strategy.diff_table_update(&before, &after, vec![], order_by_change);
+
+        assert_eq!(changes.len(), 2);
+        assert!(matches!(
+            changes[0],
+            OlapChange::Table(TableChange::Removed(_))
+        ));
+        assert!(matches!(
+            changes[1],
+            OlapChange::Table(TableChange::Added(_))
+        ));
+    }
+
+    #[test]
+    fn test_column_only_changes_use_alter() {
+        let strategy = ClickHouseTableDiffStrategy;
+
+        let before = create_test_table("test", vec!["id".to_string()], false);
+        let after = create_test_table("test", vec!["id".to_string()], false);
+
+        let column_changes = vec![ColumnChange::Added {
+            column: Column {
+                name: "new_col".to_string(),
+                data_type: ColumnType::String,
+                required: false,
+                unique: false,
+                primary_key: false,
+                default: None,
+                annotations: vec![],
+            },
+            position_after: Some("timestamp".to_string()),
+        }];
+
+        let order_by_change = OrderByChange {
+            before: vec![],
+            after: vec![],
+        };
+
+        let changes = strategy.diff_table_update(&before, &after, column_changes, order_by_change);
+
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(
+            changes[0],
+            OlapChange::Table(TableChange::Updated { .. })
+        ));
+    }
+}

--- a/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
+++ b/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
@@ -400,41 +400,23 @@ fn handle_table_remove(table: &Table) -> OperationPlan {
     OperationPlan::teardown(vec![drop_table_operation(table)])
 }
 
-/// Handles non-mutable changes to a table, such as changing the order of columns or the primary key
-fn handle_non_mutable_change_operation(before: &Table, after: &Table) -> OperationPlan {
-    let teardown_op = drop_table_operation(before);
-    let setup_op = create_table_operation(after);
-
-    let mut plan = OperationPlan::new();
-    plan.teardown_ops.push(teardown_op);
-    plan.setup_ops.push(setup_op);
-    plan
-}
-
 /// Handles updating a table operation
+///
+/// This function now uses a generic approach since database-specific logic
+/// has been moved to the planning phase via TableDiffStrategy implementations.
+/// The ddl_ordering module should only receive the operations that the database
+/// can actually perform.
 fn handle_table_update(
     before: &Table,
     after: &Table,
     column_changes: &[ColumnChange],
 ) -> OperationPlan {
-    // Check if ORDER BY has changed
-    if !before.order_by_equals(after) {
-        // If ORDER BY changed, we need to drop and recreate the table
-        handle_non_mutable_change_operation(before, after)
-    } else {
-        // Check if primary key structure has changed
-        let before_primary_keys = before.primary_key_columns();
-        let after_primary_keys = after.primary_key_columns();
-
-        if before_primary_keys != after_primary_keys {
-            // If primary key structure changed, we need to drop and recreate the table
-            // This handles cases like changing from orderByFields to Key<T> annotations
-            handle_non_mutable_change_operation(before, after)
-        } else {
-            // If neither ORDER BY nor primary key structure changed, use the already computed column changes
-            process_column_changes(before, after, column_changes)
-        }
-    }
+    // Since database-specific transformations now happen during the diff phase,
+    // we can assume that any table update that reaches this point can be handled
+    // via column-level operations. If a database requires drop+create for certain
+    // changes, those should have been converted to separate Remove+Add operations
+    // by the appropriate TableDiffStrategy.
+    process_column_changes(before, after, column_changes)
 }
 
 /// Process a column addition with position information
@@ -2259,11 +2241,12 @@ mod tests {
     }
 
     #[test]
-    fn test_order_by_modification() {
-        // Test handling of ORDER BY modifications
-        // When ORDER BY changes, we need to drop and recreate the table
+    fn test_generic_table_update() {
+        // Test handling of generic table updates that can be handled via column operations
+        // ORDER BY changes are now handled at the diff phase by database-specific strategies,
+        // so this test focuses on column-level changes that all databases can handle.
 
-        // Create before and after tables
+        // Create before and after tables with the same ORDER BY but different columns
         let before_table = Table {
             name: "test_table".to_string(),
             columns: vec![
@@ -2277,9 +2260,9 @@ mod tests {
                     annotations: vec![],
                 },
                 Column {
-                    name: "timestamp".to_string(),
-                    data_type: ColumnType::DateTime { precision: None },
-                    required: true,
+                    name: "old_column".to_string(),
+                    data_type: ColumnType::String,
+                    required: false,
                     unique: false,
                     primary_key: false,
                     default: None,
@@ -2311,16 +2294,16 @@ mod tests {
                     annotations: vec![],
                 },
                 Column {
-                    name: "timestamp".to_string(),
-                    data_type: ColumnType::DateTime { precision: None },
-                    required: true,
+                    name: "new_column".to_string(),
+                    data_type: ColumnType::String,
+                    required: false,
                     unique: false,
                     primary_key: false,
                     default: None,
                     annotations: vec![],
                 },
             ],
-            order_by: vec!["timestamp".to_string()], // Changed from "id" to "timestamp"
+            order_by: vec!["id".to_string()], // Same ORDER BY
             deduplicate: false,
             engine: None,
             version: None,
@@ -2332,43 +2315,78 @@ mod tests {
             life_cycle: LifeCycle::FullyManaged,
         };
 
-        // Generate the operation plan
-        let plan = handle_table_update(&before_table, &after_table, &[]);
+        // Create column changes (remove old_column, add new_column)
+        let column_changes = vec![
+            ColumnChange::Removed(Column {
+                name: "old_column".to_string(),
+                data_type: ColumnType::String,
+                required: false,
+                unique: false,
+                primary_key: false,
+                default: None,
+                annotations: vec![],
+            }),
+            ColumnChange::Added {
+                column: Column {
+                    name: "new_column".to_string(),
+                    data_type: ColumnType::String,
+                    required: false,
+                    unique: false,
+                    primary_key: false,
+                    default: None,
+                    annotations: vec![],
+                },
+                position_after: Some("id".to_string()),
+            },
+        ];
 
-        // Check that the plan includes dropping and recreating the table
+        // Generate the operation plan
+        let plan = handle_table_update(&before_table, &after_table, &column_changes);
+
+        // Check that the plan uses column-level operations (not drop+create)
         assert_eq!(
             plan.teardown_ops.len(),
             1,
-            "Should have one teardown operation for ORDER BY change"
+            "Should have one teardown operation for column removal"
         );
         assert_eq!(
             plan.setup_ops.len(),
             1,
-            "Should have one setup operation for ORDER BY change"
+            "Should have one setup operation for column addition"
         );
 
         match &plan.teardown_ops[0] {
-            AtomicOlapOperation::DropTable { table, .. } => {
-                assert_eq!(table.name, "test_table", "Should drop the original table");
+            AtomicOlapOperation::DropTableColumn {
+                table, column_name, ..
+            } => {
                 assert_eq!(
-                    table.order_by,
-                    vec!["id".to_string()],
-                    "Should have original ORDER BY"
+                    table.name, "test_table",
+                    "Should drop column from correct table"
                 );
+                assert_eq!(column_name, "old_column", "Should drop the old column");
             }
-            _ => panic!("Expected DropTable operation"),
+            _ => panic!("Expected DropTableColumn operation"),
         }
 
         match &plan.setup_ops[0] {
-            AtomicOlapOperation::CreateTable { table, .. } => {
-                assert_eq!(table.name, "test_table", "Should create the new table");
+            AtomicOlapOperation::AddTableColumn {
+                table,
+                column,
+                after_column,
+                ..
+            } => {
                 assert_eq!(
-                    table.order_by,
-                    vec!["timestamp".to_string()],
-                    "Should have new ORDER BY"
+                    table.name, "test_table",
+                    "Should add column to correct table"
+                );
+                assert_eq!(column.name, "new_column", "Should add the new column");
+                assert_eq!(
+                    after_column,
+                    &Some("id".to_string()),
+                    "Should position after id column"
                 );
             }
-            _ => panic!("Expected CreateTable operation"),
+            _ => panic!("Expected AddTableColumn operation"),
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a ClickHouse-specific table diffing strategy to handle schema changes and updates the existing infrastructure to use this strategy. The changes include implementing the new strategy, integrating it into the infrastructure map diffing process, and refactoring the handling of table updates to rely on database-specific strategies. Below are the most important changes grouped by theme:

### ClickHouse-specific diffing strategy:
* Added a new module `diff_strategy` in `apps/framework-cli/src/infrastructure/olap/clickhouse/` that implements `ClickHouseTableDiffStrategy`. This strategy handles ClickHouse-specific limitations, such as requiring drop-and-create operations for changes to the `ORDER BY` clause, primary key structure, or deduplication settings.

### Integration of ClickHouse-specific strategy:
* Updated `admin_plan_route` in `apps/framework-cli/src/cli/local_webserver.rs` to use the `ClickHouseTableDiffStrategy` for diffing infrastructure maps.
* Updated `plan_changes` in `apps/framework-cli/src/framework/core/plan.rs` to use the `ClickHouseTableDiffStrategy` for diffing reconciled infrastructure maps.
* Updated `remote_refresh` in `apps/framework-cli/src/cli/routines.rs` to switch from a generic table diff method to a simpler `simple_table_diff` method.

### Refactoring of table update handling:
* Removed the `handle_non_mutable_change_operation` function in `apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs` and replaced `handle_table_update` with `handle_table_column_updates`, which now assumes that database-specific transformations are handled during the diff phase. [[1]](diffhunk://#diff-bfe1723e1a57eea016d6865666bea7751a5a98d1ed3b4694274b7012ce42f28bL403-L438) [[2]](diffhunk://#diff-bfe1723e1a57eea016d6865666bea7751a5a98d1ed3b4694274b7012ce42f28bL662-R650)
* Updated tests in `ddl_ordering.rs` to reflect the new approach, focusing on column-level changes rather than handling `ORDER BY` or primary key changes directly. [[1]](diffhunk://#diff-bfe1723e1a57eea016d6865666bea7751a5a98d1ed3b4694274b7012ce42f28bL2262-R2255) [[2]](diffhunk://#diff-bfe1723e1a57eea016d6865666bea7751a5a98d1ed3b4694274b7012ce42f28bR2324-R2395)

### Code organization:
* Added the new `diff_strategy` module to `apps/framework-cli/src/infrastructure/olap/clickhouse.rs`.
* Updated imports in `apps/framework-cli/src/framework/core/plan.rs` to include `ClickHouseTableDiffStrategy`.