### PR TITLE
Improve nix flakes changelog entry

### DIFF
--- a/apps/framework-docs/src/pages/release-notes/2025-11-01.mdx
+++ b/apps/framework-docs/src/pages/release-notes/2025-11-01.mdx
@@ -128,6 +128,12 @@ PR: [#2876](https://github.com/514-labs/moosestack/pull/2876) | Docs: [Multi-dat
 - Fixed the redirect loop after deleting an organization so users land back on the create-org screen instead of bouncing between routes.
 
 ## Nix development environment
-`flake.nix` now bootstraps a full MooseStack toolchain (`nix develop` drops you into Rust, Node.js, and Python with shared test commands). If you use Nix, let us know!
+`flake.nix` now bootstraps a full MooseStack build environment (`nix develop` drops you into a development shell that will have everything you need to build all the components of moosestack). If you use Nix, let us know!
+
+Give it a go if you have nix installed on your machine with:
+
+```bash
+nix run github:514-labs/moosestack # -- to pass additional arguments to the cli
+```
 
 PR: [#2920](https://github.com/514-labs/moosestack/pull/2920)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies Nix flake notes and adds `nix run` usage to the Nov 1, 2025 release notes.
> 
> - **Docs (release notes)**:
>   - Update `apps/framework-docs/src/pages/release-notes/2025-11-01.mdx`:
>     - Clarify highlight about Nix flake: mention installing the CLI via `nix run github:514-labs/moosestack` and note dev shell for contributors.
>     - Revise Nix section wording ("build environment") and add a usage snippet showing `nix run github:514-labs/moosestack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be033a3503eca399a4d5be9461ba5f70e747c527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->