### PR TITLE
docs: fix table name for `moose peek` in quickstart

### DIFF
--- a/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
@@ -483,7 +483,7 @@ The workflow runs in the background, powered by [Temporal](https://temporal.io).
 <ToggleBlock openText="(Bonus) Peek at your data" closeText="Hide details">
 
 ```bash filename="Terminal" copy
-moose peek Bar --limit 5 # This queries your Clickhouse database to show raw data; useful for debugging / verification
+moose peek local_Bar --limit 5 # This queries your Clickhouse database to show raw data; useful for debugging / verification
 ```
 
 You should see output like:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update quickstart docs to use `moose peek local_Bar` instead of `moose peek Bar` in the data peek example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be4410624f1e5871b412345bb9fd7e1513f73625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->