### PR TITLE
mitchell/bug-main: release fix

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -30,8 +30,11 @@ if (tags.length > 0 && tags.startsWith("v")) {
   process.exit(0);
 }
 
-// We retrieve the last release tag.
-const latestTag = execSync("git describe --tags --abbrev=0").toString().trim();
+// We retrieve the last release tag (excluding CI tags).
+// This ensures we only consider actual releases, not CI builds
+const latestTag = execSync("git describe --tags --abbrev=0 --exclude='*-ci-*'")
+  .toString()
+  .trim();
 // We parse the version number from the tag
 const version = latestTag.match(/v(\d+)\.(\d+)\.(\d+)/);
 


### PR DESCRIPTION
**bug: exclude ci tags when describing tags for the main release workflow**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude CI tags when computing the latest release version in the version script.
> 
> - **Release tooling**:
>   - Update `scripts/version.js` to derive the latest tag using `git describe --tags --abbrev=0 --exclude='*-ci-*'`, filtering out CI tags from version calculation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd8b2f6483b3baeee1040019c055e17531def097. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->