### PR TITLE
python fastapi openapi docs fix

### DIFF
--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -1263,6 +1263,42 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
           );
         });
 
+        it("should serve OpenAPI documentation for FastAPI WebApp", async function () {
+          this.timeout(TIMEOUTS.TEST_SETUP_MS);
+
+          // Test OpenAPI JSON schema endpoint
+          await verifyWebAppEndpoint("/fastapi/openapi.json", 200, (json) => {
+            if (!json.openapi) {
+              throw new Error(
+                "Expected OpenAPI schema to have 'openapi' field",
+              );
+            }
+            if (!json.info) {
+              throw new Error("Expected OpenAPI schema to have 'info' field");
+            }
+            if (!json.paths) {
+              throw new Error("Expected OpenAPI schema to have 'paths' field");
+            }
+            // Verify that paths include the mount_path prefix
+            const paths = Object.keys(json.paths);
+            if (paths.length === 0) {
+              throw new Error(
+                "Expected OpenAPI schema to have at least one path",
+              );
+            }
+            // Check that at least one path includes /health (should be /fastapi/health or just /health)
+            const hasHealthPath = paths.some((p) => p.includes("/health"));
+            if (!hasHealthPath) {
+              throw new Error(
+                `Expected OpenAPI schema to include /health path. Found paths: ${paths.join(", ")}`,
+              );
+            }
+          });
+
+          // Test interactive docs endpoint (Swagger UI)
+          await verifyWebAppEndpoint("/fastapi/docs", 200, undefined);
+        });
+
         it("should handle multiple WebApp endpoints independently (PY)", async function () {
           this.timeout(TIMEOUTS.TEST_SETUP_MS);
 

--- a/apps/framework-cli/src/framework/python/wrappers/consumption_runner.py
+++ b/apps/framework-cli/src/framework/python/wrappers/consumption_runner.py
@@ -242,7 +242,7 @@ def handler_with_client(moose_client):
                                 'scheme': 'http',
                                 'path': proxied_path,
                                 'query_string': parsed_path.query.encode() if parsed_path.query else b'',
-                                'root_path': '',
+                                'root_path': normalized_mount,
                                 'headers': [(k.lower().encode(), v.encode()) for k, v in self.headers.items()],
                                 'server': (server_name, server_port),
                                 'client': self.client_address,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure FastAPI WebApps respect mount paths by setting ASGI root_path and add e2e tests validating OpenAPI JSON and Swagger UI endpoints.
> 
> - **Python wrapper (`consumption_runner.py`)**:
>   - Set ASGI scope `root_path` to the FastAPI WebApp `mount_path` to correctly serve mounted routes (e.g., OpenAPI/docs).
> - **E2E Tests (`apps/framework-cli-e2e/test/templates.test.ts`)**:
>   - Add FastAPI WebApp tests verifying OpenAPI JSON (`/fastapi/openapi.json`) structure and presence of `/health` path.
>   - Add test for interactive docs endpoint (`/fastapi/docs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d747c05fcf667787240d2d1932378b47d2c626f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->