### PR TITLE
make tsconfig-paths a peer dependency

### DIFF
--- a/packages/ts-moose-lib/package.json
+++ b/packages/ts-moose-lib/package.json
@@ -47,7 +47,6 @@
     "redis": "^4.6.13",
     "toml": "3.0.0",
     "ts-node": "^10.9.1",
-    "tsconfig-paths": "^4.2.0",
     "typescript": "~5.9.2"
   },
   "devDependencies": {
@@ -64,10 +63,14 @@
   },
   "peerDependencies": {
     "ts-patch": "^3.3.0",
+    "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "peerDependenciesMeta": {
     "ts-patch": {
+      "optional": false
+    },
+    "tsconfig-paths": {
       "optional": false
     },
     "typia": {

--- a/templates/typescript-empty/package.json
+++ b/templates/typescript-empty/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
+    "tsconfig-paths": "^4.2.0",
     "@514labs/moose-lib": "latest",
     "typia": "^9.6.1"
   },

--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -11,6 +11,7 @@
     "axios": "^1.7.7",
     "express": "^5.1.0",
     "ts-patch": "^3.3.0",
+    "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {

--- a/templates/typescript-migrate-test/package.json
+++ b/templates/typescript-migrate-test/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
+    "tsconfig-paths": "^4.2.0",
     "@514labs/moose-lib": "latest",
     "typia": "^9.6.1"
   },

--- a/templates/typescript-tests/package.json
+++ b/templates/typescript-tests/package.json
@@ -14,6 +14,7 @@
     "koa": "^2.15.3",
     "koa-bodyparser": "^4.4.1",
     "ts-patch": "^3.3.0",
+    "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1",
     "drizzle-orm": "latest"
   },

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -13,6 +13,7 @@
     "@514labs/moose-lib": "latest",
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
+    "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
the context tsconfig-path runs in is the moose application, not moose-lib itself.

because package managers like pnpm will not hoist packages which aren't directly used by dependencies, essentially tree-shaking them, tsconfig-path needs to be a peer dependency like typia and ts-patch already are.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves `tsconfig-paths` to a required peer dependency in `@514labs/moose-lib` and adds it as a direct dependency across TypeScript templates.
> 
> - **Library (`packages/ts-moose-lib`)**:
>   - Move `tsconfig-paths` from `dependencies` to `peerDependencies` and mark as required in `peerDependenciesMeta`.
> - **Templates**:
>   - Add `tsconfig-paths` to `dependencies` in `templates/typescript`, `templates/typescript-empty`, `templates/typescript-express`, `templates/typescript-migrate-test`, and `templates/typescript-tests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cee9bb344e0eae8c1e907788a8dbe7b165963c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->