### PR TITLE
api worker count config

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -222,6 +222,11 @@ pub struct LocalWebserverConfig {
     /// Script to run once when the dev server first starts (never repeats in this process)
     #[serde(default, alias = "post_dev_server_start_script")]
     pub on_first_start_script: Option<String>,
+    /// Number of workers for consumption API cluster (TypeScript only)
+    /// None = auto-calculated (70% of CPU cores for TypeScript, 1 for Python)
+    /// Python always uses 1 worker regardless of this setting
+    #[serde(default)]
+    pub api_workers: Option<usize>,
 }
 
 pub fn default_proxy_port() -> u16 {
@@ -382,6 +387,7 @@ impl Default for LocalWebserverConfig {
             max_request_body_size: default_max_request_body_size(),
             on_reload_complete_script: None,
             on_first_start_script: None,
+            api_workers: None,
         }
     }
 }

--- a/apps/framework-cli/src/framework/typescript/consumption.rs
+++ b/apps/framework-cli/src/framework/typescript/consumption.rs
@@ -84,6 +84,11 @@ pub fn run(
         string_args.push(port.to_string());
     }
 
+    if let Some(worker_count) = project.http_server_config.api_workers {
+        string_args.push("--worker-count".to_string());
+        string_args.push(worker_count.to_string());
+    }
+
     let args: Vec<&str> = string_args.iter().map(|s| s.as_str()).collect();
     let mut consumption_process = bin::run(CONSUMPTION_RUNNER_BIN, project_path, &args, project)?;
 

--- a/apps/framework-docs/src/pages/moose/configuration.mdx
+++ b/apps/framework-docs/src/pages/moose/configuration.mdx
@@ -71,6 +71,9 @@ port = 4000
 management_port = 5001
 # Optional path prefix for all routes (Default: None)
 # path_prefix = "api"
+# Number of worker processes for consumption API cluster (TypeScript only) (Default: Auto-calculated - 70% of CPU cores)
+# Python projects always use 1 worker regardless of this setting
+# api_workers = 2
 
 # Redis configuration
 [redis_config]

--- a/packages/ts-moose-lib/src/consumption-apis/runner.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/runner.ts
@@ -40,6 +40,7 @@ interface ApisConfig {
   enforceAuth: boolean;
   isDmv2: boolean;
   proxyPort?: number;
+  workerCount?: number;
 }
 
 // Convert our config to Clickhouse client config
@@ -253,6 +254,8 @@ const apiHandler = async (
 
 export const runApis = async (config: ApisConfig) => {
   const apisCluster = new Cluster({
+    maxWorkerCount:
+      (config.workerCount ?? 0) > 0 ? config.workerCount : undefined,
     workerStart: async () => {
       let temporalClient: TemporalClient | undefined;
       if (config.temporalConfig) {

--- a/packages/ts-moose-lib/src/moose-runner.ts
+++ b/packages/ts-moose-lib/src/moose-runner.ts
@@ -135,6 +135,11 @@ program
   .option("--api-key <key>", "API key for authentication")
   .option("--is-dmv2", "Whether this is a DMv2 consumption", false)
   .option("--proxy-port <port>", "Port to run the proxy server on", parseInt)
+  .option(
+    "--worker-count <count>",
+    "Number of worker processes for the consumption API cluster",
+    parseInt,
+  )
   .action(
     (
       apisDir,
@@ -170,6 +175,7 @@ program
         enforceAuth: options.enforceAuth,
         isDmv2: options.isDmv2,
         proxyPort: options.proxyPort,
+        workerCount: options.workerCount,
       });
     },
   );

--- a/packages/ts-moose-lib/tests/cluster-utils.test.ts
+++ b/packages/ts-moose-lib/tests/cluster-utils.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import { Cluster } from "../src/cluster-utils";
+import { availableParallelism } from "node:os";
+
+describe("Cluster", () => {
+  describe("computeCPUUsageCount", () => {
+    it("should cap workers at maxWorkerCount even when ratio would give more", () => {
+      const cluster = new Cluster({
+        workerStart: async () => ({}),
+        workerStop: async () => {},
+      });
+
+      const cpuCount = availableParallelism();
+      const maxWorkers = 2;
+      const ratio = 0.7; // Would give Math.floor(cpuCount * 0.7) workers
+
+      const result = cluster.computeCPUUsageCount(ratio, maxWorkers);
+
+      // Should be capped at maxWorkers, not the ratio-calculated value
+      expect(result).to.equal(
+        Math.min(maxWorkers, Math.max(1, Math.floor(cpuCount * ratio))),
+      );
+    });
+
+    it("should ensure minimum of 1 worker even with low ratio", () => {
+      const cluster = new Cluster({
+        workerStart: async () => ({}),
+        workerStop: async () => {},
+      });
+
+      // Very low ratio on even 1-core machine should still give 1 worker
+      const result = cluster.computeCPUUsageCount(0.01, undefined);
+      expect(result).to.equal(1);
+    });
+
+    it("should treat zero maxWorkerCount as undefined due to falsy check", () => {
+      const cluster = new Cluster({
+        workerStart: async () => ({}),
+        workerStop: async () => {},
+      });
+
+      const cpuCount = availableParallelism();
+      // 0 is falsy, so `0 || cpuCount` returns cpuCount
+      const result = cluster.computeCPUUsageCount(0.7, 0);
+
+      expect(result).to.equal(Math.max(1, Math.floor(cpuCount * 0.7)));
+    });
+  });
+
+  describe("constructor validation", () => {
+    it("should reject maxCpuUsageRatio > 1", () => {
+      expect(() => {
+        new Cluster({
+          workerStart: async () => ({}),
+          workerStop: async () => {},
+          maxCpuUsageRatio: 1.5,
+        });
+      }).to.throw("maxCpuUsageRatio must be between 0 and 1");
+    });
+
+    it("should reject maxCpuUsageRatio < 0", () => {
+      expect(() => {
+        new Cluster({
+          workerStart: async () => ({}),
+          workerStop: async () => {},
+          maxCpuUsageRatio: -0.1,
+        });
+      }).to.throw("maxCpuUsageRatio must be between 0 and 1");
+    });
+
+    it("should accept maxCpuUsageRatio = 0", () => {
+      // Edge case: 0 is valid (though will always give 1 worker due to Math.max)
+      expect(() => {
+        new Cluster({
+          workerStart: async () => ({}),
+          workerStop: async () => {},
+          maxCpuUsageRatio: 0,
+        });
+      }).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `api_workers` config and `--worker-count` flag to control TS consumption API cluster size, wired from Rust CLI to TS runner/Cluster, with docs and tests.
> 
> - **Consumption APIs (TypeScript)**:
>   - Add `workerCount` support in `runner.ts`; pass to `Cluster` as `maxWorkerCount` (ignored when <= 0).
>   - CLI: add `--worker-count <count>` option in `moose-runner.ts` and propagate into `runApis` config.
>   - Tests: add `cluster-utils.test.ts` covering CPU usage calculation and `maxCpuUsageRatio` validation.
> - **CLI (Rust)**:
>   - Extend `LocalWebserverConfig` with `api_workers: Option<usize>`; default `None`.
>   - Forward to TS runner as `--worker-count` in `typescript/consumption.rs`.
> - **Docs**:
>   - Update `moose/configuration.mdx` to document `http_server_config.api_workers` and behavior (TypeScript only; Python fixed at 1).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aec1d9fe3d4e0917443963628edbe0957ca57875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->