### PR TITLE
fix code snippets in release notes

### DIFF
--- a/apps/framework-docs/src/pages/release-notes/2025-10-24.mdx
+++ b/apps/framework-docs/src/pages/release-notes/2025-10-24.mdx
@@ -9,7 +9,7 @@ import { Callout } from "@/components";
 
 <Callout type="info" title="Highlights">
 * **New:** `moose migrate --clickhouse-url` enables serverless ClickHouse schema deploys
-* **Improved:** JSON columns now accept dynamic payloads with fine-grained controls
+* **Improved:** `ClickHouseJson` type enables dynamic JSON payloads with fine-grained controls
 </Callout>
 
 ## Serverless ClickHouse migrations with `moose migrate`
@@ -25,47 +25,44 @@ moose generate migration \
 moose migrate --clickhouse-url "https://user:pass@ch.serverless.dev/main"
 ```
 
-🐙 PR: ([#2872](https://github.com/514labs/moose/pull/2872)) | 📘 Docs: [Serverless ClickHouse migrations guide](/moose/migrate#serverless-deployments)
+🐙 PR: ([#2872](https://github.com/514-labs/moosestack/pull/2872)) | 📘 Docs: [Serverless ClickHouse migrations guide](/moose/migrate#serverless-deployments)
 
-## Adaptive JSON columns with `__mooseJsonOptions`
+## Adaptive JSON columns with `ClickHouseJson`
 Model semi-structured payloads while locking in typed paths for the fields you care about.
 
 ```typescript
