### PR TITLE
fix: quick fix on LAST_KEY_PREFIX permission issue

### DIFF
--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -1868,9 +1868,14 @@ impl InfrastructureMap {
         let encoded = redis_client
             .get_with_explicit_prefix(last_prefix, "infrastructure_map")
             .await
-            .context("Failed to get InfrastructureMap from Redis using LAST_KEY_PREFIX")?;
+            .context("Failed to get InfrastructureMap from Redis using LAST_KEY_PREFIX");
 
-        if let Some(encoded) = encoded {
+        if let Err(e) = encoded {
+            log::error!("{}", e);
+            return Ok(None);
+        }
+
+        if let Ok(Some(encoded)) = encoded {
             let decoded = InfrastructureMap::from_proto(encoded).map_err(|e| {
                 anyhow::anyhow!("Failed to decode InfrastructureMap from proto: {}", e)
             })?;


### PR DESCRIPTION
This pull request updates error handling when retrieving the `InfrastructureMap` from Redis. Instead of propagating the error, it now logs the error and returns `Ok(None)` if the Redis call fails, making the function more robust to Redis failures.

Error handling improvements:

* Changed the retrieval of the `InfrastructureMap` from Redis to log errors and return `Ok(None)` instead of propagating errors, improving resilience to Redis issues.