### PR TITLE
enable tls features for ch rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "futures-util",
  "http-body-util",
  "hyper 1.7.0",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "lz4_flex",
  "replace_with",

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -27,7 +27,7 @@ toml = "0.5.8"
 serde = { version = "1.0", features = ["derive"] }
 config = { version = "0.13.1", features = ["toml"] }
 home = "0.5.5"
-clickhouse = { version = "0.14.0", features = ["uuid"] }
+clickhouse = { version = "0.14.0", features = ["uuid", "native-tls"] }
 clickhouse-rs = { version = "1.1.0-alpha.1", features = ["tls"] }
 handlebars = "5.1"
 rdkafka = { version = "0.38", features = ["ssl"] }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable TLS for the ClickHouse Rust client by turning on the `native-tls` feature in the CLI.
> 
> - **Dependencies**:
>   - Enable TLS for ClickHouse by adding the `native-tls` feature to `apps/framework-cli/Cargo.toml` `clickhouse` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dddc29fd0febbb75a67344d8d5a4aeb3362d180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->