### PR TITLE
Update safe-chain-nix in flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764035635,
-        "narHash": "sha256-BQXF3dmdSY9k6fS82HdmYjAsrU+Y3o7rDK8rh9oYY6g=",
+        "lastModified": 1764107305,
+        "narHash": "sha256-WvQKJS+eizwFPJeTom9B2H2OVt/cneStYNvnTkXADL8=",
         "owner": "LucioFranco",
         "repo": "safe-chain-nix",
-        "rev": "b286fdec32d947cd1f25c37b4b3c4ecca6f796b2",
+        "rev": "c931beaa029241bf9010d76d68e47c20f4d3bcf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `safe-chain-nix` in `flake.lock` to `c931beaa` (updated rev, narHash, and timestamp).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0171a301bb797514d57893a0faffdba1c503337e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->