### PR TITLE
Nicolas/eng 611 planning functionality not working properly with different

### DIFF
--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -74,7 +74,7 @@ pub enum PlanningError {
 ///
 /// # Returns
 /// * `Result<InfrastructureMap, PlanningError>` - The reconciled infrastructure map or an error
-async fn reconcile_with_reality<T: OlapOperations>(
+pub async fn reconcile_with_reality<T: OlapOperations>(
     project: &Project,
     current_infra_map: &InfrastructureMap,
     target_table_names: &HashSet<String>,


### PR DESCRIPTION
This pull request introduces a new `/admin/inframap` endpoint to the local webserver, enabling clients to retrieve the server's current infrastructure map (in both JSON and protobuf formats) reconciled with the actual database state. The CLI's remote plan logic is updated to use this new endpoint when available, performing the diff locally for improved accuracy and flexibility, while falling back to the legacy `/admin/plan` endpoint if necessary. The changes also include improved error handling, new test coverage, and various refactorings for clarity and maintainability.

**New Admin Inframap Endpoint:**

- Added the `admin_inframap_route` handler and supporting types to `local_webserver.rs`, providing a new `/admin/inframap` endpoint that returns the reconciled infrastructure map in either JSON or protobuf depending on the `Accept` header. This endpoint ensures that the returned map reflects the true current state, not just what's stored in Redis. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1156-R1169) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR2155-R2222) [[3]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR2321-R2393)

- Implemented the `get_admin_reconciled_inframap` helper, which combines Redis state and a reality check (including unmapped tables) to produce the most accurate infrastructure map for admin endpoints.

**CLI Remote Plan Improvements:**

- Updated the CLI's `remote_plan` routine to first attempt retrieving the infrastructure map from the new `/admin/inframap` endpoint (using protobuf for efficiency, with JSON fallback), then calculate the diff locally. If the new endpoint is unavailable, it falls back to the legacy `/admin/plan` endpoint. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL506-R641) [[2]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL617-R817)

- Added robust error handling for the new endpoint, including custom error types for endpoint absence, authentication failure, network issues, and parse errors.

- Refactored and clarified authentication logic for remote operations, with clear documentation of precedence and best practices.

**Testing and Refactoring:**

- Added a test for the new `InfraMapResponse` structure to ensure correct JSON serialization and deserialization.

- Exposed the `reconcile_with_reality` function publicly to support the new endpoint's implementation.

**Legacy Support:**

- Extracted legacy remote plan logic into a dedicated function for clarity and maintainability, invoked only when the new endpoint is not available. [[1]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL506-R641) [[2]](diffhunk://#diff-98a40f984655c2a7cb4ffee8fe2e9e14420b623ffbb1257bd355621f0537d17fL617-R817)

These changes make the remote plan process more robust, accurate, and future-proof, while maintaining backward compatibility for older servers.