### PR TITLE
set anthropic api key in typescript-mcp template

### DIFF
--- a/templates/typescript-mcp/README.md
+++ b/templates/typescript-mcp/README.md
@@ -33,6 +33,13 @@ Initiate your project:
 moose init <project-name> typescript-mcp
 ```
 
+Set the ANTHROPIC_API_KEY environment variable:
+
+```bash
+cd <project-name>
+echo "ANTHROPIC_API_KEY=your_api_key_here" >> packages/web-app/.env.local
+```
+
 Install dependencies for both applications:
 
 ```bash

--- a/templates/typescript-mcp/template.config.toml
+++ b/templates/typescript-mcp/template.config.toml
@@ -13,6 +13,9 @@ https://boreal.cloud
 📂 Go to your project directory:
     $ cd {project_dir}
 
+📦 Set Anthropic API Key
+    $ echo "ANTHROPIC_API_KEY=your_api_key_here" >> packages/web-app/.env.local
+
 📦 Install all dependencies:
     $ pnpm install
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Anthropic API key setup instructions to the TypeScript MCP template README and post-install message.
> 
> - **Docs (typescript-mcp template)**:
>   - Add setup step to set `ANTHROPIC_API_KEY` in `packages/web-app/.env.local`.
>   - Update instructions in `templates/typescript-mcp/README.md` and `templates/typescript-mcp/template.config.toml` post-install message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41aca356c9f6c095ae0bf345f376810b40077966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->