### PR TITLE
Quickstart example

### DIFF
--- a/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
@@ -406,10 +406,12 @@ curl "http://localhost:4000/api/bar?limit=5&orderBy=totalRows"
 
 <TypeScript>
 ```ts filename="app/ingest/models.ts" {5} copy
-export interface Foo {
-  primaryKey: Key<string>; // Unique ID
-  timestamp: number; // Unix timestamp
-  optionalText?: string; // Text to analyze
+/** Analyzed text metrics derived from Foo */
+export interface Bar {
+  primaryKey: Key<string>; // From Foo.primaryKey
+  utcTimestamp: DateTime; // From Foo.timestamp
+  hasText: boolean; // From Foo.optionalText?
+  textLength: number; // From Foo.optionalText.length
   newField?: string; // Add this new optional field
 }
 ```
@@ -427,12 +429,13 @@ class Baz(StringToEnumMixin, IntEnum):
     QUUX = auto()
 
 
-class Foo(BaseModel):
+class Bar(BaseModel):
     primary_key: Key[str]
-    timestamp: float
+    utc_timestamp: datetime
     baz: Baz
-    optional_text: Optional[str] = None
-    new_field: Optional[str] = None
+    has_text: bool
+    text_length: int
+    new_field: Optional[str] = None # New field
 ```
 </Python>
 
@@ -443,7 +446,7 @@ You should see Moose automatically update your infrastructure:
 <TypeScript>
 ```txt
 ⠋ Processing Infrastructure changes from file watcher
-             ~  Table Foo:
+             ~  Table Bar:
                   Column changes:
                     + newField: String
 ```
@@ -452,7 +455,7 @@ You should see Moose automatically update your infrastructure:
 <Python>
 ```txt
 ⠋ Processing Infrastructure changes from file watcher
