### PR TITLE
add kafka binding build dependency for pnpm

### DIFF
--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -19,5 +19,10 @@
     "@types/express": "^5.0.3",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@confluentinc/kafka-javascript"
+    ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configure pnpm to only build `@confluentinc/kafka-javascript` in the TypeScript Express template.
> 
> - **templates/typescript-express**:
>   - **pnpm config**: Add `pnpm.onlyBuiltDependencies` with `@confluentinc/kafka-javascript` in `templates/typescript-express/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e77ef26c394f5c9c7f778654331820c0db5aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->