### PR TITLE
ENG-560: ca-certs for moose

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -124,8 +124,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Update the package lists for upgrades for security purposes
 RUN apt-get update && apt-get upgrade -y
 
-# Install tail and locales package
-RUN apt-get install -y locales coreutils curl
+# Install ca-certificates, tail and locales package
+RUN apt-get install -y ca-certificates locales coreutils curl && update-ca-certificates
 
 # moose depends on libc 2.40+, not available in stable
 # This uses unstable, but unpinned because they delete older versions


### PR DESCRIPTION
**ENG-560: added ca-certs for moose docker builds**
required by kafka connections