### PR TITLE
fix clickhouse keeper lib volume leak

### DIFF
--- a/apps/framework-cli/src/utilities/docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/docker-compose.yml.hbs
@@ -7,6 +7,7 @@ volumes:
   clickhouse-0-logs: null
   clickhouse-0-users: null
   clickhouse-keeper-data: null
+  clickhouse-keeper-lib: null
   {{/if}}
   redis-data:
   {{#if scripts_feature}}
@@ -68,6 +69,7 @@ services:
     image: docker.io/clickhouse/clickhouse-keeper:${CLICKHOUSE_VERSION:-25.6}
     volumes:
       - clickhouse-keeper-data:/var/lib/clickhouse-keeper
+      - clickhouse-keeper-lib:/var/lib/clickhouse
     environment:
       - KEEPER_SERVER_ID=1
     expose:

--- a/apps/framework-cli/src/utilities/prod-docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/prod-docker-compose.yml.hbs
@@ -7,6 +7,7 @@ volumes:
   clickhouse-0-logs: null
   clickhouse-0-users: null
   clickhouse-keeper-data: null
+  clickhouse-keeper-lib: null
 {{/if}}
   redis-data: null
 {{#if scripts_feature}}
@@ -79,6 +80,7 @@ services:
     image: docker.io/clickhouse/clickhouse-keeper:${CLICKHOUSE_VERSION:-25.6}
     volumes:
       - clickhouse-keeper-data:/var/lib/clickhouse-keeper
+      - clickhouse-keeper-lib:/var/lib/clickhouse
     environment:
       - KEEPER_SERVER_ID=1
     ports:


### PR DESCRIPTION
It was creating an anonymous volume on every moose dev & accumulating.

From the image:

```
docker image inspect clickhouse/clickhouse-keeper:25.6 | jq '.[0].Config.Volumes'
{
  "/var/lib/clickhouse": {},
  "/var/lib/clickhouse-keeper": {}
}
```

This makes it follow the naming convention as other moose volumes & re-use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `clickhouse-keeper-lib` named volume and mount it to `/var/lib/clickhouse` for `clickhouse-keeper` in both dev and prod compose templates.
> 
> - **Storage (ClickHouse Keeper)**:
>   - Define `clickhouse-keeper-lib` volume in `apps/framework-cli/src/utilities/docker-compose.yml.hbs` and `apps/framework-cli/src/utilities/prod-docker-compose.yml.hbs`.
>   - Mount `clickhouse-keeper-lib` to `clickhouse-keeper` at `/var/lib/clickhouse` to avoid anonymous volume creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e91e70f520aefc629cfb1715871aee5cc47d540. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->