### PR TITLE
mitchell/bug-main: ts release versions

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -71,20 +71,24 @@ jobs:
               exit 1
             fi
 
-            echo "VERSION=${CI_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "PYTHON_VERSION=${PYTHON_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "IS_CI_BUILD=true" >> "$GITHUB_OUTPUT"
-            echo "Generated CI version: ${CI_VERSION}"
-            echo "Generated Python version: ${PYTHON_VERSION}"
+            VERSION="${CI_VERSION}"
+            IS_CI_BUILD="true"
+
           else
             # For release builds (main branch), use the existing version.js script
-            ./scripts/version.js ${{ github.sha }} >> "$GITHUB_OUTPUT"
-            # For release builds, Python version is the same as the main version
-            RELEASE_VERSION=$(./scripts/version.js ${{ github.sha }} | grep "VERSION=" | cut -d'=' -f2)
-            echo "PYTHON_VERSION=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "IS_CI_BUILD=false" >> "$GITHUB_OUTPUT"
-            echo "hello"
+            VERSION_OUTPUT=$(./scripts/version.js ${{ github.sha }})
+            VERSION=$(echo "$VERSION_OUTPUT" | grep "VERSION=" | cut -d'=' -f2)
+            PYTHON_VERSION="${VERSION}"
+            IS_CI_BUILD="false"
           fi
+
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "PYTHON_VERSION=${PYTHON_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "IS_CI_BUILD=${IS_CI_BUILD}" >> "$GITHUB_OUTPUT"
+
+          echo "IS_CI_BUILD = ${IS_CI_BUILD}"
+          echo "Generated Semantic Version: ${VERSION}"
+          echo "Generated Python Version: ${PYTHON_VERSION}"
 
       - name: Create Release/Tag
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
**bug: main release versions are not ci versions**



**bug: added logging around setting release versions**
ci tags are being picked up as release tags.
this is wrong. added logging so that we have a better
understanding of how these versions are being set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the release workflow to consistently compute and export VERSION/PYTHON_VERSION/IS_CI_BUILD for CI vs release builds and adds explicit logging.
> 
> - **CI/CD (GitHub Actions)**:
>   - **Version generation refactor** in `.github/workflows/release-cli.yaml`:
>     - Compute `VERSION`, `PYTHON_VERSION`, and `IS_CI_BUILD` within the branch-specific logic, then export all outputs once.
>     - For release builds, parse `./scripts/version.js` output to set `VERSION` and mirror to `PYTHON_VERSION`.
>     - Preserve CI version scheme (exclude `-ci-` tags for base, inject `-ci-` and derive PEP 440 `PYTHON_VERSION`).
>     - Add logging for `IS_CI_BUILD`, semantic version, and Python version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abcee4fcf7a3b9afea0ece09dbccece732f27a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->