### PR TITLE
uncomment OptionalNestedTest

### DIFF
--- a/apps/framework-cli-e2e/test/utils/schema-definitions.ts
+++ b/apps/framework-cli-e2e/test/utils/schema-definitions.ts
@@ -293,21 +293,20 @@ export const TYPESCRIPT_TEST_SCHEMAS: ExpectedTableSchema[] = [
       { name: "complexArray", type: /Nested\(.*\)/ },
     ],
   },
-  // TODO: Fix ClickHouseDefault usage - temporarily commented out to unblock array transform tests
-  // {
-  //   tableName: "OptionalNestedTest",
-  //   columns: [
-  //     { name: "id", type: "String" },
-  //     { name: "timestamp", type: /DateTime\('UTC'\)/ },
-  //     // Arrays of objects with optional fields - should become Nested type with nullable inner fields
-  //     {
-  //       name: "nested",
-  //       type: /Nested\(name Nullable\(String\), age Nullable\(Float64\)\)/,
-  //     },
-  //     // Field with ClickHouse default - should be String with default value, not nullable
-  //     { name: "other", type: "String", nullable: false },
-  //   ],
-  // },
+  {
+    tableName: "OptionalNestedTest",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      // Arrays of objects with optional fields - should become Nested type with nullable inner fields
+      {
+        name: "nested",
+        type: /Nested\(name Nullable\(String\), age Nullable\(Float64\)\)/,
+      },
+      // Field with ClickHouse default - should be String with default value, not nullable
+      { name: "other", type: "String", nullable: false },
+    ],
+  },
   // Geometry tables
   {
     tableName: "GeoTypes",
@@ -674,21 +673,20 @@ export const PYTHON_TEST_SCHEMAS: ExpectedTableSchema[] = [
       { name: "complex_array", type: /Nested\(.*\)/ },
     ],
   },
-  // TODO: Fix ClickHouseDefault usage - temporarily commented out to unblock array transform tests
-  // {
-  //   tableName: "OptionalNestedTest",
-  //   columns: [
-  //     { name: "id", type: "String" },
-  //     { name: "timestamp", type: /DateTime\('UTC'\)/ },
-  //     // Arrays of objects with optional fields - should become Nested type with nullable inner fields
-  //     {
-  //       name: "nested",
-  //       type: /Nested\(name Nullable\(String\), age Nullable\(Float64\)\)/,
-  //     },
-  //     // Field with ClickHouse default - should be String with default value, not nullable
-  //     { name: "other", type: "String", nullable: false },
-  //   ],
-  // },
+  {
+    tableName: "OptionalNestedTest",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      // Arrays of objects with optional fields - should become Nested type with nullable inner fields
+      {
+        name: "nested",
+        type: /Nested\(name Nullable\(String\), age Nullable\(Float64\)\)/,
+      },
+      // Field with ClickHouse default - should be String with default value, not nullable
+      { name: "other", type: "String", nullable: false },
+    ],
+  },
   // Geometry tables
   {
     tableName: "GeoTypes",

--- a/templates/typescript-tests/app/ingest/models.ts
+++ b/templates/typescript-tests/app/ingest/models.ts
@@ -277,26 +277,25 @@ export const EdgeCasesPipeline = new IngestPipeline<EdgeCases>("EdgeCases", {
 
 /** =======Optional Nested Fields with ClickHouse Defaults Test========= */
 
-// TODO: Fix ClickHouseDefault usage - temporarily commented out to unblock array transform tests
-// /** Test interface with optional nested fields and ClickHouse defaults */
-// export interface TestNested {
-//   name?: string;
-//   age?: number;
-// }
+/** Test interface with optional nested fields and ClickHouse defaults */
+export interface TestNested {
+  name?: string;
+  age?: number;
+}
 
-// export interface OptionalNestedTest {
-//   id: Key<string>;
-//   timestamp: DateTime;
-//   nested: TestNested[];
-//   other: string & ClickHouseDefault<"default_value">;
-// }
+export interface OptionalNestedTest {
+  id: Key<string>;
+  timestamp: DateTime;
+  nested: TestNested[];
+  other: string & ClickHouseDefault<"">;
+}
 
-// export const OptionalNestedTestPipeline =
-//   new IngestPipeline<OptionalNestedTest>("OptionalNestedTest", {
-//     table: true,
-//     stream: true,
-//     ingestApi: true,
-//   });
+export const OptionalNestedTestPipeline =
+  new IngestPipeline<OptionalNestedTest>("OptionalNestedTest", {
+    table: true,
+    stream: true,
+    ingestApi: true,
+  });
 
 /** =======Geometry Types========= */
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Re-enables OptionalNestedTest in e2e schemas and TypeScript test templates, adding models/pipeline and setting other’s ClickHouse default to an empty string.
> 
> - **Tests (e2e)**:
>   - Enable `OptionalNestedTest` in `apps/framework-cli-e2e/test/utils/schema-definitions.ts` for both TypeScript and Python schemas, expecting `nested` as `Nested(name Nullable(String), age Nullable(Float64))` and `other` as non-nullable `String`.
> - **TypeScript Templates**:
>   - Add `TestNested`, `OptionalNestedTest`, and `OptionalNestedTestPipeline` in `templates/typescript-tests/app/ingest/models.ts`, using `ClickHouseDefault<"">` for `other`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66351e6e5116111f294ede54dda26191166eca9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->