+import { Key, ClickHouseJson, Int64 } from "@514labs/moose-lib";
+
+interface UserMetadata {
+  userId: string;
+  sessionId: string;
+}
+
 export interface UserActivity {
   id: Key<string>;
-  metadata: {
-    userId: string;
-    sessionId: string;
-    __mooseJsonOptions: {
-      maxDynamicPaths: 256;
-      typedPaths: [
-        ["userId", "String"],
-        ["sessionId", "String"]
-      ];
-      skipRegexps: ["^debug\\."];
-    };
-  };
+  // ClickHouseJson<maxDynamicPaths, maxDynamicTypes, skipPaths, skipRegexes>
+  metadata: UserMetadata & ClickHouseJson<256, 16, ["internal.debug"], ["^tmp\\."]>;
 }
 ```
 
-🐙 PR:([#2887](https://github.com/514labs/moose/pull/2887)) | 📘 Docs: [Configurable JSON columns reference](/moose/data-modeling#configurable-json-columns)
+🐙 PR:([#2887](https://github.com/514-labs/moosestack/pull/2887)) | 📘 Docs: [Data modeling](/moose/data-modeling)
 
 ## Moose
 
-- **`moose migrate --clickhouse-url`** – Generate and apply migrations directly against hosted ClickHouse, ideal for OLAP-only or CI/CD workflows that run without the full Moose runtime. [Docs: Serverless ClickHouse migrations](/moose/migrate#serverless-deployments) | PRs [#2872](https://github.com/514labs/moose/pull/2872).
-- **LLM-friendly docs & endpoints** – Framework pages expose TS/Py “LLM view” links and the CLI now serves `/llm-ts.txt` + `/llm-py.txt` for assistants that need scoped context. [Docs: LLM docs](/moose/llm-docs) | PRs [#2892](https://github.com/514labs/moose/pull/2892).
-- **Flexible JSON columns** – `__mooseJsonOptions` lets models cap dynamic paths, pin typed paths, or skip keys/regexes so ingestion can accept evolving payloads without breaking typed reads. [Docs: Configurable JSON columns](/moose/data-modeling#configurable-json-columns) | PRs [#2887](https://github.com/514labs/moose/pull/2887).
-- **Configurable `source_dir`** – `moose.config.toml` can point at `src/` (or any folder) instead of the default `app/`, simplifying adoption inside existing repos. [Docs: Custom source directory](/moose/configuration#custom-source-directory) | PRs [#2886](https://github.com/514labs/moose/pull/2886).
-- **Array transforms can fan out events** – Transform functions that return arrays automatically emit one Kafka message per element, covering explode/normalize patterns without extra producers. [Docs: Array transforms](/moose/streaming/transform-functions#array-transforms) | PRs [#2882](https://github.com/514labs/moose/pull/2882).
-- **ClickHouse modeling controls** – Table DSL now covers TTL per table/column, `sampleByExpression`, and fully configurable secondary indexes (type, args, granularity) so you can encode retention + performance plans directly in code. [Docs: TTL](/moose/olap/ttl) • [Docs: Sample BY](/moose/olap/schema-optimization#sample-by-expressions) • [Docs: Secondary indexes](/moose/olap/indexes) | PRs [#2845](https://github.com/514labs/moose/pull/2845), [#2867](https://github.com/514labs/moose/pull/2867), [#2869](https://github.com/514labs/moose/pull/2869).
-- **`get_source` MCP tool** – AI assistants can resolve a Moose component (tables, APIs, streams) back to its source file for faster code navigation. [Docs: MCP get_source tool](/moose/mcp-dev-server#get_source) | PRs [#2848](https://github.com/514labs/moose/pull/2848).
-- **Google Analytics v4 connector** – Service-account authenticated connector streams GA4 reports and realtime metrics into Moose pipelines so marketing data lands without bespoke ETL. [Docs: Connector reference](https://registry.moosestack.com/connectors/google-analytics) | PRs [registry#121](https://github.com/514-labs/registry/pull/121).
-- **Connector registry APIs** – Public REST endpoints expose connector metadata, docs, schemas, and versions for catalogs or automation. [Docs: Registry API docs](https://registry.moosestack.com/docs/api) | PRs [registry#120](https://github.com/514-labs/registry/pull/120).
-- **Onboarding & docs polish** – Quickstart, auth, materialized view, and config guides now call out install checkpoints, nullable column behavior, and when to prefer `moose.config.toml` over Docker overrides. [Docs: Quickstart](/moose/getting-started/quickstart) | PRs [#2903](https://github.com/514labs/moose/pull/2903), [#2894](https://github.com/514labs/moose/pull/2894), [#2893](https://github.com/514labs/moose/pull/2893), [#2890](https://github.com/514labs/moose/pull/2890).
-- **Integer validation parity** – The ingest API enforces every ClickHouse integer range (Int8–UInt256) with clear errors, preventing silent overflows. [Docs: Ingest API](/moose/apis/ingest-api) | PRs [#2861](https://github.com/514labs/moose/pull/2861).
-- **MCP watcher stability** – The MCP server now waits for file-system changes to settle before responding so IDE bots always read consistent artifacts. [Docs: MCP server](/moose/mcp-dev-server) | PRs [#2884](https://github.com/514labs/moose/pull/2884).
-- **Release + schema compiler hardening** – Version detection ignores CI-only tags, and ClickHouse parsing handles ORDER BY around `PARTITION BY`, `TTL`, `SAMPLE BY`, and secondary indexes even when optional arguments are omitted. PRs [#2902](https://github.com/514labs/moose/pull/2902), [#2898](https://github.com/514labs/moose/pull/2898), [#2897](https://github.com/514labs/moose/pull/2897), [#2889](https://github.com/514labs/moose/pull/2889).
-- **Proxy request fidelity** – Consumption APIs now preserve headers/body metadata end-to-end, keeping auth tokens and content negotiation intact. PRs [#2881](https://github.com/514labs/moose/pull/2881).
+- **`moose migrate --clickhouse-url`** – Generate and apply migrations directly against hosted ClickHouse, ideal for OLAP-only or CI/CD workflows that run without the full Moose runtime. [Docs: Serverless ClickHouse migrations](/moose/migrate#serverless-deployments) | PRs [#2872](https://github.com/514-labs/moosestack/pull/2872).
+- **LLM-friendly docs & endpoints** – Framework pages expose TS/Py "LLM view" links and the CLI now serves `/llm-ts.txt` + `/llm-py.txt` for assistants that need scoped context. [Docs: LLM docs](/moose/llm-docs) | PRs [#2892](https://github.com/514-labs/moosestack/pull/2892).
+- **Flexible JSON columns** – `ClickHouseJson` lets models cap dynamic paths, pin typed paths, or skip keys/regexes so ingestion can accept evolving payloads without breaking typed reads. [Docs: Data modeling](/moose/data-modeling) | PRs [#2887](https://github.com/514-labs/moosestack/pull/2887).
+- **Configurable `source_dir`** – `moose.config.toml` can point at `src/` (or any folder) instead of the default `app/`, simplifying adoption inside existing repos. [Docs: Configuration](/moose/configuration) | PRs [#2886](https://github.com/514-labs/moosestack/pull/2886).
+- **Array transforms can fan out events** – Transform functions that return arrays automatically emit one Kafka message per element, covering explode/normalize patterns without extra producers. [Docs: Transform functions](/moose/streaming/transform-functions) | PRs [#2882](https://github.com/514-labs/moosestack/pull/2882).
+- **ClickHouse modeling controls** – Table DSL now covers TTL per table/column, `sampleByExpression`, and fully configurable secondary indexes (type, args, granularity) so you can encode retention + performance plans directly in code. [Docs: TTL](/moose/olap/ttl) • [Docs: Schema optimization](/moose/olap/schema-optimization) • [Docs: Secondary indexes](/moose/olap/indexes) | PRs [#2845](https://github.com/514-labs/moosestack/pull/2845), [#2867](https://github.com/514-labs/moosestack/pull/2867), [#2869](https://github.com/514-labs/moosestack/pull/2869).
+- **`get_source` MCP tool** – AI assistants can resolve a Moose component (tables, APIs, streams) back to its source file for faster code navigation. [Docs: MCP get_source tool](/moose/mcp-dev-server#get_source) | PRs [#2848](https://github.com/514-labs/moosestack/pull/2848).
+- **Google Analytics v4 connector** – Service-account authenticated connector streams GA4 reports and realtime metrics into Moose pipelines so marketing data lands without bespoke ETL. [Docs: Connector reference](https://registry.514.ai/connectors/google-analytics) | PRs [registry#121](https://github.com/514-labs/registry/pull/121).
+- **Connector registry APIs** – Public REST endpoints expose connector metadata, docs, schemas, and versions for catalogs or automation. [Docs: Registry API docs](https://registry.514.ai/docs/api) | PRs [registry#120](https://github.com/514-labs/registry/pull/120).
+- **Onboarding & docs polish** – Quickstart, auth, materialized view, and config guides now call out install checkpoints, nullable column behavior, and when to prefer `moose.config.toml` over Docker overrides. [Docs: Quickstart](/moose/getting-started/quickstart) | PRs [#2903](https://github.com/514-labs/moosestack/pull/2903), [#2894](https://github.com/514-labs/moosestack/pull/2894), [#2893](https://github.com/514-labs/moosestack/pull/2893), [#2890](https://github.com/514-labs/moosestack/pull/2890).
+- **Integer validation parity** – The ingest API enforces every ClickHouse integer range (Int8–UInt256) with clear errors, preventing silent overflows. [Docs: Ingest API](/moose/apis/ingest-api) | PRs [#2861](https://github.com/514-labs/moosestack/pull/2861).
+- **MCP watcher stability** – The MCP server now waits for file-system changes to settle before responding so IDE bots always read consistent artifacts. [Docs: MCP server](/moose/mcp-dev-server) | PRs [#2884](https://github.com/514-labs/moosestack/pull/2884).
+- **Release + schema compiler hardening** – Version detection ignores CI-only tags, and ClickHouse parsing handles ORDER BY around `PARTITION BY`, `TTL`, `SAMPLE BY`, and secondary indexes even when optional arguments are omitted. PRs [#2902](https://github.com/514-labs/moosestack/pull/2902), [#2898](https://github.com/514-labs/moosestack/pull/2898), [#2897](https://github.com/514-labs/moosestack/pull/2897), [#2889](https://github.com/514-labs/moosestack/pull/2889).
+- **Proxy request fidelity** – Consumption APIs now preserve headers/body metadata end-to-end, keeping auth tokens and content negotiation intact. PRs [#2881](https://github.com/514-labs/moosestack/pull/2881).
 
 ## Boreal
 


### PR DESCRIPTION
Fix links and hallucinations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refresh 2025-10-24 release notes: update JSON columns to `ClickHouseJson` with new example and fix repo/docs/registry links and paths.
> 
> - **Release notes (`apps/framework-docs/src/pages/release-notes/2025-10-24.mdx`)**:
>   - Replace `__mooseJsonOptions` with `ClickHouseJson`; add typed `UserMetadata` example and imports.
>   - Correct PR links from `514labs/moose` to `514-labs/moosestack`; update docs paths and titles.
>   - Update registry links to `registry.514.ai` and connector/docs URLs.
>   - Minor text tweaks (section titles, highlight bullet) to align with new type and link structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2f18b381035989d7b9249a63b71b8d4d3e3e88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->