### PR TITLE
feat: add bypass for not executing changes

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -386,6 +386,7 @@ pub async fn start_development_mode(
         process_registry.clone(),
         metrics.clone(),
         redis_client.clone(),
+        settings.clone(),
     )?;
 
     info!("Starting web server...");

--- a/apps/framework-cli/src/cli/settings.rs
+++ b/apps/framework-cli/src/cli/settings.rs
@@ -43,7 +43,7 @@ use crate::utilities::constants::{CLI_CONFIG_FILE, CLI_USER_DIRECTORY};
 const ENVIRONMENT_VARIABLE_PREFIX: &str = "MOOSE";
 
 /// Configuration for metric collection labels and endpoints
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct MetricLabels {
     /// Custom labels to attach to metrics
     pub labels: Option<String>,
@@ -52,7 +52,7 @@ pub struct MetricLabels {
 }
 
 /// Telemetry configuration for usage tracking and metrics
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Telemetry {
     /// Whether telemetry collection is enabled
     pub enabled: bool,
@@ -102,7 +102,7 @@ impl Features {
 }
 
 /// Main settings structure containing all configuration options
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Settings {
     /// Logging configuration settings
     #[serde(default)]
@@ -126,7 +126,7 @@ pub struct Settings {
 }
 
 /// Development-specific configuration options
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct DevSettings {
     /// Optional custom path to container CLI executable
     pub container_cli_path: Option<PathBuf>,
@@ -135,6 +135,12 @@ pub struct DevSettings {
     /// This can be set via the MOOSE_SKIP_CONTAINER_SHUTDOWN environment variable
     #[serde(default)]
     pub skip_container_shutdown: bool,
+
+    /// Whether to bypass execution of infrastructure changes (OLAP and streaming)
+    /// When enabled, the system will plan changes but not execute them
+    /// This can be set via the MOOSE_DEV__BYPASS_INFRASTRUCTURE_EXECUTION environment variable
+    #[serde(default)]
+    pub bypass_infrastructure_execution: bool,
 }
 
 /// Returns the path to the config file in the user's home directory
@@ -278,5 +284,17 @@ impl Settings {
     /// - Returns false when shutdown should be skipped
     pub fn should_shutdown_containers(&self) -> bool {
         !self.should_skip_container_shutdown()
+    }
+
+    /// Checks if infrastructure execution should be bypassed
+    ///
+    /// When enabled, OLAP and streaming changes will be planned but not executed.
+    /// This is useful for testing or debugging the planning phase without applying changes.
+    ///
+    /// The value can be set via:
+    /// - Configuration file: `dev.bypass_infrastructure_execution = true`
+    /// - Environment variable: `MOOSE_DEV__BYPASS_INFRASTRUCTURE_EXECUTION=true`
+    pub fn should_bypass_infrastructure_execution(&self) -> bool {
+        self.dev.bypass_infrastructure_execution
     }
 }

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -30,6 +30,7 @@ use tokio::sync::RwLock;
 use crate::framework::core::infrastructure_map::{ApiChange, InfrastructureMap};
 
 use super::display::{self, with_spinner_completion_async, Message, MessageType};
+use super::settings::Settings;
 
 use crate::cli::routines::openapi::openapi;
 use crate::infrastructure::processes::kafka_clickhouse_sync::SyncingProcessesRegistry;
@@ -114,6 +115,8 @@ impl EventBuckets {
 /// * `project_registries` - Registry for project processes
 /// * `metrics` - Metrics collection
 /// * `redis_client` - Redis client for state management
+/// * `settings` - CLI settings configuration
+#[allow(clippy::too_many_arguments)]
 async fn watch(
     project: Arc<Project>,
     route_update_channel: tokio::sync::mpsc::Sender<(InfrastructureMap, ApiChange)>,
@@ -122,6 +125,7 @@ async fn watch(
     project_registries: Arc<RwLock<ProcessRegistries>>,
     metrics: Arc<Metrics>,
     redis_client: Arc<RedisClient>,
+    settings: Settings,
 ) -> Result<(), anyhow::Error> {
     log::debug!(
         "Starting file watcher for project: {:?}",
@@ -177,6 +181,7 @@ async fn watch(
                                         syncing_process_registry,
                                         &mut project_registries,
                                         metrics.clone(),
+                                        &settings,
                                     )
                                     .await
                                     {
@@ -270,6 +275,7 @@ impl FileWatcher {
         project_registries: Arc<RwLock<ProcessRegistries>>,
         metrics: Arc<Metrics>,
         redis_client: Arc<RedisClient>,
+        settings: Settings,
     ) -> Result<(), Error> {
         show_message!(MessageType::Info, {
             Message {
@@ -290,6 +296,7 @@ impl FileWatcher {
                 project_registries,
                 metrics,
                 redis_client,
+                settings,
             )
             .await
         };

--- a/apps/framework-cli/src/framework/core/execute.rs
+++ b/apps/framework-cli/src/framework/core/execute.rs
@@ -89,13 +89,18 @@ pub async fn execute_initial_infra_change(
     redis_client: &Arc<RedisClient>,
 ) -> Result<(SyncingProcessesRegistry, ProcessRegistries), ExecutionError> {
     // This probably can be parallelized through Tokio Spawn
-    // Only execute OLAP changes if OLAP is enabled
-    if project.features.olap {
-        olap::execute_changes(project, &plan.changes.olap_changes).await?;
-    }
-    // Only execute streaming changes if streaming engine is enabled
-    if project.features.streaming_engine {
-        stream::execute_changes(project, &plan.changes.streaming_engine_changes).await?;
+    // Check if infrastructure execution is bypassed
+    if settings.should_bypass_infrastructure_execution() {
+        log::info!("Bypassing OLAP and streaming infrastructure execution (bypass_infrastructure_execution is enabled)");
+    } else {
+        // Only execute OLAP changes if OLAP is enabled and not bypassed
+        if project.features.olap {
+            olap::execute_changes(project, &plan.changes.olap_changes).await?;
+        }
+        // Only execute streaming changes if streaming engine is enabled and not bypassed
+        if project.features.streaming_engine {
+            stream::execute_changes(project, &plan.changes.streaming_engine_changes).await?;
+        }
     }
 
     // In prod, the webserver is part of the current process that gets spawned. As such
@@ -170,15 +175,21 @@ pub async fn execute_online_change(
     sync_processes_registry: &mut SyncingProcessesRegistry,
     process_registries: &mut ProcessRegistries,
     metrics: Arc<Metrics>,
+    settings: &Settings,
 ) -> Result<(), ExecutionError> {
     // This probably can be parallelized through Tokio Spawn
-    // Only execute OLAP changes if OLAP is enabled
-    if project.features.olap {
-        olap::execute_changes(project, &plan.changes.olap_changes).await?;
-    }
-    // Only execute streaming changes if streaming engine is enabled
-    if project.features.streaming_engine {
-        stream::execute_changes(project, &plan.changes.streaming_engine_changes).await?;
+    // Check if infrastructure execution is bypassed
+    if settings.should_bypass_infrastructure_execution() {
+        log::info!("Bypassing OLAP and streaming infrastructure execution (bypass_infrastructure_execution is enabled)");
+    } else {
+        // Only execute OLAP changes if OLAP is enabled and not bypassed
+        if project.features.olap {
+            olap::execute_changes(project, &plan.changes.olap_changes).await?;
+        }
+        // Only execute streaming changes if streaming engine is enabled and not bypassed
+        if project.features.streaming_engine {
+            stream::execute_changes(project, &plan.changes.streaming_engine_changes).await?;
+        }
     }
 
     // In prod, the webserver is part of the current process that gets spawned. As such


### PR DESCRIPTION
This pull request introduces a new development setting that allows bypassing the execution of infrastructure changes (OLAP and streaming) in the CLI, enabling users to plan changes without actually applying them. To support this, the `Settings` and related structures are updated to be `Clone`, and the new setting is threaded through the relevant routines and execution logic.

**Development settings and configuration:**

* Added a new `bypass_infrastructure_execution` field to the `DevSettings` struct, allowing infrastructure execution to be skipped for OLAP and streaming changes via configuration or environment variable (`MOOSE_DEV__BYPASS_INFRASTRUCTURE_EXECUTION`).
* Implemented the `should_bypass_infrastructure_execution` method on the `Settings` struct to check this new setting.
* Updated `MetricLabels`, `Telemetry`, `Settings`, and `DevSettings` structs to derive `Clone` so that settings can be passed and cloned as needed. [[1]](diffhunk://#diff-d6b6a46228582b2408f743d2673ddffd8894a4d3ce97819769f784b637ad14b8L46-R46) [[2]](diffhunk://#diff-d6b6a46228582b2408f743d2673ddffd8894a4d3ce97819769f784b637ad14b8L55-R55) [[3]](diffhunk://#diff-d6b6a46228582b2408f743d2673ddffd8894a4d3ce97819769f784b637ad14b8L105-R105) [[4]](diffhunk://#diff-d6b6a46228582b2408f743d2673ddffd8894a4d3ce97819769f784b637ad14b8L129-R129)

**Execution logic changes:**

* Modified the infrastructure execution routines (`execute_initial_infra_change` and `execute_online_change`) to check the new setting and skip OLAP/streaming execution when enabled, logging a message when bypassed. [[1]](diffhunk://#diff-c71fb825d6d58be7265cd922a8f0bc182bff6e71f507ac6ce4c3398ec58d2b10L92-R104) [[2]](diffhunk://#diff-c71fb825d6d58be7265cd922a8f0bc182bff6e71f507ac6ce4c3398ec58d2b10R178-R193)

**Threading settings through routines:**

* Updated the CLI routines and watcher logic to accept and pass the cloned `Settings` struct, ensuring the new bypass option is available where needed. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fR389) [[2]](diffhunk://#diff-ee3107cf026aa45aece42e299972e255086381edae1c62bbdac46f4d08cb8ce4R33) [[3]](diffhunk://#diff-ee3107cf026aa45aece42e299972e255086381edae1c62bbdac46f4d08cb8ce4R118-R119) [[4]](diffhunk://#diff-ee3107cf026aa45aece42e299972e255086381edae1c62bbdac46f4d08cb8ce4R128) [[5]](diffhunk://#diff-ee3107cf026aa45aece42e299972e255086381edae1c62bbdac46f4d08cb8ce4R184) [[6]](diffhunk://#diff-ee3107cf026aa45aece42e299972e255086381edae1c62bbdac46f4d08cb8ce4R278) [[7]](diffhunk://#diff-ee3107cf026aa45aece42e299972e255086381edae1c62bbdac46f4d08cb8ce4R299)