### PR TITLE
config to ignore certain migration operations

### DIFF
--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -1142,10 +1142,15 @@ pub async fn remote_gen_migration(
         },
     );
 
+    let mut db_migration = MigrationPlan::from_infra_plan(&changes)?;
+
+    // Filter out ignored operations based on project config
+    db_migration.filter_ignored_operations(&project.migration_config.ignore_operations);
+
     Ok(MigrationPlanWithBeforeAfter {
         remote_state: remote_infra_map,
         local_infra_map,
-        db_migration: MigrationPlan::from_infra_plan(&changes)?,
+        db_migration,
     })
 }
 

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -336,6 +336,7 @@ mod tests {
             temporal_config:
                 crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
             state_config: crate::project::StateConfig::default(),
+            migration_config: crate::project::MigrationConfig::default(),
             language_project_config: crate::project::LanguageProjectConfig::default(),
             project_location: std::path::PathBuf::new(),
             is_production: false,

--- a/apps/framework-cli/src/framework/core/migration_plan.rs
+++ b/apps/framework-cli/src/framework/core/migration_plan.rs
@@ -1,5 +1,6 @@
+use crate::framework::core::infrastructure::table::Table;
 use crate::framework::core::infrastructure_map::{InfraChanges, InfrastructureMap};
-use crate::infrastructure::olap::clickhouse::SerializableOlapOperation;
+use crate::infrastructure::olap::clickhouse::{IgnorableOperation, SerializableOlapOperation};
 use crate::infrastructure::olap::ddl_ordering::{order_olap_changes, PlanOrderingError};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -52,10 +53,234 @@ impl MigrationPlan {
         let plan_yaml = serde_yaml::to_string(&plan_json)?;
         Ok(plan_yaml)
     }
+
+    /// Filter out operations that should be ignored based on config
+    pub fn filter_ignored_operations(&mut self, ignore_ops: &[IgnorableOperation]) {
+        if ignore_ops.is_empty() {
+            return;
+        }
+
+        self.operations.retain(|op| {
+            // Keep operation if none of the ignore rules match it
+            !ignore_ops.iter().any(|ig| ig.matches(op))
+        });
+    }
 }
 
 pub struct MigrationPlanWithBeforeAfter {
     pub remote_state: InfrastructureMap,
     pub local_infra_map: InfrastructureMap,
     pub db_migration: MigrationPlan,
+}
+
+/// Strips fields from a table that correspond to ignored operations
+/// This is used during drift detection to ignore differences in fields that the user has configured to ignore
+pub fn strip_ignored_fields(table: &Table, ignore_ops: &[IgnorableOperation]) -> Table {
+    let mut table = table.clone();
+
+    if ignore_ops.contains(&IgnorableOperation::ModifyTableTtl) {
+        table.table_ttl_setting = None;
+    }
+
+    if ignore_ops.contains(&IgnorableOperation::ModifyColumnTtl) {
+        for col in &mut table.columns {
+            col.ttl = None;
+        }
+    }
+
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::framework::core::infrastructure::table::{Column, ColumnType, OrderBy};
+    use crate::framework::core::infrastructure_map::PrimitiveSignature;
+    use crate::framework::core::partial_infrastructure_map::LifeCycle;
+
+    fn create_test_table() -> Table {
+        Table {
+            name: "test_table".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: ColumnType::String,
+                    required: true,
+                    unique: false,
+                    primary_key: true,
+                    default: None,
+                    annotations: vec![],
+                    comment: None,
+                    ttl: None,
+                },
+                Column {
+                    name: "expiring_field".to_string(),
+                    data_type: ColumnType::String,
+                    required: false,
+                    unique: false,
+                    primary_key: false,
+                    default: None,
+                    annotations: vec![],
+                    comment: None,
+                    ttl: Some("timestamp + INTERVAL 30 DAY".to_string()),
+                },
+            ],
+            order_by: OrderBy::Fields(vec!["id".to_string()]),
+            partition_by: None,
+            sample_by: None,
+            indexes: vec![],
+            version: None,
+            source_primitive: PrimitiveSignature {
+                name: "test_table".to_string(),
+                primitive_type:
+                    crate::framework::core::infrastructure_map::PrimitiveTypes::DataModel,
+            },
+            engine: None,
+            metadata: None,
+            life_cycle: LifeCycle::FullyManaged,
+            engine_params_hash: None,
+            table_settings: None,
+            table_ttl_setting: Some("timestamp + INTERVAL 90 DAY".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_filter_modify_table_ttl() {
+        let test_table = create_test_table();
+        let mut plan = MigrationPlan {
+            created_at: Utc::now(),
+            operations: vec![
+                SerializableOlapOperation::CreateTable {
+                    table: test_table.clone(),
+                },
+                SerializableOlapOperation::ModifyTableTtl {
+                    table: "users".to_string(),
+                    before: None,
+                    after: Some("timestamp + INTERVAL 30 DAY".to_string()),
+                },
+                SerializableOlapOperation::DropTable {
+                    table: "old_users".to_string(),
+                },
+            ],
+        };
+
+        plan.filter_ignored_operations(&[IgnorableOperation::ModifyTableTtl]);
+
+        assert_eq!(plan.operations.len(), 2);
+        assert!(matches!(
+            plan.operations[0],
+            SerializableOlapOperation::CreateTable { .. }
+        ));
+        assert!(matches!(
+            plan.operations[1],
+            SerializableOlapOperation::DropTable { .. }
+        ));
+    }
+
+    #[test]
+    fn test_filter_modify_column_ttl() {
+        let test_table = create_test_table();
+        let mut plan = MigrationPlan {
+            created_at: Utc::now(),
+            operations: vec![
+                SerializableOlapOperation::CreateTable {
+                    table: test_table.clone(),
+                },
+                SerializableOlapOperation::ModifyColumnTtl {
+                    table: "users".to_string(),
+                    column: "created_at".to_string(),
+                    before: None,
+                    after: Some("timestamp + INTERVAL 30 DAY".to_string()),
+                },
+                SerializableOlapOperation::DropTable {
+                    table: "old_users".to_string(),
+                },
+            ],
+        };
+
+        plan.filter_ignored_operations(&[IgnorableOperation::ModifyColumnTtl]);
+
+        assert_eq!(plan.operations.len(), 2);
+        assert!(matches!(
+            plan.operations[0],
+            SerializableOlapOperation::CreateTable { .. }
+        ));
+        assert!(matches!(
+            plan.operations[1],
+            SerializableOlapOperation::DropTable { .. }
+        ));
+    }
+
+    #[test]
+    fn test_filter_multiple_ignored_operations() {
+        let test_table = create_test_table();
+        let mut plan = MigrationPlan {
+            created_at: Utc::now(),
+            operations: vec![
+                SerializableOlapOperation::ModifyTableTtl {
+                    table: "users".to_string(),
+                    before: None,
+                    after: Some("ttl1".to_string()),
+                },
+                SerializableOlapOperation::ModifyColumnTtl {
+                    table: "users".to_string(),
+                    column: "col".to_string(),
+                    before: None,
+                    after: Some("ttl2".to_string()),
+                },
+                SerializableOlapOperation::CreateTable {
+                    table: test_table.clone(),
+                },
+            ],
+        };
+
+        plan.filter_ignored_operations(&[
+            IgnorableOperation::ModifyTableTtl,
+            IgnorableOperation::ModifyColumnTtl,
+        ]);
+
+        assert_eq!(plan.operations.len(), 1);
+        assert!(matches!(
+            plan.operations[0],
+            SerializableOlapOperation::CreateTable { .. }
+        ));
+    }
+
+    #[test]
+    fn test_strip_table_ttl() {
+        let table = create_test_table();
+        assert!(table.table_ttl_setting.is_some());
+
+        let stripped = strip_ignored_fields(&table, &[IgnorableOperation::ModifyTableTtl]);
+
+        assert!(stripped.table_ttl_setting.is_none());
+        assert_eq!(stripped.columns[1].ttl, table.columns[1].ttl); // Column TTL unchanged
+    }
+
+    #[test]
+    fn test_strip_column_ttl() {
+        let table = create_test_table();
+        assert!(table.columns[1].ttl.is_some());
+
+        let stripped = strip_ignored_fields(&table, &[IgnorableOperation::ModifyColumnTtl]);
+
+        assert!(stripped.columns[1].ttl.is_none());
+        assert_eq!(stripped.table_ttl_setting, table.table_ttl_setting); // Table TTL unchanged
+    }
+
+    #[test]
+    fn test_strip_both_ttls() {
+        let table = create_test_table();
+
+        let stripped = strip_ignored_fields(
+            &table,
+            &[
+                IgnorableOperation::ModifyTableTtl,
+                IgnorableOperation::ModifyColumnTtl,
+            ],
+        );
+
+        assert!(stripped.table_ttl_setting.is_none());
+        assert!(stripped.columns[1].ttl.is_none());
+    }
 }

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -392,6 +392,7 @@ mod tests {
             temporal_config:
                 crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
             state_config: crate::project::StateConfig::default(),
+            migration_config: crate::project::MigrationConfig::default(),
             language_project_config: crate::project::LanguageProjectConfig::default(),
             project_location: std::path::PathBuf::new(),
             is_production: false,

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse.rs
@@ -193,6 +193,28 @@ pub enum SerializableOlapOperation {
     },
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "PascalCase")]
+pub enum IgnorableOperation {
+    ModifyTableTtl,
+    ModifyColumnTtl,
+}
+
+impl IgnorableOperation {
+    pub fn matches(&self, op: &SerializableOlapOperation) -> bool {
+        matches!(
+            (self, op),
+            (
+                Self::ModifyTableTtl,
+                SerializableOlapOperation::ModifyTableTtl { .. }
+            ) | (
+                Self::ModifyColumnTtl,
+                SerializableOlapOperation::ModifyColumnTtl { .. }
+            )
+        )
+    }
+}
+
 /// Executes a series of changes to the ClickHouse database schema
 ///
 /// # Arguments

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -38,6 +38,7 @@ use crate::framework::languages::SupportedLanguages;
 use crate::framework::streaming::loader::parse_streaming_function;
 use crate::framework::versions::Version;
 use crate::infrastructure::olap::clickhouse::config::ClickHouseConfig;