-             ~  Table Foo:
+             ~  Table Bar:
                   Column changes:
                     + new_field: String
 ```

--- a/apps/framework-docs/src/pages/moose/olap/_meta.tsx
+++ b/apps/framework-docs/src/pages/moose/olap/_meta.tsx
@@ -11,6 +11,9 @@ const rawMeta = {
   "model-materialized-view": {
     title: "Modeling Materialized Views",
   },
+  "model-view": {
+    title: "Modeling Views",
+  },
   "supported-types": {
     title: "Supported Types",
   },

--- a/apps/framework-docs/src/pages/moose/olap/model-view.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-view.mdx
@@ -1,0 +1,94 @@
+---
+title: Modeling Views
+description: Define standard ClickHouse Views for read-time projections
+---
+
+import { Callout, LanguageSwitcher, TypeScript, Python, PathConfig } from "@/components";
+
+# Modeling Views
+
+<LanguageSwitcher />
+
+## Overview
+Views are read-time projections in ClickHouse. A static `SELECT` defines the view over one or more base tables or other views. Moose wraps [ClickHouse `VIEW`](https://clickhouse.com/docs/en/sql-reference/statements/create/view) with a simple `View` class in <Python inline>Python</Python><TypeScript inline>TypeScript</TypeScript>. You provide the view name, the `SELECT`, and the list of source tables/views so Moose can order DDL correctly during migrations.
+
+<Callout type="info" title="When to use a View" compact>
+Use `View` when you want a virtual read-time projection and don’t need write-time transformation or a separate storage table. For write-time pipelines and backfills, use a Materialized View instead.
+</Callout>
+
+## Basic Usage
+
+<TypeScript>
+```ts filename="BasicUsage.ts" copy
+import { View, sql } from "@514labs/moose-lib";
+import { users } from "./Users";
+import { events } from "./Events";
+
+export const activeUserEvents = new View(
+  "active_user_events",
+  sql`
+    SELECT
+      ${events.columns.id}    AS event_id,
+      ${users.columns.id}     AS user_id,
+      ${users.columns.name}   AS user_name,
+      ${events.columns.ts}    AS ts
+    FROM ${events}
+    JOIN ${users} ON ${events.columns.user_id} = ${users.columns.id}
+    WHERE ${users.columns.active} = 1
+  `,
+  [events, users],
+);
+```
+</TypeScript>
+
+<Python>
+```python filename="BasicUsage.py" copy
+from moose_lib import View
+from tables import users, events
+
+active_user_events = View(
+    "active_user_events",
+    """
+    SELECT
+      {events.columns.id}    AS event_id,
+      {users.columns.id}     AS user_id,
+      {users.columns.name}   AS user_name,
+      {events.columns.ts}    AS ts
+    FROM {events}
+    JOIN {users} ON {events.columns.user_id} = {users.columns.id}
+    WHERE {users.columns.active} = 1
+    """,
+    [events, users],
+)
+```
+</Python>
+
+## Quick Reference
+
+<TypeScript>
+```ts filename="Signature.ts" copy
+// new View(name, selectStatement, baseTables)
+new View(
+  "view_name",
+  sql`SELECT ... FROM ${someTable}`,
+  [someTable, /* other tables or views */],
+);
+```
+</TypeScript>
+
+<Python>
+```python filename="Signature.py" copy
+# View(name: str, select_statement: str, base_tables: list[OlapTable | View])
+View(
+    "view_name",
+    "SELECT ... FROM {someTable}",
+    [someTable],
+)
+```
+</Python>
+
+<Callout type="info" title="Static SQL recommended" compact icon={PathConfig.fromClickhouse.icon} href="https://clickhouse.com/docs/en/sql-reference" ctaLabel="ClickHouse SQL">
+The `SELECT` should be static (no runtime parameters). In TypeScript, prefer Moose’s `sql` template for safe table/column interpolation; in Python, use string templates with `{table.columns.col}`.
+</Callout>
+
+

--- a/templates/typescript/app/views/barAggregated.ts
+++ b/templates/typescript/app/views/barAggregated.ts
@@ -1,5 +1,5 @@
 import typia from "typia";
-import { MaterializedView, sql } from "@514labs/moose-lib";
+import { MaterializedView, View, sql } from "@514labs/moose-lib";
 import { BarPipeline } from "../ingest/models";
 
 interface BarAggregated {


### PR DESCRIPTION
This pull request updates the Moose documentation and code samples to reflect a shift from the `Foo` model to a new `Bar` model, introduces documentation for modeling ClickHouse views, and makes supporting changes to metadata and code imports. The primary focus is on improving clarity and providing examples for the new model and view functionality.

**Model and Documentation Updates:**

* Replaced the `Foo` model with the new `Bar` model in both TypeScript (`app/ingest/models.ts`) and Python (`app/ingest/models.py`), updating field names and types to reflect analyzed text metrics and introducing an enum `Baz` in Python.
* Updated infrastructure change output examples in the quickstart docs to reference the new `Bar` table and its fields, replacing previous references to `Foo`. [[1]](diffhunk://#diff-804517bbb2ecd91cd4fc282aaa3dd57e0da90d67b0308764d980ae486b64227bL437-R449) [[2]](diffhunk://#diff-804517bbb2ecd91cd4fc282aaa3dd57e0da90d67b0308764d980ae486b64227bL446-R458)

**View Modeling Documentation:**

* Added a new documentation page `model-view.mdx` describing how to define and use ClickHouse views with Moose in both TypeScript and Python, including usage examples and best practices.

**Supporting Metadata and Imports:**

* Added metadata for the new "Modeling Views" documentation page to `_meta.tsx` to ensure proper navigation and titling.
* Updated TypeScript imports in `app/views/barAggregated.ts` to include the new `View` class from `@514labs/moose-lib`, supporting the expanded view modeling functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates quickstart to use `Bar` schema (replacing `Foo`), adds a new “Modeling Views” doc, updates navigation, and includes a minor TypeScript import tweak.
> 
> - **Docs**:
>   - **Quickstart**: Replace `Foo` with `Bar` model in `apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx`; update schema fields, Python enum `Baz`, and example infra outputs to reference `Table Bar` and `newField/new_field`.
>   - **OLAP**: Add `apps/framework-docs/src/pages/moose/olap/model-view.mdx` documenting `View` usage in TypeScript/Python (overview, basic usage, signature).
>   - **Navigation**: Add `"model-view"` entry to `apps/framework-docs/src/pages/moose/olap/_meta.tsx`.
> - **Templates**:
>   - TypeScript: Import `View` alongside `MaterializedView` in `templates/typescript/app/views/barAggregated.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15579076b6d216179a1fd40c31585903d96f0673. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->