### PR TITLE
ENG-1122: fix mv not populating new mv on update

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -3335,6 +3335,7 @@ async fn admin_plan_route(
         &plan_request.infra_map,
         &clickhouse_strategy,
         true,
+        project.is_production,
     );
 
     // Prepare the response

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -864,7 +864,7 @@ fn calculate_plan_diff_local(
 
     let clickhouse_strategy = ClickHouseTableDiffStrategy;
     // planning about action on prod env, respect_life_cycle is true
-    current_map.diff_with_table_strategy(target_map, &clickhouse_strategy, true)
+    current_map.diff_with_table_strategy(target_map, &clickhouse_strategy, true, true)
 }
 
 /// Legacy implementation of remote_plan using the existing /admin/plan endpoint

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -336,6 +336,7 @@ pub async fn plan_changes(
         changes: reconciled_map.diff_with_table_strategy(
             &target_infra_map,
             &clickhouse_strategy,
+            true,
             project.is_production,
         ),
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Materialized view population now runs only in dev (with optional truncate) and the production flag is threaded through diffing/planning; endpoints, DDL generation, and tests updated accordingly.
> 
> - **Olap/Infra Diffing**:
>   - Extend `InfrastructureMap::diff_with_table_strategy` to accept `is_production` and propagate from callers (`local_webserver` admin plan, planning, routines).
>   - Update `diff_sql_resources` to accept `is_production` and invoke `ClickHouseTableDiffStrategy::check_materialized_view_population` with it.
> - **ClickHouse Strategy**:
>   - `check_materialized_view_population` now skips population in production; triggers population for new/updated MVs; emits `OlapChange::PopulateMaterializedView { should_truncate }`.
> - **DDL Generation**:
>   - `AtomicOlapOperation::PopulateMaterializedView` and serialization now support `should_truncate`, emitting `TRUNCATE TABLE` before `INSERT` when set.
> - **Planning/CLI**:
>   - Pass `project.is_production` into diffing in `plan.rs` and admin plan route; local diff (`calculate_plan_diff_local`) updated likewise.
> - **Tests**:
>   - Adjust tests for new method signatures and new MV population behavior; add tests ensuring truncate + insert order and MV update triggers backfill.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6860eddf3082fce1f5681330f4f110a90e9e52f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->