### PR TITLE
docs: fix incorrect table to peek on moosestack quickstart guide

### DIFF
--- a/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
@@ -487,7 +487,7 @@ The workflow runs in the background, powered by [Temporal](https://temporal.io).
 <ToggleBlock openText="(Bonus) Peek at your data" closeText="Hide details">
 
 ```bash filename="Terminal" copy
-moose peek Bar --limit 5 # This queries your Clickhouse database to show raw data; useful for debugging / verification
+moose peek local_Bar --limit 5 # This queries your Clickhouse database to show raw data; useful for debugging / verification
 ```
 
 You should see output like:
@@ -562,7 +562,7 @@ curl "http://localhost:4000/api/bar?limit=5&orderBy=totalRows"
 - You might be hitting the wrong port - use 4000, not 8080
 - Port 8080 serves the Temporal UI (workflow dashboard), not your API
 
-**If `moose peek Bar` shows 0 rows:**
+**If `moose peek local_Bar` shows 0 rows:**
 - Wait for the workflow to complete (it processes 1000 records)
 - Check the workflow is running: look for "Ingested X records..." messages
 - Verify no errors in your `moose dev` terminal logs


### PR DESCRIPTION
### 🐛 Problem
The current quickstart command `moose peek` references a `Bar` table that does **not exist**, causing the command to fail when following the guide.

---

### 💡 Solution
Updated the quickstart guide to ensure it creates the correct **`local_*`** tables before running `moose peek`.  
These tables are now used consistently throughout the example.

```
Tables
╭─────────────────────┬─────────────────────────────────────────────────────────────────────╮
│ name                ┆ schema_fields                                                       │
╞═════════════════════╪═════════════════════════════════════════════════════════════════════╡
│ local_FooWorkflow   ┆ id, success, message                                                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ local_BarAggregated ┆ dayOfMonth, totalRows, rowsWithText, totalTextLength, maxTextLength │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ local_FooDeadLetter ┆ originalRecord, errorMessage, errorType, failedAt, source           │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ local_Bar           ┆ primaryKey, utcTimestamp, hasText, textLength                       │
╰─────────────────────┴─────────────────────────────────────────────────────────────────────╯
```

### ✅ Verification
The updated guide successfully creates the tables and allows `moose peek` to run as expected:

```bash
matheusgr@computer % moose peek Bar
Failed: No matching table found

matheusgr@computer % moose peek local_Bar
{"primaryKey":"00019c79-4d9d-4744-bc48-9482c312795a","utcTimestamp":"2025-09-09T22:36:22+00:00","hasText":true,"textLength":118.0}
...
Peeked 5 rows
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `moose peek Bar` with `moose peek local_Bar` in the quickstart guide examples and troubleshooting.
> 
> - **Docs (Quickstart)**:
>   - Update peek command to `moose peek `local_Bar` --limit 5` in the data preview example.
>   - Adjust troubleshooting to reference `moose peek `local_Bar`` instead of `Bar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49117420011e0536835e2a6e17de3e826592f7dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->