### PR TITLE
docs: improve docker related docs around vm memory

### DIFF
--- a/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
@@ -54,7 +54,7 @@ Check that your pre-requisites are installed by running the following commands:
     },
     {
       title: "Docker Desktop",
-      description: "For local development environment",
+      description: "For local development environment (requires at least 2.5GB memory)",
       link: { text: "Download →", href: "https://docs.docker.com/get-started/get-docker/", external: true }
     },
     {
@@ -88,7 +88,7 @@ docker ps
     },
     {
       title: "Docker Desktop",
-      description: "For local development environment",
+      description: "For local development environment (requires at least 2.5GB memory)",
       link: { text: "Download →", href: "https://docs.docker.com/get-started/get-docker/", external: true }
     },
     {
@@ -106,6 +106,10 @@ python --version
 docker ps
 ```
 </Python>
+
+<Callout type="warning" title="Docker Desktop Memory Requirements" compact={true}>
+Make sure Docker Desktop has at least **2.5GB of memory allocated**. To check or change this setting, open Docker Desktop, go to Settings → Resources → Memory, and adjust the slider if needed. [Learn more about Docker Desktop settings →](https://docs.docker.com/desktop/settings/)
+</Callout>
 
 <Callout type="info" title="Already have ClickHouse running?" href={PathConfig.fromClickhouse.path} icon={PathConfig.fromClickhouse.icon} ctaLabel="Add to ClickHouse">
 Skip the tutorial and add Moose as a layer on top of your existing database


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates quickstart to note Docker Desktop needs ≥2.5GB memory and adds a warning callout with settings/link.
> 
> - **Docs (quickstart)** in `apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx`:
>   - **Prerequisites**:
>     - Update `Docker Desktop` bullet to note "requires at least 2.5GB memory" for both TypeScript and Python sections.
>   - **Callout**:
>     - Add warning callout explaining Docker Desktop memory requirement with steps to check/change (Settings → Resources → Memory) and link to docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b2d5dadd4e3d912c851595991fd3ee080a54824. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->