### PR TITLE
macos-13 images are deprecated and failing builds

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -613,10 +613,6 @@ jobs:
         shell: bash
         run: pnpm --filter ...create-moose-app  --filter ...@514labs/moose-cli install
 
-      - name: Wait for @514labs/moose-cli-darwin-x64 to be available
-        shell: bash
-        run: ./scripts/wait-for-npm-package.sh @514labs/moose-cli-darwin-x64 ${{ needs.version.outputs.version }}
-
       - name: Wait for @514labs/moose-cli-darwin-arm64 to be available
         shell: bash
         run: ./scripts/wait-for-npm-package.sh @514labs/moose-cli-darwin-arm64 ${{ needs.version.outputs.version }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the macOS x64 (macos-13) build target and its npm wait step from the release workflow, retaining darwin-arm64 and Linux targets.
> 
> - **CI/CD (release workflow)**
>   - **Build matrix**: Remove `darwin-x64` (`macos-13-large`) target; keep `darwin-arm64` on `macos-14-large` and Linux targets.
>   - **Publishing steps**: Remove wait for `@514labs/moose-cli-darwin-x64`; keep waits for `darwin-arm64`, `linux-arm64`, and `linux-x64` packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17f608770b968ab46aa058deaa0dbc6e3e90eb90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->