### PR TITLE
fix sample by parsing

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/sql_parser.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/sql_parser.rs
@@ -247,13 +247,9 @@ pub fn extract_sample_by_from_create_table(sql: &str) -> Option<String> {
     if let Some(i) = after_upper.find("PRIMARY KEY") {
         end = end.min(i);
     }
-    // Note: We search for keywords with leading space/newline to avoid matching substrings
+    // Note: Match " TTL" with leading space to avoid matching substrings
     // within identifiers (e.g., "cattle" contains "ttl")
-    // Check for both " TTL" and "\nTTL" to handle whitespace variations
     if let Some(i) = after_upper.find(" TTL") {
-        end = end.min(i);
-    }
-    if let Some(i) = after_upper.find("\nTTL") {
         end = end.min(i);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects SAMPLE BY extraction to terminate at TTL and avoids false matches in identifiers; adds targeted tests.
> 
> - **SQL parsing (ClickHouse)**:
>   - Update `extract_sample_by_from_create_table` to terminate at `TTL` (with leading space) when extracting `SAMPLE BY`, preventing capture of TTL expressions and avoiding substring matches in identifiers.
> - **Tests**:
>   - Add `test_extract_sample_by_with_ttl_single_line` to validate stopping at `TTL`.
>   - Add `test_extract_sample_by_with_identifier_containing_ttl` to ensure identifiers like `cattle_count` aren’t misinterpreted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 021ac8845fff1998d3d46a4785cfab0a7c9b37ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->