### PR TITLE
Improve docs about MV backfill with S3Queue tables

### DIFF
--- a/apps/framework-docs/src/pages/moose/olap/model-materialized-view.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-materialized-view.mdx
@@ -621,6 +621,10 @@ Go to the [Advanced: Writing SELECT statements to Aggregated tables](#writing-se
 ## Backfill Destination Tables
 When the MaterializedView is created, Moose backfills the destination once by running your `SELECT` (so you start with a fully populated table).
 
+<Callout type="info" title="S3Queue sources are not backfilled" compact>
+Materialized views that source from S3Queue tables are **not backfilled** automatically. S3Queue tables only process new files added to S3 after the table is created - there is no historical data to backfill from. The MV will start populating as new files arrive in S3.
+</Callout>
+
 You can see the SQL that Moose will run to backfill the destination table when you generate the [Migration Plan](./migration-plan).
 
 During dev mode, as soon as you save the MaterializedView, Moose will run the backfill and you can see the results in the destination table by querying it in your local ClickHouse instance.

--- a/apps/framework-docs/src/pages/moose/olap/model-table.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-table.mdx
@@ -683,6 +683,10 @@ For more details, see the [ClickHouse documentation](https://clickhouse.com/docs
 #### Streaming from S3 (`S3Queue`)
 Use the `S3Queue` engine to automatically ingest data from S3 buckets as files are added:
 
+<Callout type="info" title="S3Queue with Materialized Views" compact>
+S3Queue tables only process **new files** added to S3 after table creation. When used as a source for materialized views, **no backfill occurs** - the MV will only start populating as new files arrive. See the [Materialized Views documentation](./model-materialized-view#backfill-destination-tables) for more details.
+</Callout>
+
 <TypeScript>
 ```ts filename="S3StreamingTable.ts" copy
 import { OlapTable, ClickHouseEngines } from '@514labs/moose-lib';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies that materialized views sourcing from S3Queue tables are not backfilled and only process new S3 files post-creation.
> 
> - **Docs (OLAP)**
>   - **Materialized Views** (`apps/framework-docs/src/pages/moose/olap/model-materialized-view.mdx`)
>     - Add info callout under Backfill section: MVs with `S3Queue` sources are not backfilled; they populate only as new S3 files arrive.
>   - **Tables** (`apps/framework-docs/src/pages/moose/olap/model-table.mdx`)
>     - Add info callout in `S3Queue` streaming section: when used as MV sources, no backfill occurs; link to MV backfill docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634ac59ed6c6533637d86abf44ff239d42d229f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->