### PR TITLE
handle TS types that do not have a declaration

### DIFF
--- a/packages/ts-moose-lib/src/dataModels/typeConvert.ts
+++ b/packages/ts-moose-lib/src/dataModels/typeConvert.ts
@@ -751,9 +751,9 @@ export const toColumns = (t: ts.Type, checker: TypeChecker): Column[] => {
   return checker.getPropertiesOfType(t).map((prop) => {
     let declarations = prop.getDeclarations();
     const node =
-      declarations !== undefined ?
-        (declarations[0] as ts.PropertyDeclaration)
-      : undefined;
+      declarations && declarations.length > 0
+        ? (declarations[0] as ts.PropertyDeclaration)
+        : undefined;
     const type =
       node !== undefined ?
         checker.getTypeOfSymbolAtLocation(prop, node)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `toColumns` robust when TS properties lack declarations by falling back to `checker.getTypeOfSymbol` and guarding wrapper/default detection with optional chaining.
> 
> - **packages/ts-moose-lib/src/dataModels/typeConvert.ts**:
>   - **`toColumns`**:
>     - Handle properties with no declarations by falling back to `checker.getTypeOfSymbol(prop)`.
>     - Use optional chaining on `node?.type` for `Key`/`JWT` wrapping and default handling.
>     - Pass `node?.type` to `tsTypeToDataType` to avoid crashes when declarations are absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfccacca69e6cc5486d5d3873582f9ede0ffcc77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->