### PR TITLE
prevent putting identifiers in sql interpolator

### DIFF
--- a/packages/ts-moose-lib/src/dataModels/dataModelTypes.ts
+++ b/packages/ts-moose-lib/src/dataModels/dataModelTypes.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { IdentifierBrandedString } from "../sqlHelpers";
 
 export type EnumValues =
   | { name: string; value: { Int: number } }[]
@@ -17,7 +18,7 @@ export type DataType =
   | MapType
   | { nullable: DataType };
 export interface Column {
-  name: string;
+  name: IdentifierBrandedString;
   data_type: DataType;
   required: boolean;
   unique: false; // what is this for?

--- a/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
@@ -11,6 +11,7 @@ import { Readable } from "node:stream";
 import { createHash } from "node:crypto";
 import type { ConfigurationRegistry } from "../../config/runtime";
 import { LifeCycle } from "./lifeCycle";
+import { IdentifierBrandedString } from "../../sqlHelpers";
 
 /**
  * Represents a failed record during insertion with error details
@@ -127,6 +128,8 @@ export type OlapConfig<T> = {
  * @template T The data type of the records stored in the table. The structure of T defines the table schema.
  */
 export class OlapTable<T> extends TypedBase<T, OlapConfig<T>> {
+  name: IdentifierBrandedString;
+
   /** @internal */
   public readonly kind = "OlapTable";
 
@@ -161,6 +164,7 @@ export class OlapTable<T> extends TypedBase<T, OlapConfig<T>> {
     validators?: TypiaValidators<T>,
   ) {
     super(name, config ?? {}, schema, columns, validators);
+    this.name = name;
 
     const tables = getMooseInternal().tables;
     if (tables.has(name)) {

--- a/packages/ts-moose-lib/src/sqlHelpers.ts
+++ b/packages/ts-moose-lib/src/sqlHelpers.ts
@@ -10,10 +10,22 @@ const isTable = (
   typeof value === "object" &&
   Object.getPrototypeOf(value).constructor.name === "OlapTable";
 
+export type IdentifierBrandedString = string & {
+  readonly __identifier_brand?: unique symbol;
+};
+export type NonIdentifierBrandedString = string & {
+  readonly __identifier_brand?: unique symbol;
+};
+
 /**
  * Values supported by SQL engine.
  */
-export type Value = string | number | boolean | Date | [string, string];
+export type Value =
+  | NonIdentifierBrandedString
+  | number
+  | boolean
+  | Date
+  | [string, string];
 
 /**
  * Supported value or SQL instance.


### PR DESCRIPTION
```
    error TS2345: Argument of type 'IdentifierBrandedString' is not assignable to parameter of type 'Column | RawValue | OlapTable<any>'.
      Type 'IdentifierBrandedString' is not assignable to type 'NonIdentifierBrandedString'.
        Type 'IdentifierBrandedString' is not assignable to type '{ readonly __identifier_brand?: unique symbol | undefined; }'.
          Types of property '__identifier_brand' are incompatible.
            Type 'typeof __identifier_brand | undefined' is not assignable to type 'typeof __identifier_brand | undefined'. Two different types with this name exist, but they are unrelated.
              Type 'typeof __identifier_brand' is not assignable to type 'typeof __identifier_brand'. Two different types with this name exist, but they are unrelated.
```