### PR TITLE
Patch users `paths` file in compilerOptions

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -12,8 +12,23 @@ use crate::utilities::{constants, system};
 use crate::{cli::display::Message, project::Project};
 
 use log::{debug, error, info};
+use serde_json;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+struct PackageInfo {
+    name: String,
+    original_path: String,
+}
+
+#[derive(Debug)]
+struct PathMapping {
+    alias: String,
+    original_path: String,
+    package_name: String,
+    package_directory: String, // The directory name from the filesystem path
+}
 
 // Adapted from https://github.com/nodejs/docker-node/blob/2928850549388a57a33365302fc5ebac91f78ffe/20/bookworm-slim/Dockerfile
 // and removed yarn
@@ -221,6 +236,29 @@ pub fn create_dockerfile(
                 let package_copies =
                     generate_workspace_copy_commands(&workspace_root, &workspace_config);
 
+                // Analyze TypeScript paths and transform tsconfig.json
+                let typescript_mappings = match analyze_typescript_paths(
+                    &workspace_root,
+                    &relative_project_path.to_string_lossy(),
+                ) {
+                    Ok(mappings) => {
+                        // Transform tsconfig.json for Docker with pre-computed paths
+                        if let Err(e) = transform_tsconfig_for_docker(
+                            &workspace_root,
+                            &relative_project_path.to_string_lossy(),
+                            &mappings,
+                            &internal_dir,
+                        ) {
+                            error!("Failed to transform tsconfig.json for Docker: {}", e);
+                        }
+                        mappings
+                    }
+                    Err(e) => {
+                        error!("Failed to analyze TypeScript paths: {}", e);
+                        Vec::new()
+                    }
+                };
+
                 // Build the monorepo Dockerfile
                 let mut dockerfile = TS_MONOREPO_DOCKER_FILE.to_string();
                 dockerfile = dockerfile.replace("MONOREPO_PACKAGE_COPIES", &package_copies);
@@ -253,10 +291,6 @@ COPY --from=monorepo-base --chown=moose:moose /monorepo/{}/app ./app
 COPY --from=monorepo-base --chown=moose:moose /monorepo/{}/package.json ./package.json
 COPY --from=monorepo-base --chown=moose:moose /monorepo/{}/tsconfig.json ./tsconfig.json
 
-# Copy config files
-COPY --chown=moose:moose ./project.tom[l] ./project.toml
-COPY --chown=moose:moose ./moose.config.tom[l] ./moose.config.toml
-
 # Use pnpm deploy from workspace context to create clean production dependencies
 USER root:root
 WORKDIR /temp-monorepo
@@ -269,9 +303,11 @@ COPY --from=monorepo-base /monorepo/{} ./{}
 RUN pnpm --filter "./{}" deploy /temp-deploy --prod --legacy
 RUN cp -r /temp-deploy/node_modules /application/node_modules
 RUN chown -R moose:moose /application/node_modules
-RUN rm -rf /temp-deploy
-# Clean up
-RUN rm -rf /temp-monorepo
+
+TYPESCRIPT_FIX_PLACEHOLDER
+USER root:root
+# Clean up temporary directories
+RUN rm -rf /temp-deploy /temp-monorepo
 
 RUN if [ -d "/application/node_modules/@514labs/moose-lib/dist/" ]; then ls -la /application/node_modules/@514labs/moose-lib/dist/; fi
 USER moose:moose
@@ -290,6 +326,14 @@ WORKDIR /application"#,
                     "INSTALL_COMMAND",
                     "# Dependencies copied from monorepo build stage",
                 );
+
+                // Replace the placeholder with a simple comment (tsconfig.json is pre-transformed)
+                let typescript_comment = if typescript_mappings.is_empty() {
+                    "# No TypeScript path transformations needed"
+                } else {
+                    "# TypeScript paths pre-transformed in tsconfig.json"
+                };
+                dockerfile = dockerfile.replace("TYPESCRIPT_FIX_PLACEHOLDER", typescript_comment);
 
                 // Store monorepo info for build phase
                 let monorepo_info_path = internal_dir.join("packager/.monorepo-info");