+use crate::infrastructure::olap::clickhouse::IgnorableOperation;
 use crate::infrastructure::orchestration::temporal::TemporalConfig;
 
 use crate::infrastructure::redis::redis_client::RedisConfig;
@@ -208,6 +209,14 @@ impl Default for ProjectFeatures {
     }
 }
 
+/// Migration configuration
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct MigrationConfig {
+    /// Operations to ignore during migration plan generation
+    #[serde(default)]
+    pub ignore_operations: Vec<IgnorableOperation>,
+}
+
 /// Represents a user's Moose project
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Project {
@@ -235,6 +244,9 @@ pub struct Project {
     /// State storage configuration
     #[serde(default)]
     pub state_config: StateConfig,
+    /// Migration configuration
+    #[serde(default)]
+    pub migration_config: MigrationConfig,
     /// Language-specific project configuration (not serialized)
     #[serde(skip)]
     pub language_project_config: LanguageProjectConfig,
@@ -332,6 +344,7 @@ impl Project {
             http_server_config: LocalWebserverConfig::default(),
             temporal_config: TemporalConfig::default(),
             state_config: StateConfig::default(),
+            migration_config: MigrationConfig::default(),
             language_project_config,
             supported_old_versions: HashMap::new(),
             git_config: GitConfig::default(),

--- a/apps/framework-docs/src/pages/moose/configuration.mdx
+++ b/apps/framework-docs/src/pages/moose/configuration.mdx
@@ -152,6 +152,13 @@ enforce_on_all_ingest_apis = false
 # Optional hashed admin API key for auth (Default: None)
 # admin_api_key = "hashed_api_key"
 
+# Migration configuration
+[migration_config]
+# Operations to ignore during migration plan generation and drift detection
+# Useful for managing TTL changes outside of Moose or when you don't want
+# migration failures due to TTL drift
+# ignore_operations = ["ModifyTableTtl", "ModifyColumnTtl"]
+
 # Feature flags
 [features]
 # Enable the streaming engine (Default: true)

--- a/apps/framework-docs/src/pages/moose/migrate.mdx
+++ b/apps/framework-docs/src/pages/moose/migrate.mdx
@@ -290,6 +290,21 @@ replication_factor = 1
 - Maintain proper authentication
 - Test migrations in staging first
 
+### Managing TTL Outside Moose
+
+If you're managing ClickHouse TTL settings through other tools or want to avoid migration failures from TTL drift, you can configure Moose to ignore TTL changes:
+
+```toml filename="moose.config.toml" copy
+[migration_config]
+ignore_operations = ["ModifyTableTtl", "ModifyColumnTtl"]
+```
+
+This tells Moose to:
+- Skip generating TTL change operations in migration plans
+- Ignore TTL differences during drift detection
+
+You'll still get migrations for all other schema changes (adding tables, modifying columns, etc.), but TTL changes won't block your deployments.
+
 ## Troubleshooting
 
 ### Authentication Errors


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds project-level config to ignore TTL-related migration operations and drift, updates planning/migration logic to honor it, and documents usage.
> 
> - **Migration planning/execution**:
>   - Add `IgnorableOperation` enum (`ModifyTableTtl`, `ModifyColumnTtl`) and matching logic.
>   - Extend `MigrationPlan` with `filter_ignored_operations(...)` and apply it in `remote_gen_migration` based on `project.migration_config.ignore_operations`.
>   - Add `strip_ignored_fields(...)` and update drift detection to strip metadata and ignored fields; adjust tests and add TTL-specific cases.
> - **Project config**:
>   - Introduce `MigrationConfig { ignore_operations: Vec<IgnorableOperation> }` on `Project`; wire defaults in plan/reality checker constructors.
> - **Docs**:
>   - Document `[migration_config]` with `ignore_operations = ["ModifyTableTtl", "ModifyColumnTtl"]` in configuration and migration guides (incl. TTL management section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9204d467cecd84c90c807fbab6376b68a9c94fad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->