### PR TITLE
Fix stream creation error with streaming engine disabled

### DIFF
--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2085,7 +2085,23 @@ impl InfrastructureMap {
         } else {
             load_main_py(project, &project.project_location).await?
         };
-        Ok(partial.into_infra_map(project.language, &project.main_file()))
+        let infra_map = partial.into_infra_map(project.language, &project.main_file());
+
+        // Provide explicit feedback when streams are defined but streaming engine is disabled
+        if !project.features.streaming_engine && !infra_map.topics.is_empty() {
+            show_message_wrapper(
+                MessageType::Error,
+                Message {
+                    action: "Disabled".to_string(),
+                    details: format!(
+                        "Streaming is disabled but {} stream(s) found. Enable it by setting [features].streaming_engine = true in moose.config.toml",
+                        infra_map.topics.len()
+                    ),
+                },
+            );
+        }
+
+        Ok(infra_map)
     }
 
     /// Gets a topic by its ID


### PR DESCRIPTION
Add an error message when streams are defined in user code but the `streaming_engine` feature is disabled.

This provides explicit feedback to the user, as previously no message was shown when attempting to define streams with the feature flag set to `false`.

---
Linear Issue: [ENG-891](https://linear.app/514/issue/ENG-891/when-you-try-and-create-a-stream-with-the-streaming-engine-module)

<a href="https://cursor.com/background-agent?bcId=bc-31702335-31b2-4c10-8a47-f7e5f3e3f5b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31702335-31b2-4c10-8a47-f7e5f3e3f5b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an explicit error message if `topics` are detected while `[features].streaming_engine = false`, guiding users to enable it in `moose.config.toml`.
> 
> - **Infrastructure map loading (`apps/framework-cli/src/framework/core/infrastructure_map.rs`)**:
>   - Detects streams (`infra_map.topics`) after building the map and, if `[features].streaming_engine` is disabled, shows an error with the stream count and enablement instruction.
>   - Refactors return to store `infra_map` before returning to support the check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdf11b6351260d85bf6bcac1af63b6e649743d67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->