### PR TITLE
Updated doc: changed OlapConfigTable to OlapConfig and how it is used

### DIFF
--- a/apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx
+++ b/apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx
@@ -71,7 +71,7 @@ const explicitTable = new OlapTable<UserData>("users", {
 
 <Python>
 ```py filename="FullyManagedExample.py" copy
-from moose_lib import OlapTable, OlapTableConfig, LifeCycle
+from moose_lib import OlapTable, OlapConfig, LifeCycle
 from pydantic import BaseModel
 
 class UserData(BaseModel):
@@ -83,7 +83,7 @@ class UserData(BaseModel):
 user_table = OlapTable[UserData]("users")
 
 # Explicit fully managed configuration
-explicit_table = OlapTable[UserData]("users", OlapTableConfig(
+explicit_table = OlapTable[UserData]("users", OlapConfig(
     order_by_fields=["id"],
     life_cycle=LifeCycle.FULLY_MANAGED
 ))

--- a/apps/framework-docs/src/pages/moose/olap/model-table.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-table.mdx
@@ -369,10 +369,10 @@ const tableWithOrderByFieldsOnly = new OlapTable<SchemaWithoutPrimaryKey>("table
 </TypeScript>
 
 <Python>
-Leverage the `OlapTableConfig` class to configure your table:
+Leverage the `OlapConfig` class to configure your table:
 
 ```py filename="OrderByFieldsOnly.py" copy
-from moose_lib import Key, OlapTable, OlapTableConfig
+from moose_lib import Key, OlapTable, OlapConfig
 from pydantic import BaseModel
 from datetime import datetime
 
@@ -381,8 +381,8 @@ class SchemaWithoutPrimaryKey(BaseModel):
     field2: int
     field3: datetime
 
-table2 = OlapTable[SchemaWithoutPrimaryKey]("table2", OlapTableConfig(
-  orderByFields=["field1", "field2"] # Specify ordering without primary key
+table2 = OlapTable[SchemaWithoutPrimaryKey]("table2", OlapConfig(
+  order_by_fields=["field1", "field2"] # Specify ordering without primary key
 ))
 ```
 </Python>
@@ -406,7 +406,7 @@ const tableWithKeyAndOrderByFields = new OlapTable<SchemaWithKey>("table3", {
 
 <Python>
 ```py filename="ComboKeyAndOrderByFields.py" copy
-from moose_lib import Key, OlapTable, OlapTableConfig
+from moose_lib import Key, OlapTable, OlapConfig
 from pydantic import BaseModel
 
 class SchemaWithKey(BaseModel):
@@ -414,8 +414,8 @@ class SchemaWithKey(BaseModel):
     field1: str
     field2: int
 
-table3 = OlapTable[SchemaWithKey]("table3", OlapTableConfig(
-  orderByFields=["id", "field1"] # Primary key must be first
+table3 = OlapTable[SchemaWithKey]("table3", OlapConfig(
+  order_by_fields=["id", "field1"] # Primary key must be first
 ))
 ```
 </Python>
@@ -438,7 +438,7 @@ const multiKeyTable = new OlapTable<MultiKeyRecord>("multi_key_table", {
 
 <Python>
 ```py filename="MultiKeyTable.py" copy
-from moose_lib import Key, OlapTable, OlapTableConfig
+from moose_lib import Key, OlapTable, OlapConfig
 from pydantic import BaseModel
 
 class MultiKeyRecord(BaseModel):
@@ -446,8 +446,8 @@ class MultiKeyRecord(BaseModel):
     key2: Key[int]
     field1: str
 
-multi_key_table = OlapTable[MultiKeyRecord]("multi_key_table", OlapTableConfig(
-  orderByFields=["key1", "key2", "field1"] # Multiple keys must come first
+multi_key_table = OlapTable[MultiKeyRecord]("multi_key_table", OlapConfig(
+  order_by_fields=["key1", "key2", "field1"] # Multiple keys must come first
 ))
 ```
 </Python>
@@ -704,7 +704,7 @@ const badTable3 = new OlapTable<BadRecord3>("bad_table3", {
 
 <Python>
 ```py filename="InvalidConfig.py" copy
-from moose_lib import Key, OlapTable, OlapTableConfig
+from moose_lib import Key, OlapTable, OlapConfig
 from typing import Optional
 
 class BadRecord1(BaseModel):
@@ -717,8 +717,8 @@ class BadRecord2(BaseModel):
     id: Key[str]
     field1: str
 
-bad_table2 = OlapTable[BadRecord2]("bad_table2", OlapTableConfig(
-  orderByFields=["field1", "id"] # Wrong order - primary key must be first
+bad_table2 = OlapTable[BadRecord2]("bad_table2", OlapConfig(
+  order_by_fields=["field1", "id"] # Wrong order - primary key must be first
 ))
 
 class BadRecord3(BaseModel):
@@ -726,8 +726,8 @@ class BadRecord3(BaseModel):
     field1: str
     field2: Optional[int]
 
-bad_table3 = OlapTable[BadRecord3]("bad_table3", OlapTableConfig(
-  orderByFields=["id", "field2"] # Can't have nullable field in orderByFields
+bad_table3 = OlapTable[BadRecord3]("bad_table3", OlapConfig(
+  order_by_fields=["id", "field2"] # Can't have nullable field in orderByFields
 ))
 ```
 </Python>


### PR DESCRIPTION
This pull request updates the Moose documentation to reflect a change in the Python API for configuring OLAP tables. Specifically, it replaces usage of the `OlapTableConfig` class with the new `OlapConfig` class and updates parameter naming conventions for consistency. These changes ensure that the documentation matches the latest version of the Moose library and clarifies the configuration syntax for users.

**API migration and documentation updates:**

* Replaced all instances of `OlapTableConfig` with `OlapConfig` in Python code examples across `lifecycle.mdx` and `model-table.mdx` to match the updated Moose library API. [[1]](diffhunk://#diff-1aea604dbf4a5aa6a065b336351551ba3f582e24f52f385ecea0d5635761499dL74-R74) [[2]](diffhunk://#diff-1aea604dbf4a5aa6a065b336351551ba3f582e24f52f385ecea0d5635761499dL86-R86) [[3]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L372-R375) [[4]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L384-R385) [[5]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L409-R418) [[6]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L441-R450) [[7]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L707-R707) [[8]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L720-R730)
* Updated parameter names from `orderByFields` to `order_by_fields` for consistency with Python naming conventions in all relevant examples. [[1]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L384-R385) [[2]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L409-R418) [[3]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L441-R450) [[4]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L720-R730)

These changes ensure that users referencing the documentation will use the correct and current API when configuring OLAP tables in Moose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Moose docs to replace OlapTableConfig with OlapConfig in Python examples and rename orderByFields to order_by_fields.
> 
> - **Documentation (Python examples)**:
>   - **Lifecycle** (`apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx`):
>     - Replace `OlapTableConfig` with `OlapConfig` and update imports.
>     - Keep config semantics; use `order_by_fields` and `life_cycle`.
>   - **Modeling Tables** (`apps/framework-docs/src/pages/moose/olap/model-table.mdx`):
>     - Replace `OlapTableConfig` with `OlapConfig` across examples (order-by only, combo key/order, multi-key, invalid configs, engines, S3Queue, externally managed).
>     - Rename parameters from `orderByFields` to `order_by_fields`; adjust related text accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61c58275bc078a6bce7f68cd698c2dded895d44f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->