### PR TITLE
fix #2847, url decode usernamd password before passing them to CH driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,6 +2881,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.29.0",
  "pbkdf2",
+ "percent-encoding",
  "petgraph 0.8.3",
  "posthog514client-rs",
  "predicates",

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -114,6 +114,7 @@ schema-registry-client = "0.4.1"
 
 keyring = { version = "3.6", features = ["apple-native", "linux-native"] }
 rmcp = { version = "0.8.1", features = ["server", "transport-streamable-http-server"] }
+percent-encoding = "2.3.2"
 
 [dev-dependencies]
 clickhouse = { version = "0.11.5", features = ["uuid", "test-util"] }

--- a/apps/framework-cli/src/cli/routines/code_generation.rs
+++ b/apps/framework-cli/src/cli/routines/code_generation.rs
@@ -116,10 +116,12 @@ pub async fn create_client_and_db(
         }
     };
     if !url_username.is_empty() {
-        client = client.with_user(url_username)
+        client = client
+            .with_user(percent_encoding::percent_decode_str(&url_username).decode_utf8_lossy())
     }
     if let Some(password) = url.password() {
-        client = client.with_password(password);
+        client = client
+            .with_password(percent_encoding::percent_decode_str(password).decode_utf8_lossy());
     }
 
     let url_db = url


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Percent-decodes URL-encoded username/password before configuring the ClickHouse client and adds the percent-encoding dependency.
> 
> - **CLI**:
>   - In `apps/framework-cli/src/cli/routines/code_generation.rs`, decode URL-encoded `user` and `password` before passing to `clickhouse::Client` via `with_user(...)` and `with_password(...)`.
> - **Dependencies**:
>   - Add `percent-encoding` to `apps/framework-cli/Cargo.toml` (and lockfile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4e6f04c8269cbcb47b7a1122d5a0b6f8bd9b2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->