### PR TITLE
add function to set cors headers consitently in local_webserver.rs

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -405,7 +405,7 @@ impl Default for LocalWebserverConfig {
 fn add_cors_headers(builder: hyper::http::response::Builder) -> hyper::http::response::Builder {
     builder
         .header("Access-Control-Allow-Origin", "*")
-        .header("Access-Control-Allow-Methods", "GET, POST")
+        .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         .header(
             "Access-Control-Allow-Headers",
             "Authorization, Content-Type, baggage, sentry-trace, traceparent, tracestate",
@@ -636,7 +636,6 @@ impl<I: InfraMapProvider + Clone + Send + 'static> Service<Request<Incoming>>
 fn options_route() -> Result<Response<Full<Bytes>>, hyper::http::Error> {
     let response = add_cors_headers(Response::builder())
         .status(StatusCode::OK)
-        .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         .body(Full::new(Bytes::from("Success")))
         .unwrap();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce add_cors_headers helper and apply it across consumption proxy, OPTIONS, and workflow endpoints to consistently set CORS (including OPTIONS).
> 
> - **Server (local_webserver.rs)**:
>   - **CORS**:
>     - Add `add_cors_headers` helper to standardize CORS headers (`Access-Control-Allow-*`).
>     - Apply to responses in `get_consumption_api_res` (including UNAUTHORIZED and proxied responses).
>     - Apply to `options_route` (explicitly supports `OPTIONS`).
>     - Apply to workflow endpoints: `workflows_history_route`, `workflows_trigger_route`, `workflows_terminate_route` for both success and error paths.
>     - Normalize allowed methods to `GET, POST, OPTIONS` where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 778dda9b5696be493e65639270faeafc5d2fb9f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->