### PR TITLE
Add environment variable to control compiler logs

### DIFF
--- a/packages/ts-moose-lib/src/commons.ts
+++ b/packages/ts-moose-lib/src/commons.ts
@@ -1,6 +1,16 @@
 import http from "http";
 import { createClient } from "@clickhouse/client";
 
+/**
+ * Utility function for compiler-related logging that can be disabled via environment variable.
+ * Set MOOSE_DISABLE_COMPILER_LOGS=true to suppress these logs (useful for testing environments).
+ */
+export const compilerLog = (message: string) => {
+  if (process.env.MOOSE_DISABLE_COMPILER_LOGS !== "true") {
+    console.log(message);
+  }
+};
+
 export const antiCachePath = (path: string) =>
   `${path}?num=${Math.random().toString()}&time=${Date.now()}`;
 

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -24,6 +24,7 @@ import { Column } from "../dataModels/dataModelTypes";
 import { ConsumptionUtil } from "../index";
 import { OlapTable } from "./sdk/olapTable";
 import { ConsumerConfig, Stream, TransformConfig } from "./sdk/stream";
+import { compilerLog } from "../commons";
 
 /**
  * Internal registry holding all defined Moose dmv2 resources.
@@ -436,7 +437,7 @@ export const getStreamingFunctions = async () => {
     stream._transformations.forEach((transforms, destinationName) => {
       transforms.forEach(([_, transform, config]) => {
         const transformFunctionKey = `${stream.name}_${destinationName}${config.version ? `_${config.version}` : ""}`;
-        console.log(`getStreamingFunctions: ${transformFunctionKey}`);
+        compilerLog(`getStreamingFunctions: ${transformFunctionKey}`);
         transformFunctions.set(transformFunctionKey, [transform, config]);
       });
     });

--- a/packages/ts-moose-lib/src/moduleExportSerializer.ts
+++ b/packages/ts-moose-lib/src/moduleExportSerializer.ts
@@ -1,4 +1,6 @@
+import { compilerLog } from "./commons";
+
 export async function runExportSerializer(targetModel: string) {
   const exports_list = require(targetModel);
-  console.log(JSON.stringify(exports_list));
+  compilerLog(JSON.stringify(exports_list));
 }


### PR DESCRIPTION
Add `MOOSE_DISABLE_COMPILER_LOGS` environment variable to suppress compiler plugin and related build-time logs.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8640f4e-dd7d-4f3c-8993-defb8ff3c22d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8640f4e-dd7d-4f3c-8993-defb8ff3c22d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>