### PR TITLE
add get_data_catalog to typescript-mcp template

### DIFF
--- a/templates/typescript-mcp/app/apis/mcp.ts
+++ b/templates/typescript-mcp/app/apis/mcp.ts
@@ -164,7 +164,7 @@ async function formatCatalogSummary(
   tables: Array<{ name: string; engine: string }>,
   materializedViews: Array<{ name: string; engine: string }>,
 ): Promise<string> {
-  let output = "# Commvault Data Catalog (Summary)\n\n";
+  let output = "# Data Catalog (Summary)\n\n";
 
   // Format tables
   if (tables.length > 0) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an MCP tool to list tables/materialized views and their schemas from ClickHouse, supporting filters and summary/detailed output.
> 
> - **MCP Server**:
>   - **New Tool**: `get_data_catalog` to enumerate ClickHouse `tables` and `materialized_views` with schema info.
>     - Inputs: `component_type`, `search` (regex), `format` (`summary`|`detailed`).
>     - Outputs: formatted catalog (text/JSON) and `structuredContent`.
> - **Data Catalog Utilities**:
>   - `getTableColumns` to fetch column metadata from `system.columns`.
>   - `getTablesAndMaterializedViews` to list components from `system.tables` with filtering and regex/substring fallback.
>   - Formatters: `formatCatalogSummary` and `formatCatalogDetailed`.
> - **Misc**:
>   - Import `sql` from `@514labs/moose-lib` to build queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58abafb3f1dedf4577fd36e91fb505bec522e029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->