### PR TITLE
Fix: Ignore operations are considered when creating a migration plan

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -1225,8 +1225,11 @@ pub async fn remote_gen_migration(
 
     plan_validator::validate(project, &plan)?;
 
-    let db_migration =
-        MigrationPlan::from_infra_plan(&plan.changes, &project.clickhouse_config.db_name)?;
+    let db_migration = MigrationPlan::from_infra_plan(
+        &plan.changes,
+        &project.clickhouse_config.db_name,
+        &project.migration_config.ignore_operations,
+    )?;
 
     Ok(MigrationPlanWithBeforeAfter {
         remote_state: remote_infra_map,

--- a/apps/framework-cli/src/framework/core/migration_plan.rs
+++ b/apps/framework-cli/src/framework/core/migration_plan.rs
@@ -24,6 +24,7 @@ impl MigrationPlan {
     pub fn from_infra_plan(
         infra_plan_changes: &InfraChanges,
         default_database: &str,
+        ignore_ops: &[crate::infrastructure::olap::clickhouse::IgnorableOperation],
     ) -> Result<Self, PlanOrderingError> {
         // Convert OLAP changes to atomic operations
         let (teardown_ops, setup_ops) =
@@ -35,18 +36,36 @@ impl MigrationPlan {
 
         // Add teardown operations first
         for op in teardown_ops {
-            operations.push(op.to_minimal());
+            let minimal_op = op.to_minimal();
+            // Filter out operations that should be ignored
+            if !Self::should_ignore_operation(&minimal_op, ignore_ops) {
+                operations.push(minimal_op);
+            }
         }
 
         // Add setup operations second
         for op in setup_ops {
-            operations.push(op.to_minimal());
+            let minimal_op = op.to_minimal();
+            // Filter out operations that should be ignored
+            if !Self::should_ignore_operation(&minimal_op, ignore_ops) {
+                operations.push(minimal_op);
+            }
         }
 
         Ok(MigrationPlan {
             created_at: Utc::now(),
             operations,
         })
+    }
+
+    /// Determines if an operation should be ignored based on the ignore operations list
+    fn should_ignore_operation(
+        operation: &SerializableOlapOperation,
+        ignore_ops: &[crate::infrastructure::olap::clickhouse::IgnorableOperation],
+    ) -> bool {
+        ignore_ops
+            .iter()
+            .any(|ignore_op| ignore_op.matches(operation))
     }
 
     /// Returns the total number of operations
@@ -95,4 +114,372 @@ pub struct MigrationPlanWithBeforeAfter {
     pub remote_state: InfrastructureMap,
     pub local_infra_map: InfrastructureMap,
     pub db_migration: MigrationPlan,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::framework::core::infrastructure::table::{Column, ColumnType, OrderBy, Table};
+    use crate::framework::core::infrastructure_map::{OlapChange, TableChange};
+    use crate::framework::core::infrastructure_map::{PrimitiveSignature, PrimitiveTypes};
+    use crate::framework::core::partial_infrastructure_map::LifeCycle;
+    use crate::framework::versions::Version;
+    use crate::infrastructure::olap::clickhouse::queries::ClickhouseEngine;
+    use crate::infrastructure::olap::clickhouse::IgnorableOperation;
+
+    fn create_test_table(name: &str) -> Table {
+        Table {
+            name: name.to_string(),
+            database: None,
+            cluster_name: None,
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: ColumnType::String,
+                    required: true,
+                    unique: false,
+                    primary_key: true,
+                    default: None,
+                    annotations: vec![],
+                    comment: None,
+                    ttl: None,
+                },
+                Column {
+                    name: "timestamp".to_string(),
+                    data_type: ColumnType::String,
+                    required: true,
+                    unique: false,
+                    primary_key: false,
+                    default: None,
+                    annotations: vec![],
+                    comment: None,
+                    ttl: None,
+                },
+            ],
+            order_by: OrderBy::Fields(vec!["id".to_string()]),
+            partition_by: None,
+            sample_by: None,
+            engine: ClickhouseEngine::MergeTree,
+            version: Some(Version::from_string("1.0.0".to_string())),
+            source_primitive: PrimitiveSignature {
+                name: "test".to_string(),
+                primitive_type: PrimitiveTypes::DataModel,
+            },
+            metadata: None,
+            life_cycle: LifeCycle::FullyManaged,
+            engine_params_hash: None,
+            table_settings: None,
+            indexes: vec![],
+            table_ttl_setting: None,
+            primary_key_expression: None,
+        }
+    }
+
+    #[test]
+    fn test_migration_plan_filters_ignored_table_ttl_operations() {
+        // Create a table change that includes a ModifyTableTtl operation
+        let table = create_test_table("test_table");
+        let table_change = TableChange::Updated {
+            name: "test_table".to_string(),
+            column_changes: vec![],
+            order_by_change: crate::framework::core::infrastructure_map::OrderByChange {
+                before: OrderBy::Fields(vec!["id".to_string()]),
+                after: OrderBy::Fields(vec!["id".to_string()]),
+            },
+            partition_by_change: crate::framework::core::infrastructure_map::PartitionByChange {
+                before: None,
+                after: None,
+            },
+            before: table.clone(),
+            after: table,
+        };
+
+        let infra_changes = InfraChanges {
+            olap_changes: vec![OlapChange::Table(table_change)],
+            processes_changes: vec![],
+            api_changes: vec![],
+            web_app_changes: vec![],
+            streaming_engine_changes: vec![],
+        };
+
+        // Test without ignore operations - should include all operations
+        let plan_without_ignore = MigrationPlan::from_infra_plan(
+            &infra_changes,
+            "test_db",
+            &[], // No ignore operations
+        )
+        .unwrap();
+
+        // Test with ModifyTableTtl ignored - should filter out TTL operations
+        let plan_with_ignore = MigrationPlan::from_infra_plan(
+            &infra_changes,
+            "test_db",
+            &[IgnorableOperation::ModifyTableTtl], // Ignore TTL operations
+        )
+        .unwrap();
+
+        // The plan with ignored operations should have fewer (or equal) operations
+        assert!(plan_with_ignore.operations.len() <= plan_without_ignore.operations.len());
+
+        // Check that no ModifyTableTtl operations remain in the filtered plan
+        for operation in &plan_with_ignore.operations {
+            assert!(
+                !matches!(operation, SerializableOlapOperation::ModifyTableTtl { .. }),
+                "ModifyTableTtl operation should have been filtered out"
+            );
+        }
+    }
+
+    #[test]
+    fn test_migration_plan_filters_ignored_column_ttl_operations() {
+        let before_column = Column {
+            name: "test_col".to_string(),
+            data_type: ColumnType::String,
+            required: true,
+            unique: false,
+            primary_key: false,
+            default: None,
+            annotations: vec![],
+            comment: None,
+            ttl: Some("timestamp + INTERVAL 7 DAY".to_string()),
+        };
+
+        let after_column = Column {
+            name: "test_col".to_string(),
+            data_type: ColumnType::String,
+            required: true,
+            unique: false,
+            primary_key: false,
+            default: None,
+            annotations: vec![],
+            comment: None,
+            ttl: Some("timestamp + INTERVAL 14 DAY".to_string()),
+        };
+
+        let table_change = TableChange::Updated {
+            name: "test_table".to_string(),
+            column_changes: vec![
+                crate::framework::core::infrastructure_map::ColumnChange::Updated {
+                    before: before_column,
+                    after: after_column,
+                },
+            ],
+            order_by_change: crate::framework::core::infrastructure_map::OrderByChange {
+                before: OrderBy::Fields(vec!["id".to_string()]),
+                after: OrderBy::Fields(vec!["id".to_string()]),
+            },
+            partition_by_change: crate::framework::core::infrastructure_map::PartitionByChange {
+                before: None,
+                after: None,
+            },
+            before: create_test_table("test_table"),
+            after: create_test_table("test_table"),
+        };
+
+        let infra_changes = InfraChanges {
+            olap_changes: vec![OlapChange::Table(table_change)],
+            processes_changes: vec![],
+            api_changes: vec![],
+            web_app_changes: vec![],
+            streaming_engine_changes: vec![],
+        };
+
+        // Test with ModifyColumnTtl ignored
+        let plan_with_ignore = MigrationPlan::from_infra_plan(
+            &infra_changes,
+            "test_db",
+            &[IgnorableOperation::ModifyColumnTtl],
+        )
+        .unwrap();
+
+        // Check that no column TTL operations remain
+        for operation in &plan_with_ignore.operations {
+            if let SerializableOlapOperation::ModifyTableColumn {
+                before_column,
+                after_column,
+                ..
+            } = operation
+            {
+                // If it's a ModifyTableColumn operation, it should not be a TTL-only change
+                assert_ne!(
+                    before_column.ttl, after_column.ttl,
+                    "TTL-only column changes should have been filtered out"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_migration_plan_filters_ignored_low_cardinality_operations() {
+        let before_column = Column {
+            name: "test_col".to_string(),
+            data_type: ColumnType::String,
+            required: true,
+            unique: false,
+            primary_key: false,
+            default: None,
+            annotations: vec![("LowCardinality".to_string(), serde_json::json!(true))],
+            comment: None,
+            ttl: None,
+        };
+
+        let after_column = Column {
+            name: "test_col".to_string(),
+            data_type: ColumnType::String,
+            required: true,
+            unique: false,
+            primary_key: false,
+            default: None,
+            annotations: vec![], // LowCardinality removed
+            comment: None,
+            ttl: None,
+        };
+
+        let table_change = TableChange::Updated {
+            name: "test_table".to_string(),
+            column_changes: vec![
+                crate::framework::core::infrastructure_map::ColumnChange::Updated {
+                    before: before_column,
+                    after: after_column,
+                },
+            ],
+            order_by_change: crate::framework::core::infrastructure_map::OrderByChange {
+                before: OrderBy::Fields(vec!["id".to_string()]),
+                after: OrderBy::Fields(vec!["id".to_string()]),
+            },
+            partition_by_change: crate::framework::core::infrastructure_map::PartitionByChange {
+                before: None,
+                after: None,
+            },
+            before: create_test_table("test_table"),
+            after: create_test_table("test_table"),
+        };
+
+        let infra_changes = InfraChanges {
+            olap_changes: vec![OlapChange::Table(table_change)],
+            processes_changes: vec![],
+            api_changes: vec![],
+            web_app_changes: vec![],
+            streaming_engine_changes: vec![],
+        };
+
+        // Test with IgnoreStringLowCardinalityDifferences
+        let plan_with_ignore = MigrationPlan::from_infra_plan(
+            &infra_changes,
+            "test_db",
+            &[IgnorableOperation::IgnoreStringLowCardinalityDifferences],
+        )
+        .unwrap();
+
+        // Check that no LowCardinality-only column operations remain
+        for operation in &plan_with_ignore.operations {
+            if let SerializableOlapOperation::ModifyTableColumn {
+                before_column,
+                after_column,
+                ..
+            } = operation
+            {
+                // Should not be a LowCardinality-only change
+                assert!(
+                    !IgnorableOperation::is_low_cardinality_only_change(
+                        before_column,
+                        after_column
+                    ),
+                    "LowCardinality-only changes should have been filtered out"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_migration_plan_filters_ignored_partition_operations() {
+        let mut before_table = create_test_table("test_table");
+        let mut after_table = create_test_table("test_table");
+
+        // Set different partition_by values to trigger drop+create
+        before_table.partition_by = None;
+        after_table.partition_by = Some("toYYYYMM(timestamp)".to_string());
+
+        let table_change = TableChange::Updated {
+            name: "test_table".to_string(),
+            column_changes: vec![],
+            order_by_change: crate::framework::core::infrastructure_map::OrderByChange {
+                before: before_table.order_by.clone(),
+                after: after_table.order_by.clone(),
+            },
+            partition_by_change: crate::framework::core::infrastructure_map::PartitionByChange {
+                before: before_table.partition_by.clone(),
+                after: after_table.partition_by.clone(),
+            },
+            before: before_table,
+            after: after_table,
+        };
+
+        let infra_changes = InfraChanges {
+            olap_changes: vec![OlapChange::Table(table_change)],
+            processes_changes: vec![],
+            api_changes: vec![],
+            web_app_changes: vec![],
+            streaming_engine_changes: vec![],
+        };
+
+        // Test without ignore operations - may include drop+create
+        let plan_without_ignore =
+            MigrationPlan::from_infra_plan(&infra_changes, "test_db", &[]).unwrap();
+
+        // Test with ModifyPartitionBy ignored - should filter drop+create for partition changes
+        let plan_with_ignore = MigrationPlan::from_infra_plan(
+            &infra_changes,
+            "test_db",
+            &[IgnorableOperation::ModifyPartitionBy],
+        )
+        .unwrap();
+
+        // The plan with ignored operations should have fewer (or equal) operations
+        assert!(plan_with_ignore.operations.len() <= plan_without_ignore.operations.len());
+    }
+
+    #[test]
+    fn test_should_ignore_operation() {
+        let ttl_op = SerializableOlapOperation::ModifyTableTtl {
+            table: "test_table".to_string(),
+            before: Some("timestamp + INTERVAL 30 DAY".to_string()),
+            after: Some("timestamp + INTERVAL 60 DAY".to_string()),
+            database: None,
+            cluster_name: None,
+        };
+
+        let column_op = SerializableOlapOperation::AddTableColumn {
+            table: "test_table".to_string(),
+            column: Column {
+                name: "new_col".to_string(),
+                data_type: ColumnType::String,
+                required: false,
+                unique: false,
+                primary_key: false,
+                default: None,
+                annotations: vec![],
+                comment: None,
+                ttl: None,
+            },
+            after_column: None,
+            database: None,
+            cluster_name: None,
+        };
+
+        // Test with ModifyTableTtl ignored
+        assert!(MigrationPlan::should_ignore_operation(
+            &ttl_op,
+            &[IgnorableOperation::ModifyTableTtl]
+        ));
+
+        assert!(!MigrationPlan::should_ignore_operation(
+            &column_op,
+            &[IgnorableOperation::ModifyTableTtl]
+        ));
+
+        // Test with no ignore operations
+        assert!(!MigrationPlan::should_ignore_operation(&ttl_op, &[]));
+        assert!(!MigrationPlan::should_ignore_operation(&column_op, &[]));
+    }
 }


### PR DESCRIPTION
## Summary

- Fix bug where ignore operations weren't considered during migration plan generation
- Update column comparison logic to respect ignore operations configuration
- Add test coverage for ignore operations functionality

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migration plan generation now filters out configured ignore operations, with expanded ClickHouse matching logic and comprehensive tests.
> 
> - **Core (Migration Plan)**
>   - Extend `MigrationPlan::from_infra_plan` to accept `ignore_ops` and filter `SerializableOlapOperation`s via `should_ignore_operation`.
>   - Add `should_ignore_operation` helper.
> - **CLI**
>   - Pass `project.migration_config.ignore_operations` when creating migration plans in `remote_gen_migration`.
> - **ClickHouse (IgnorableOperation)**
>   - Enhance `IgnorableOperation::matches` to handle `ModifyColumnTtl`, partition changes (`DropTable`/`CreateTable`), and LowCardinality-only diffs.
>   - Add `is_low_cardinality_only_change` helper.
> - **Tests**
>   - Add extensive unit tests validating filtering of TTL, partition, and LowCardinality-only operations and `IgnorableOperation` matching behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e885795e0593a0a6ff24f67a5b9c01395346195. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->