### PR TITLE
increase grace period from 10 -> 30 seconds in prod

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -2584,7 +2584,7 @@ impl Webserver {
 
         // Use different timeouts for dev vs production:
         // - Dev: 2 seconds (balance between fast shutdown and allowing in-flight requests to complete)
-        // - Production: 10 seconds (allow load balancers time to drain connections during rolling deployments)
+        // - Production: 30 seconds (allow load balancers time to drain connections during rolling deployments)
         let shutdown_timeout = if project.is_production {
             std::time::Duration::from_secs(30)
         } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase production HTTP graceful shutdown timeout from 10s to 30s in `local_webserver.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29115d800afebfdbb70ff032ff62f2a5a14e02dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->