### PR TITLE
mitchell/bug-remove: ci-tags-for-gh ready only

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   version:
     concurrency: release
-    if: ${{ ! contains(github.event.head_commit.message , '[no-release]') }}
+    if: ${{ ! contains(github.event.head_commit.message , '[no-release]') && ! startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: "write"


### PR DESCRIPTION
**bug: gh read only queues were running the release-cli job**
this caused tags on the main branch to occur.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents the Release CLI workflow’s version job from running on GitHub read-only queue branches by extending the job condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14716507925f614e24b645c6fce4f254b60ce6db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->