### PR TITLE
ENG-1111: moose-auth docs update

### DIFF
--- a/apps/framework-docs/src/pages/moose/apis/_meta.tsx
+++ b/apps/framework-docs/src/pages/moose/apis/_meta.tsx
@@ -1,6 +1,9 @@
 import { render } from "@/components";
 
 const rawMeta = {
+  auth: {
+    title: "Auth",
+  },
   "ingest-api": {
     title: "Ingest New Data",
   },
@@ -9,9 +12,6 @@ const rawMeta = {
   },
   "trigger-api": {
     title: "Trigger Workflows",
-  },
-  auth: {
-    title: "Securing API Endpoints",
   },
   __client__: {
     type: "separator",

--- a/apps/framework-docs/src/pages/moose/apis/auth.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/auth.mdx
@@ -7,25 +7,96 @@ import { Callout } from "@/components";
 
 # API Authentication & Security
 
-Secure your Moose deployment by configuring authentication for your API endpoints. Moose supports two authentication methods:
+Moose supports two authentication mechanisms for securing your API endpoints:
 
-- [JWT (JSON Web Tokens)](#jwt-authentication) - For integration with existing identity providers
-- [API Keys](#api-key-authentication) - For simple, static authentication
+- **[API Keys](#api-key-authentication)** - Simple, static authentication for internal applications and getting started
+- **[JWT (JSON Web Tokens)](#jwt-authentication)** - Token-based authentication for integration with existing identity providers
 
-## Getting Started
+Choose the method that fits your use case, or use both together with custom configuration.
 
-1. Choose your authentication method
-2. Generate tokens using `moose generate hash-token`
-3. Configure your authentication in `moose.config.toml` or with environment variables
-4. Send requests with `Authorization: Bearer <token>` header
+## Do you want to use API Keys?
 
-## Authentication Methods
+API keys are the simplest way to secure your Moose endpoints. They're ideal for:
+- Internal applications and microservices
+- Getting started quickly with authentication
+- Scenarios where you control both client and server
 
-### JWT Authentication
+### How API Keys Work
 
-Use JWT when you have an existing identity provider or want standard token-based authentication.
+API keys use PBKDF2 HMAC SHA256 hashing for secure storage. You generate a token pair (plain-text and hashed) using the Moose CLI, store the hashed version in environment variables, and send the plain-text version in your request headers.
 
-#### Configure in `moose.config.toml`
+### Step 1: Generate API Keys
+
+Generate tokens and hashed keys using the Moose CLI:
+
+```bash
+moose generate hash-token
+```
+
+**Output:**
+- **ENV API Keys**: Hashed key for environment variables (use this in your server configuration)
+- **Bearer Token**: Plain-text token for client applications (use this in `Authorization` headers)
+
+<Callout type="info">
+  Use the **hashed key** for environment variables and `moose.config.toml`. Use the **plain-text token** in your `Authorization: Bearer token` headers.
+</Callout>
+
+### Step 2: Configure API Keys with Environment Variables
+
+Set environment variables with the **hashed** API keys you generated:
+```bash
+# For ingest endpoints
+export MOOSE_INGEST_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
+
+# For analytics endpoints  
+export MOOSE_CONSUMPTION_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
+
+# For admin endpoints
+export MOOSE_ADMIN_TOKEN='your_plain_text_token'
+```
+
+Or set the admin API key in `moose.config.toml`:
+
+```toml filename="moose.config.toml"
+[authentication]
+admin_api_key = "your_pbkdf2_hmac_sha256_hashed_key"
+```
+
+<Callout type="info" title="Storing Admin API Keys in Project Configuration File">
+  Storing the `admin_api_key` (which is a PBKDF2 HMAC SHA256 hash) in your `moose.config.toml` file is an acceptable practice, even if the file is version-controlled. This is because the actual plain-text Bearer token (the secret) is not stored. The hash is computationally expensive to reverse, ensuring that your secret is not exposed in the codebase.
+</Callout>
+
+### Step 3: Make Authenticated Requests
+
+All authenticated requests require the `Authorization` header with the **plain-text token**:
+
+```bash
+# Using curl
+curl -H "Authorization: Bearer your_plain_text_token_here" \
+     https://your-moose-instance.com/ingest/YourDataModel
+
+# Using JavaScript
+fetch('https://your-moose-instance.com/api/endpoint', {
+  headers: {
+    'Authorization': 'Bearer your_plain_text_token_here'
+  }
+})
+```
+
+## Do you want to use JWTs?
+
+JWT authentication integrates with existing identity providers and follows standard token-based authentication patterns. Use JWTs when:
+- You have an existing identity provider (Auth0, Okta, etc.)
+- You need user-specific authentication and authorization
+- You want standard OAuth 2.0 / OpenID Connect flows
+
+### How JWT Works
+
+Moose validates JWT tokens using RS256 algorithm with your identity provider's public key. You configure the expected issuer and audience, and Moose handles token verification automatically.
+
+### Step 1: Configure JWT Settings
+
+#### Option A: Configure in `moose.config.toml`
 
 ```toml filename=moose.config.toml
 [jwt]
@@ -39,13 +110,13 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy...
 issuer = "https://my-auth-server.com/"
 # Expected JWT audience  
 audience = "my-moose-app"
-# Optional: Enforce JWT on all ingest APIs (default: false)
-enforce_on_all_ingest_apis = false
-# Optional: Enforce JWT on all Analytics APIs (default: false)
-enforce_on_all_consumptions_apis = false
 ```
 
-#### Configure with Environment Variables
+<Callout type="info">
+  The `secret` field should contain your JWT **public key** used to verify signatures using RS256 algorithm.
+</Callout>
+
+#### Option B: Configure with Environment Variables
 
 You can also set these values as environment variables:
 
@@ -55,166 +126,144 @@ MOOSE_JWT_ISSUER=your_jwt_issuer # Expected JWT issuer (overrides `issuer` in `m
 MOOSE_JWT_AUDIENCE=your_jwt_audience # Expected JWT audience (overrides `audience` in `moose.config.toml`)
 ```
 
-<Callout type="info">
-  The `secret` field should contain your JWT **public key** used to verify signatures using RS256 algorithm.
-</Callout>
+### Step 2: Make Authenticated Requests
 
-### API Key Authentication
-
-Use API keys for simple, static authentication scenarios.
-
-#### Configure with Environment Variables
-
-Set environment variables with **hashed** API keys:
-```bash
-# For ingest endpoints
-export MOOSE_INGEST_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
-
-# For analytics endpoints  
-export MOOSE_CONSUMPTION_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
-
-# For admin endpoints
-export MOOSE_ADMIN_TOKEN='your_plain_text_token'
-```
-
-## Endpoint Types and Authentication Priority
-
-
-### Ingest Endpoints
-
-If both JWT (in the `[jwt]` table) and an API (`MOOSE_INGEST_API_KEY`) are configured, and you have `jwt.enforce_on_all_ingest_apis` set to `false` in your `moose.config.toml` (or its not set):
-
-```toml filename="moose.config.toml"
-[jwt]
-enforce_on_all_ingest_apis = false
-```
-
-```env filename=".env" copy
-MOOSE_INGEST_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
-```
-
-Then, when a request is made to an `/ingest` endpoint, the server will:
-
-- First attempt JWT validation (RS256 signature check). 
-- If that fails or is not applicable, it will then try to validate using the API key (PBKDF2 HMAC SHA256). 
-
-
-If you have `enforce_on_all_ingest_apis` set to true in your `moose.config.toml`:
-
-```toml filename="moose.config.toml"
-[jwt]
-enforce_on_all_ingest_apis = true
-```
-
-Then, only JWT will be accepted if JWT is configured.
-
-
-### API Endpoints
-
-(Same as Ingest Endpoints, but for `/api` endpoints)
-
-If both JWT (in the `[jwt]` table) and an API (`MOOSE_CONSUMPTION_API_KEY`) are configured, and you have `jwt.enforce_on_all_consumptions_apis` set to `false` in your `moose.config.toml` (or its not set):
-
-```toml filename="moose.config.toml"
-[jwt]
-enforce_on_all_consumptions_apis = false
-```
-
-```bash filename=".env" copy
-MOOSE_CONSUMPTION_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
-```
-
-Then, when a request is made to an `/api` endpoint, the server will:
-
-- First attempt JWT validation (RS256 signature check). 
-- If that fails or is not applicable, it will then try to validate using the API key (PBKDF2 HMAC SHA256). 
-
-If you have `enforce_on_all_consumptions_apis` set to true in your `moose.config.toml`:
-
-```toml filename="moose.config.toml"
-[jwt]
-enforce_on_all_consumptions_apis = true
-```
-
-Then, only JWT will be accepted if JWT is configured.
-
-
-### Admin Endpoints
-Admin Endpoint Authentication
-Administrative endpoints in Moose (e.g., for managing deployments, viewing plans) also require authentication to prevent unauthorized access.
-
-#### Configuration:
-
-Admin authentication relies on a token that can be supplied in the following order of precedence:
-- `--token` CLI Parameter: When using Moose CLI commands that interact with a remote admin endpoint (e.g., `moose remote plan --token <value>`), this parameter takes highest precedence. The value should be the plain-text Bearer token.
-- `MOOSE_ADMIN_TOKEN` Environment Variable: You can set the `MOOSE_ADMIN_TOKEN` environment variable to the plain-text Bearer token.
-
-```bash copy
-MOOSE_ADMIN_TOKEN='your_generated_plain_text_token'
-```
-
-This is useful for CI/CD environments or scripts interacting with admin endpoints.
-
-- Project Configuration File (moose.config.toml): You can specify a hashed admin API key in your `moose.config.toml` under the [authentication] table. This key is expected to be a PBKDF2 HMAC SHA256 hash, obtainable from the `moose generate hash-token` command.
-
-```toml filename="moose.config.toml"
- 
-[authentication]
-admin_api_key = "your_pbkdf2_hmac_sha256_hashed_key"
-```
-<Callout type="info" title="Storing Admin API Keys in Project Configuration File">
-  Storing the `admin_api_key` (which is a PBKDF2 HMAC SHA256 hash) in your `moose.config.toml` file is an acceptable practice, even if the file is version-controlled. This is because the actual plain-text Bearer token (the secret) is not stored. The hash is computationally expensive to reverse, ensuring that your secret is not exposed in the codebase.
-</Callout>
-
-The Moose server running locally will use this key to protect its admin endpoints. Use the hashed key output from `moose generate hash-token` here.
-
-#### How it Works:
-
-- For CLI interactions with a remote server, the CLI will use the token from `--token` or `MOOSE_ADMIN_TOKEN`.
-- The Moose server itself (when running `moose dev` or a deployed instance) protects its admin API routes (e.g., `/admin/plan`, `/admin/integrate-changes`) using the `admin_api_key` (a PBKDF2 HMAC SHA256 hash) from `moose.config.toml` (in the `[authentication]` table) or the `MOOSE_ADMIN_TOKEN` environment variable if the `moose.config.toml` key is not set. 
-- The server expects the plain-text token in the `Authorization: Bearer <token>` header and will verify it against the stored hashed key using PBKDF2 HMAC SHA256.
-- Use the `moose generate hash-token` command as described above to generate the plain-text token and its corresponding PBKDF2 HMAC SHA256 hashed version for `admin_api_key`.
-
-## Token Generation
-
-Generate tokens and hashed keys using the Moose CLI:
-
-```bash
-moose generate hash-token
-```
-
-**Output:**
-- **ENV API Keys**: Hashed key for environment variables (e.g., `MOOSE_INGEST_API_KEY`, `MOOSE_CONSUMPTION_API_KEY`, `MOOSE_ADMIN_TOKEN`)
-- **Bearer Token**: Plain-text token for client applications (e.g., `Authorization: Bearer <token>`)
-
-<Callout type="info">
-  Use the **hashed key** for environment variables and `moose.config.toml`. Use the **plain-text token** in your `Authorization: Bearer token` headers.
-</Callout>
-
-## Making Authenticated Requests
-
-All authenticated requests require the `Authorization` header:
+Send requests with the JWT token in the `Authorization` header:
 
 ```bash
 # Using curl
-curl -H "Authorization: Bearer your_token_here" \
-     https://your-moose-instance.com/api/endpoint
+curl -H "Authorization: Bearer your_jwt_token_here" \
+     https://your-moose-instance.com/ingest/YourDataModel
 
 # Using JavaScript
 fetch('https://your-moose-instance.com/api/endpoint', {
   headers: {
-    'Authorization': 'Bearer your_token_here'
+    'Authorization': 'Bearer your_jwt_token_here'
   }
 })
 ```
 
+## Want to use both? Here's the caveats
+
+You can configure both JWT and API Key authentication simultaneously. When both are configured, Moose's authentication behavior depends on the `enforce_on_all_*` flags.
+
+### Understanding Authentication Priority
+
+#### Default Behavior (No Enforcement)
+
+By default, when both JWT and API Keys are configured, Moose tries JWT validation first, then falls back to API Key validation:
+
+```toml filename="moose.config.toml"
+[jwt]
+# JWT configuration
+secret = "..."
+issuer = "https://my-auth-server.com/"
+audience = "my-moose-app"
+# enforce flags default to false
+```
+
+```bash filename=".env"
+# API Key configuration
+MOOSE_INGEST_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
+MOOSE_CONSUMPTION_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
+```
+
+**For Ingest Endpoints (`/ingest/*`)**:
+- Attempts JWT validation first (RS256 signature check)
+- Falls back to API Key validation (PBKDF2 HMAC SHA256) if JWT fails
+
+**For Analytics Endpoints (`/api/*`)**:
+- Same fallback behavior as ingest endpoints
+
+This allows you to use either authentication method for your clients.
+
+#### Enforcing JWT Only
+
+If you want to **only** accept JWT tokens (no API key fallback), set the enforcement flags:
+
+```toml filename="moose.config.toml"
+[jwt]
+secret = "..."
+issuer = "https://my-auth-server.com/"
+audience = "my-moose-app"
+# Only accept JWT, no API key fallback
+enforce_on_all_ingest_apis = true
+enforce_on_all_consumptions_apis = true
+```
+
+**Result**: When enforcement is enabled, API Key authentication is disabled even if the environment variables are set. Only valid JWT tokens will be accepted.
+
+### Common Use Cases
+
+#### Use Case 1: Different Auth for Different Endpoints
+
+Configure JWT for user-facing analytics endpoints, API keys for internal ingestion:
+
+```toml filename="moose.config.toml"
+[jwt]
+secret = "..."
+issuer = "https://my-auth-server.com/"
+audience = "my-moose-app"
+enforce_on_all_consumptions_apis = true  # JWT only for /api/*
+enforce_on_all_ingest_apis = false        # Allow fallback for /ingest/*
+```
+
+```bash filename=".env"
+MOOSE_INGEST_API_KEY='hashed_key_for_internal_services'
+```
+
+#### Use Case 2: Migration from API Keys to JWT
+
+Start with both configured, no enforcement. Gradually migrate clients to JWT. Once complete, enable enforcement:
+
+```toml filename="moose.config.toml"
+[jwt]
+secret = "..."
+issuer = "https://my-auth-server.com/"
+audience = "my-moose-app"
+# Start with both allowed during migration
+enforce_on_all_ingest_apis = false
+enforce_on_all_consumptions_apis = false
+# Later, enable to complete migration
+# enforce_on_all_ingest_apis = true
+# enforce_on_all_consumptions_apis = true
+```
+
+### Admin Endpoints
+
+Admin endpoints use API key authentication exclusively (configured separately from ingest/analytics endpoints).
+
+**Configuration precedence** (highest to lowest):
+1. `--token` CLI parameter (plain-text token)
+2. `MOOSE_ADMIN_TOKEN` environment variable (plain-text token)
+3. `admin_api_key` in `moose.config.toml` (hashed token)
+
+**Example:**
+
+```bash
+# Option 1: CLI parameter
+moose remote plan --token your_plain_text_token
+
+# Option 2: Environment variable
+export MOOSE_ADMIN_TOKEN='your_plain_text_token'
+moose remote plan
+
+# Option 3: Config file
+# In moose.config.toml:
+# [authentication]
+# admin_api_key = "your_pbkdf2_hmac_sha256_hashed_key"
+```
+
 ## Security Best Practices
 
-- **Use environment variables** for production deployments
-- **Generate unique tokens** for different environments
-- **Rotate tokens regularly** for enhanced security
-- **Use JWT** when integrating with existing identity providers
-- **Use API keys** for simple, internal applications
+- **Never commit plain-text tokens to version control** - Always use hashed keys in configuration files
+- **Use environment variables for production** - Keep secrets out of your codebase
+- **Generate unique tokens for different environments** - Separate development, staging, and production credentials
+- **Rotate tokens regularly** - Especially for long-running production deployments
+- **Choose the right method for your use case**:
+  - Use **API Keys** for internal services and getting started
+  - Use **JWT** when integrating with identity providers or need user-level auth
+- **Store hashed keys safely** - The PBKDF2 HMAC SHA256 hash in `moose.config.toml` is safe to version control, but the plain-text token should only exist in secure environment variables or secret management systems
 
 <Callout type="warning">
   Never commit plain-text tokens to version control. Use hashed keys in configuration files and environment variables for production.


### PR DESCRIPTION
**ENG-1111: updated moose auth docs**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites the auth docs to prioritize API keys, clarify JWT config, document combined auth behavior/enforcement, and update admin token precedence; updates sidebar meta to show Auth section.
> 
> - **Docs (Auth Guide `apps/framework-docs/src/pages/moose/apis/auth.mdx`)**:
>   - Reorganizes guide to emphasize API Keys first with step-by-step generation, env/config usage, and request examples.
>   - Expands JWT section with config options (toml vs env), clarifies `secret` as public key, and adds request examples.
>   - Documents combined JWT + API Key behavior, default fallback order, and enforcement flags for `/ingest/*` and `/api/*`; includes common use cases and migration path.
>   - Clarifies Admin endpoints: API key–only, precedence (`--token` > `MOOSE_ADMIN_TOKEN` > `admin_api_key`), and examples; notes hashed key storage safety.
>   - Updates security best practices to stress hashed storage and token hygiene.
> - **Docs Nav (`apps/framework-docs/src/pages/moose/apis/_meta.tsx`)**:
>   - Updates `auth` entry (now titled `Auth`) position in sidebar and removes older "Securing API Endpoints" title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3ba795ffdf56cb4f9b42809b02e05111676dcb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->