@@ -783,6 +827,236 @@ fn generate_workspace_copy_commands(workspace_root: &Path, patterns: &[String]) 
     }
 
     copy_commands.join("\n")
+}
+
+/// Analyzes TypeScript paths in tsconfig.json and reads actual package.json files
+fn analyze_typescript_paths(
+    workspace_root: &Path,
+    relative_project_path: &str,
+) -> Result<Vec<PathMapping>, std::io::Error> {
+    let tsconfig_path = workspace_root
+        .join(relative_project_path)
+        .join("tsconfig.json");
+
+    if !tsconfig_path.exists() {
+        debug!("No tsconfig.json found at {:?}", tsconfig_path);
+        return Ok(Vec::new());
+    }
+
+    let content = fs::read_to_string(&tsconfig_path)?;
+    let tsconfig: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(config) => config,
+        Err(e) => {
+            debug!("Failed to parse tsconfig.json: {}", e);
+            return Ok(Vec::new());
+        }
+    };
+
+    let mut mappings = Vec::new();
+
+    if let Some(paths) = tsconfig
+        .get("compilerOptions")
+        .and_then(|co| co.get("paths"))
+        .and_then(|p| p.as_object())
+    {
+        for (alias, path_array) in paths {
+            if let Some(paths) = path_array.as_array() {
+                for path in paths {
+                    if let Some(path_str) = path.as_str() {
+                        if let Some((package_info, package_dir)) = read_package_from_typescript_path(
+                            workspace_root,
+                            relative_project_path,
+                            path_str,
+                        ) {
+                            mappings.push(PathMapping {
+                                alias: alias.clone(),
+                                original_path: path_str.to_string(),
+                                package_name: package_info.name,
+                                package_directory: package_dir,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    debug!("Found {} TypeScript path mappings", mappings.len());
+    for mapping in &mappings {
+        debug!(
+            "  {} -> {} (package: {}, dir: {})",
+            mapping.alias, mapping.original_path, mapping.package_name, mapping.package_directory
+        );
+    }
+
+    Ok(mappings)
+}
+
+/// Reads package.json from a TypeScript path and returns the package name and directory
+fn read_package_from_typescript_path(
+    workspace_root: &Path,
+    relative_project_path: &str,
+    ts_path: &str,
+) -> Option<(PackageInfo, String)> {
+    // Start from the project directory
+    let project_dir = workspace_root.join(relative_project_path);
+
+    // Find the package directory by traversing up the path until we find package.json
+    let resolved_path = if ts_path.starts_with("/") {
+        PathBuf::from(ts_path)
+    } else {
+        project_dir.join(ts_path)
+    };
+
+    // Traverse up the resolved path to find package.json
+    let mut current_path = resolved_path.as_path();
+    while let Some(parent) = current_path.parent() {
+        let package_json_path = parent.join("package.json");
+
+        debug!("Checking for package.json at: {:?}", package_json_path);
+
+        if package_json_path.exists() {
+            match fs::read_to_string(&package_json_path) {
+                Ok(content) => {
+                    match serde_json::from_str::<serde_json::Value>(&content) {
+                        Ok(package_json) => {
+                            if let Some(name) = package_json.get("name").and_then(|n| n.as_str()) {
+                                // Extract the directory name from the filesystem path
+                                let package_dir = parent
+                                    .file_name()
+                                    .and_then(|n| n.to_str())
+                                    .unwrap_or("")
+                                    .to_string();
+
+                                debug!(
+                                    "Found package: {} in directory: {} at {:?}",
+                                    name, package_dir, package_json_path
+                                );
+                                return Some((
+                                    PackageInfo {
+                                        name: name.to_string(),
+                                        original_path: ts_path.to_string(),
+                                    },
+                                    package_dir,
+                                ));
+                            }
+                        }
+                        Err(e) => debug!(
+                            "Failed to parse package.json at {:?}: {}",
+                            package_json_path, e
+                        ),
+                    }
+                }
+                Err(e) => debug!(
+                    "Failed to read package.json at {:?}: {}",
+                    package_json_path, e
+                ),
+            }
+
+            // Found package.json but couldn't parse it, stop searching
+            break;
+        }
+
+        current_path = parent;
+    }
+
+    None
+}
+
+/// Extracts the path suffix after the package directory (generic approach)
+fn extract_path_suffix(original_path: &str, package_directory: &str) -> String {
+    // Find the last occurrence of the package directory in the path
+    if let Some(package_pos) = original_path.rfind(package_directory) {
+        let after_package_pos = package_pos + package_directory.len();
+        if after_package_pos < original_path.len() {
+            original_path[after_package_pos..].to_string()
+        } else {
+            String::new()
+        }
+    } else {
+        // If package directory not found, preserve the whole path as suffix
+        original_path.to_string()
+    }
+}
+
+/// Transforms tsconfig.json for Docker by pre-computing node_modules paths
+fn transform_tsconfig_for_docker(
+    workspace_root: &Path,
+    relative_project_path: &str,
+    mappings: &[PathMapping],
+    internal_dir: &Path,
+) -> Result<(), std::io::Error> {
+    if mappings.is_empty() {
+        debug!("No TypeScript path mappings to transform");
+        return Ok(());
+    }
+
+    let original_tsconfig_path = workspace_root
+        .join(relative_project_path)
+        .join("tsconfig.json");
+    let packager_tsconfig_path = internal_dir.join("packager/tsconfig.json");
+
+    if !original_tsconfig_path.exists() {
+        debug!("No tsconfig.json found at {:?}", original_tsconfig_path);
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&original_tsconfig_path)?;
+    let mut tsconfig: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let mut transformation_count = 0;
+
+    // Transform paths directly in Rust
+    if let Some(paths) = tsconfig
+        .get_mut("compilerOptions")
+        .and_then(|co| co.get_mut("paths"))
+        .and_then(|p| p.as_object_mut())
+    {
+        for (_alias, path_array) in paths.iter_mut() {
+            if let Some(paths) = path_array.as_array_mut() {
+                for path in paths.iter_mut() {
+                    if let Some(path_str) = path.as_str() {
+                        // Find the mapping for this path
+                        if let Some(mapping) = mappings.iter().find(|m| m.original_path == path_str)
+                        {
+                            // Extract the suffix after the package directory
+                            let suffix = extract_path_suffix(path_str, &mapping.package_directory);
+
+                            // Transform to node_modules path with the discovered package name
+                            let new_path =
+                                format!("./node_modules/{}{}", mapping.package_name, suffix);
+
+                            info!("Transforming TypeScript path: {} -> {}", path_str, new_path);
+                            *path = serde_json::Value::String(new_path);
+                            transformation_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if transformation_count > 0 {
+        // Write the transformed tsconfig.json to packager directory
+        let transformed_content = serde_json::to_string_pretty(&tsconfig)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        // Ensure the packager directory exists
+        if let Some(parent) = packager_tsconfig_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::write(&packager_tsconfig_path, transformed_content)?;
+        info!(
+            "Created transformed tsconfig.json with {} path updates at {:?}",
+            transformation_count, packager_tsconfig_path
+        );
+    } else {
+        info!("No TypeScript paths needed transformation");
+    }
+
+    Ok(())
 }
 
 /// Creates standard TypeScript Dockerfile content (non-monorepo)


### PR DESCRIPTION
This is something I spent very long trying to avoid, but in area-code there is no configuration that either @groy-514 or I could use that doesnt rely on using `paths` in tsconfig. When we copy over and pnpm deploy, we lose these references. This only handles one specific case of a hard problem and what to do with more external dependencies