### PR TITLE
Disable otel

### DIFF
--- a/apps/framework-cli/src/cli/logger.rs
+++ b/apps/framework-cli/src/cli/logger.rs
@@ -594,15 +594,15 @@ fn setup_modern_format(
 
 fn setup_legacy_format(
     settings: &LoggerSettings,
-    session_id: &str,
-    machine_id: &str,
+    _session_id: &str,
+    _machine_id: &str,
     custom_fields: CustomFields,
 ) -> Result<(), LoggerError> {
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(settings.level.to_tracing_level().to_string()));
 
     // Setup with or without OTEL based on configuration
-    if let Some(endpoint) = &settings.export_to {
+    if let Some(_endpoint) = &settings.export_to {
         if settings.stdout {
             let legacy_layer = LegacyFormatLayer::new(
                 std::io::stdout,
@@ -625,7 +625,6 @@ fn setup_legacy_format(
             );
 
             tracing_subscriber::registry()
-                .with(otel_layer)
                 .with(env_filter)
                 .with(legacy_layer)
                 .init();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables OTEL integration for the legacy logging format and marks session/machine IDs unused.
> 
> - **Logger (`apps/framework-cli/src/cli/logger.rs`)**:
>   - **Legacy format**:
>     - Remove OTEL layer wiring even when `settings.export_to` is set (no `otel_layer` used).
>     - Mark `session_id` and `machine_id` parameters as unused (`_session_id`, `_machine_id`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c39bd4df84b14d9e407dbf6cf51e606a37b78bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->