### PR TITLE
anthropic api key in env

### DIFF
--- a/templates/typescript-mcp/README.md
+++ b/templates/typescript-mcp/README.md
@@ -27,6 +27,9 @@ A Next.js web application with a pre-configured AI chat interface. This applicat
 
 ## Getting Started
 
+Note: You must set the ANTHROPIC_API_KEY environment variable for the chat
+feature to function.
+
 Install dependencies for both applications:
 
 ```bash
@@ -46,7 +49,7 @@ Or start services individually:
 pnpm dev:moose
 
 # Start only the Next.js web app
-pnpm dev:web
+pnpm dev:web # requires ANTHROPIC_API_KEY to be set in the environment
 ```
 
 ## MCP Tools Available

--- a/templates/typescript-mcp/template.config.toml
+++ b/templates/typescript-mcp/template.config.toml
@@ -21,6 +21,6 @@ https://boreal.cloud
 
 Or start services individually:
     $ pnpm dev:moose    # Start MooseStack service only
-    $ pnpm dev:web      # Start web app only
+    $ pnpm dev:web      # Start web app only; requires ANTHROPIC_API_KEY to be set in the environment
 """
 default_sloan_telemetry = "standard"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Document the requirement to set `ANTHROPIC_API_KEY` for the web app chat, updating README and post-install instructions.
> 
> - **Documentation**
>   - `templates/typescript-mcp/README.md`: Add note that `ANTHROPIC_API_KEY` must be set for the chat feature; annotate `pnpm dev:web` command to require the env var.
>   - `templates/typescript-mcp/template.config.toml`: Update post-install instructions to note `pnpm dev:web` requires `ANTHROPIC_API_KEY` in the environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb156d2f265c38df81b79f9413ad32bc2b4b4f77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->