### PR TITLE
add flake.nix to easily bootstrap a devshell via nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761373498,
+        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761532837,
+        "narHash": "sha256-78mCSQgC/a6/0vWYrvE/g9E3gGsJLyBBGtmHe3ZOLG4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4f5f89f1cfd8553b1285a4a0879ea1b2b05ad286",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,328 @@
+{
+  description = "MooseStack - Multi-language monorepo for building data infrastructure";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+      perSystem = {
+        config,
+        self',
+        inputs',
+        system,
+        lib,
+        ...
+      }: let
+        # Apply rust overlay
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [(import inputs.rust-overlay)];
+        };
+
+        # Rust toolchain
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = ["rust-src" "clippy" "rustfmt"];
+        };
+
+        # Node.js with PNPM
+        nodejs = pkgs.nodejs_20;
+        pnpm = pkgs.pnpm;
+
+        # Python with required packages
+        python = pkgs.python312;
+        pythonEnv = python.withPackages (ps:
+          with ps; [
+            pip
+            setuptools
+            wheel
+          ]);
+
+        # Common build inputs
+        commonBuildInputs = with pkgs;
+          [
+            pkg-config
+            openssl
+            protobuf
+            # For rdkafka
+            rdkafka
+            cyrus_sasl
+            zlib
+            zstd
+            lz4
+          ]
+          ++ lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.apple-sdk
+            pkgs.libiconv
+          ];
+
+        # Helper to convert aliases to scripts
+        aliasToScript = alias:
+          let
+            pwd = if alias ? pwd then "$WORKSPACE_ROOT/${alias.pwd}" else "$WORKSPACE_ROOT";
+          in
+          ''
+            set -e
+            cd "${pwd}"
+            ${alias.cmd}
+          '';
+
+        # Define test command aliases
+        testAliases = {
+          cargo-test = {
+            cmd = "cargo test";
+          };
+          ts-test = {
+            pwd = "packages/ts-moose-lib";
+            cmd = "pnpm test";
+          };
+          py-test = {
+            pwd = "packages/py-moose-lib";
+            cmd = "pytest";
+          };
+          e2e-test = {
+            pwd = "apps/framework-cli-e2e";
+            cmd = "pnpm test";
+          };
+          test-all = {
+            cmd = ''
+              cargo test && \
+              (cd packages/ts-moose-lib && pnpm test) && \
+              (cd packages/py-moose-lib && pytest)
+            '';
+          };
+        };
+
+        # Generate scripts for all aliases
+        testScripts = pkgs.runCommand "test-scripts" {} ''
+          mkdir -p $out/bin
+          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: alias: ''
+            cat > $out/bin/${name} << 'EOF'
+            #!/usr/bin/env bash
+            export WORKSPACE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+            ${aliasToScript alias}
+            EOF
+            chmod +x $out/bin/${name}
+          '') testAliases)}
+        '';
+      in {
+        # Development Shell
+        devShells.default = pkgs.mkShell {
+            name = "moose";
+
+          buildInputs =
+            [
+              # Languages
+              rustToolchain
+              nodejs
+              pnpm
+              pythonEnv
+
+              # Development tools
+              pkgs.git
+              pkgs.turbo
+              pkgs.protobuf
+              pkgs.maturin
+
+              # Test scripts
+              testScripts
+
+              # Build dependencies
+            ]
+            ++ commonBuildInputs;
+
+          shellHook = ''
+            # Set up PNPM
+            export PNPM_HOME="$HOME/.local/share/pnpm"
+            export PATH="$PNPM_HOME:$PATH"
+
+            # Set Python path for development
+            export PYTHONPATH="$PWD/packages/py-moose-lib:$PYTHONPATH"
+
+            echo "🦌 MooseStack Development Environment"
+            echo ""
+            echo "Available commands:"
+            echo "  pnpm build       - Build all packages (TypeScript)"
+            echo "  pnpm dev         - Start development servers"
+            echo "  pnpm lint        - Run linters"
+            echo "  cargo build      - Build Rust CLI"
+            echo "  cargo clippy     - Run Rust linter"
+            echo ""
+            echo "Test commands:"
+            echo "  cargo-test       - Run Rust tests"
+            echo "  ts-test          - Run TypeScript library tests"
+            echo "  py-test          - Run Python library tests"
+            echo "  e2e-test         - Run end-to-end tests (requires Docker)"
+            echo "  test-all         - Run all tests"
+            echo ""
+            echo "Versions:"
+            echo "  Node.js: $(node --version)"
+            echo "  PNPM: $(pnpm --version)"
+            echo "  Rust: $(rustc --version)"
+            echo "  Python: $(python --version)"
+            echo ""
+          '';
+
+          # Environment variables
+          RUST_BACKTRACE = "1";
+          CARGO_INCREMENTAL = "1";
+        };
+
+        # Package outputs
+        packages = {
+          # Rust CLI
+          moose-cli = pkgs.rustPlatform.buildRustPackage {
+            pname = "moose-cli";
+            version = "0.0.1";
+
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              outputHashes = {
+                "opentelemetry-prometheus-0.17.0" = "sha256-KjPqfxnXoxVKZ63nL8v7yKr7KN6z0ZoChuTZpjVV0cI=";
+                "rustfsm-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+                "rustfsm_procmacro-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+                "rustfsm_trait-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+                "temporal-client-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+                "temporal-sdk-core-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+                "temporal-sdk-core-api-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+                "temporal-sdk-core-protos-0.1.0" = "sha256-XkSRoJkMLQJyhOiAAREf3sM+Jqje4z0lxE07LA3nQQo=";
+              };
+            };
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pythonEnv
+              pkgs.maturin
+              pkgs.perl
+              # For rdkafka-sys build
+              pkgs.bash
+              pkgs.gnumake
+              pkgs.cmake
+              pkgs.coreutils
+            ];
+
+            buildInputs = commonBuildInputs;
+
+            # Build only the CLI package
+            cargoBuildFlags = ["-p" "moose-cli"];
+
+            # Skip tests - some tests require filesystem access and external commands
+            # that aren't available in the Nix sandbox
+            doCheck = false;
+
+            # The build.rs uses protobuf codegen which is pure Rust
+            # No need for protoc at build time
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
+
+            # Force rdkafka-sys to use pkg-config and system library
+            RDKAFKA_SYS_USE_PKG_CONFIG = "1";
+
+            # Patch Cargo.toml to enable dynamic linking for rdkafka
+            postPatch = ''
+              # Add dynamic-linking feature to rdkafka dependency
+              sed -i 's/rdkafka = { version = "0.38", features = \["ssl"\] }/rdkafka = { version = "0.38", features = ["ssl", "dynamic-linking"] }/' apps/framework-cli/Cargo.toml
+            '';
+
+            # Ensure bash is available for configure scripts
+            preBuild = ''
+              export PATH="${pkgs.bash}/bin:${pkgs.coreutils}/bin:$PATH"
+              export SHELL="${pkgs.bash}/bin/bash"
+            '';
+
+
+            meta = with lib; {
+              description = "MooseStack CLI - Build tool for Moose apps";
+              homepage = "https://www.fiveonefour.com/moose";
+              license = licenses.mit;
+              maintainers = [];
+            };
+          };
+
+          # TypeScript packages (built via PNPM)
+          ts-moose-lib = pkgs.stdenv.mkDerivation {
+            pname = "ts-moose-lib";
+            version = "0.0.1";
+
+            src = ./.;
+
+            nativeBuildInputs = [nodejs pnpm];
+
+            buildPhase = ''
+              export HOME=$TMPDIR
+              export PNPM_HOME="$HOME/.pnpm"
+
+              # Install dependencies
+              pnpm install --frozen-lockfile
+
+              # Build TypeScript packages
+              pnpm build --filter=@514labs/moose-lib
+            '';
+
+            installPhase = ''
+              mkdir -p $out
+              cp -r packages/ts-moose-lib/dist $out/
+              cp packages/ts-moose-lib/package.json $out/
+            '';
+
+            meta = with lib; {
+              description = "TypeScript library for MooseStack";
+              homepage = "https://www.fiveonefour.com/moose";
+              license = licenses.mit;
+            };
+          };
+
+          # Python library
+          py-moose-lib = pythonEnv.pkgs.buildPythonPackage {
+            pname = "moose-lib";
+            version = "0.0.1";
+
+            src = ./packages/py-moose-lib;
+
+            format = "setuptools";
+
+            propagatedBuildInputs = with pythonEnv.pkgs; [
+              pyjwt
+              pydantic
+              temporalio
+              kafka-python-ng
+              redis
+              humanfriendly
+              clickhouse-connect
+              requests
+            ];
+
+            # Some dependencies might not be in nixpkgs
+            doCheck = false;
+
+            meta = with lib; {
+              description = "Python library for MooseStack";
+              homepage = "https://www.fiveonefour.com/moose";
+              license = licenses.mit;
+            };
+          };
+
+          # Default package
+          default = self'.packages.moose-cli;
+        };
+
+        # Apps for easy running
+        apps = {
+          moose = {
+            type = "app";
+            program = "${self'.packages.moose-cli}/bin/moose-cli";
+          };
+          default = self'.apps.moose;
+        };
+      };
+    };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce Nix flake providing a cross-platform dev shell, build/test scripts, and packages/apps for the Rust CLI, TS library, and Python library.
> 
> - **Nix Flake** (`flake.nix`):
>   - **Dev Shell**: Cross-platform `devShells.default` with Rust toolchain (via `rust-overlay`), Node.js + PNPM, Python 3.12 env, and common native deps; shellHook prints versions and exposes test commands.
>   - **Test Scripts**: Generates runnable aliases (`cargo-test`, `ts-test`, `py-test`, `e2e-test`, `test-all`) via `runCommand`.
>   - **Packages**:
>     - `moose-cli`: Builds Rust CLI with pinned Cargo lock, dynamic rdkafka linking, and protobuf config; `doCheck=false`.
>     - `ts-moose-lib`: PNPM-based build outputs `dist` and `package.json`.
>     - `py-moose-lib`: Builds setuptools package with propagated deps; `doCheck=false`.
>     - Sets `default` package to `moose-cli`.
>   - **Apps**: Adds `apps.moose` and `apps.default` to run the CLI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d7ef0ffe0e32741245b6ce3ab77534f0e2ea288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->