### PR TITLE
fix order by parsing when there's ttl

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
@@ -1546,7 +1546,7 @@ pub fn extract_order_by_from_create_query(create_query: &str) -> Vec<String> {
         let mut end_idx = after_order_by.len();
 
         // Check for TTL keyword (appears after ORDER BY but before SETTINGS)
-        if let Some(ttl_idx) = after_order_by.to_uppercase().find("TTL") {
+        if let Some(ttl_idx) = after_order_by.to_uppercase().find(" TTL ") {
             end_idx = std::cmp::min(end_idx, ttl_idx);
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update ORDER BY extraction to stop before TTL and add a test covering ORDER BY with TTL.
> 
> - **ClickHouse parsing**:
>   - `extract_order_by_from_create_query`: end detection now considers `TTL` (stops before `TTL` or `SETTINGS`).
>   - **Tests**: add case ensuring ORDER BY columns are parsed correctly when followed by `TTL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a923d4838ee6b765dcff6a352e21efddf693e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->