### PR TITLE
put workflow routes behind flag

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -1632,10 +1632,10 @@ async fn router(
             )
             .await
         }
-        (_, &hyper::Method::GET, ["workflows", "history"]) => {
+        (_, &hyper::Method::GET, ["workflows", "history"]) if project.features.workflows => {
             workflows_history_route(req, is_prod, project.clone()).await
         }
-        (_, &hyper::Method::POST, ["workflows", name, "trigger"]) => {
+        (_, &hyper::Method::POST, ["workflows", name, "trigger"]) if project.features.workflows => {
             workflows_trigger_route(
                 req,
                 is_prod,
@@ -1645,7 +1645,9 @@ async fn router(
             )
             .await
         }
-        (_, &hyper::Method::POST, ["workflows", name, "terminate"]) => {
+        (_, &hyper::Method::POST, ["workflows", name, "terminate"])
+            if project.features.workflows =>
+        {
             workflows_terminate_route(req, is_prod, project.clone(), name.to_string()).await
         }
         (_, &hyper::Method::OPTIONS, _) => options_route(),
@@ -1830,22 +1832,28 @@ async fn print_available_routes(
             "/ready".to_string(),
             "Readiness check endpoint".to_string(),
         ),
-        (
-            "GET",
-            "/workflows/history".to_string(),
-            "Workflow history".to_string(),
-        ),
-        (
-            "POST",
-            "/workflows/name/trigger".to_string(),
-            "Trigger a workflow".to_string(),
-        ),
-        (
-            "POST",
-            "/workflows/name/terminate".to_string(),
-            "Terminate a workflow".to_string(),
-        ),
     ];
+
+    // Collect workflow routes
+    if project.features.workflows {
+        static_routes.extend_from_slice(&[
+            (
+                "GET",
+                "/workflows/history".to_string(),
+                "Workflow history".to_string(),
+            ),
+            (
+                "POST",
+                "/workflows/name/trigger".to_string(),
+                "Trigger a workflow".to_string(),
+            ),
+            (
+                "POST",
+                "/workflows/name/terminate".to_string(),
+                "Terminate a workflow".to_string(),
+            ),
+        ]);
+    }
 
     // Collect ingestion routes
     let mut ingest_routes = Vec::new();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Gates workflow endpoints and their route listings behind `project.features.workflows`.
> 
> - **Server (local_webserver.rs)**:
>   - **Routing**: Only register `GET /workflows/history`, `POST /workflows/:name/trigger`, and `POST /workflows/:name/terminate` when `project.features.workflows` is enabled.
>   - **Route Listing**: Display workflow routes in `print_available_routes` only if `project.features.workflows` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7cd3acaec66f3bdd7ad73a07ecac2e47153f6a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->