### PR TITLE
chore: remove sentry from the release process

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -569,17 +569,6 @@ jobs:
         shell: bash
         run: ./apps/create-moose-app/scripts/release.sh ${{ needs.version.outputs.version }}
 
-      # TODO - convert to use 1password for the secret
-      - name: Notify Sentry release
-        uses: getsentry/action-release@v1
-        if: ${{ !inputs.dry-run }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ steps.op-load-secret.outputs.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ steps.op-load-secret.outputs.SENTRY_ORG }}
-          SENTRY_PROJECT: "framework-cli"
-        with:
-          environment: production
-          version: ${{ needs.version.outputs.version }}
 
   build-and-publish-fullstack-image:
     name: Moose Production images


### PR DESCRIPTION
This pull request makes a small change to the release workflow by removing the Sentry release notification step from the `.github/workflows/release-cli.yaml` file. This step previously notified Sentry of new releases but is now omitted, possibly in preparation for an updated approach to secret management or notification.

- Removed the "Notify Sentry release" step from the CLI release workflow, which previously used the `getsentry/action-release` GitHub Action and environment variables loaded from 1Password secrets.