### PR TITLE
fix: add python dependency for running the end to end tests

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -21,6 +21,10 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     unzip \
     iptables \
+    python3.12 \
+    python3.12-venv \
+    python3.12-dev \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch to iptables-legacy


### PR DESCRIPTION
This pull request updates the Docker build environment by adding support for Python 3.12 and related development tools. This change ensures that the container can run Python 3.12 applications and manage Python packages more effectively.

Python environment setup:

* Added installation of `python3.12`, `python3.12-venv`, and `python3.12-dev` to provide the latest Python runtime and development headers. (.cursor/Dockerfile)
* Added `python3-pip` to enable Python package management within the container. (.cursor/Dockerfile)