### PR TITLE
Feature: new ignore operation: LowCardinality(String) vs String

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -652,7 +652,12 @@ pub async fn start_development_mode(
 
                     let changed = externally_managed.iter().any(|t| {
                         if let Some(remote_table) = tables.get(&t.name) {
-                            !compute_table_columns_diff(t, remote_table, &[]).is_empty()
+                            !compute_table_columns_diff(
+                                t,
+                                remote_table,
+                                &project.migration_config.ignore_operations,
+                            )
+                            .is_empty()
                                 || !remote_table.order_by_equals(t)
                                 || t.engine != remote_table.engine
                         } else {

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -1997,7 +1997,8 @@ impl InfrastructureMap {
                             table.name
                         );
                         // Record the blocked update in filtered_changes for user visibility
-                        let column_changes = compute_table_columns_diff(table, target_table, ignore_ops);
+                        let column_changes =
+                            compute_table_columns_diff(table, target_table, ignore_ops);
                         let order_by_change = OrderByChange {
                             before: table.order_by.clone(),
                             after: target_table.order_by.clone(),
@@ -3501,10 +3502,16 @@ fn columns_are_equivalent(
         ignore_ops.contains(&IgnorableOperation::IgnoreStringLowCardinalityDifferences);
 
     // Normalize columns if ignore flag is set
-    let normalized_before =
+    let mut normalized_before =
         normalize_column_for_low_cardinality_ignore(before, ignore_low_cardinality);
-    let normalized_after =
+    let mut normalized_after =
         normalize_column_for_low_cardinality_ignore(after, ignore_low_cardinality);
+
+    // If ModifyColumnTtl is ignored, treat both TTL values as equal by nulling them out
+    if ignore_ops.contains(&IgnorableOperation::ModifyColumnTtl) {
+        normalized_before.ttl = None;
+        normalized_after.ttl = None;
+    }
 
     // Check all non-data_type and non-ttl fields first
     if normalized_before.name != normalized_after.name
@@ -3619,6 +3626,8 @@ fn workflows_config_equal(a: &Workflow, b: &Workflow) -> bool {
 /// # Arguments
 /// * `before` - The original table
 /// * `after` - The modified table
+/// * `ignore_ops` - Operations to ignore during comparison (e.g., `IgnoreStringLowCardinalityDifferences`).
+///   Pass an empty slice to detect all differences.
 ///
 /// # Returns
 /// A vector of `ColumnChange` objects describing the differences
@@ -4851,7 +4860,7 @@ mod diff_tests {
             materialized: None,
         });
 
-        let diff = compute_table_columns_diff(&before, &after);
+        let diff = compute_table_columns_diff(&before, &after, &[]);
         assert_eq!(diff.len(), 1, "Expected one change for DEFAULT removal");
         match &diff[0] {
             ColumnChange::Updated {
@@ -6018,7 +6027,11 @@ mod diff_tests {
             materialized: None,
             ..base_col.clone()
         };
-        assert!(!columns_are_equivalent(&col_with_mat, &col_without_mat, &[]));
+        assert!(!columns_are_equivalent(
+            &col_with_mat,
+            &col_without_mat,
+            &[]
+        ));
     }
 
     #[test]
@@ -7346,7 +7359,6 @@ mod diff_orchestration_worker_tests {
         assert!(removed_found, "Python worker removal not detected");
         assert!(added_found, "Typescript worker addition not detected");
     }
-
 
     #[test]
     fn test_mask_credentials_for_json_export() {

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/diff_strategy.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/diff_strategy.rs
@@ -225,8 +225,8 @@ pub fn nested_are_equivalent(
 
         // Recursively compare data types
         if !column_types_are_equivalent(
-            &actual_col.data_type,
-            &target_col.data_type,
+            &normalized_actual.data_type,
+            &normalized_target.data_type,
             ignore_low_cardinality,
         ) {
             return false;
@@ -335,10 +335,12 @@ pub fn normalize_column_for_low_cardinality_ignore(
     }
 
     let mut normalized = column.clone();
-    // Strip LowCardinality annotations
-    normalized
-        .annotations
-        .retain(|(key, _)| key != "LowCardinality");
+    // Strip LowCardinality annotations (only for String-typed columns)
+    if normalized.data_type == ColumnType::String {
+        normalized
+            .annotations
+            .retain(|(key, _)| key != "LowCardinality");
+    }
     normalized
 }
 
@@ -2836,7 +2838,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_types_are_equivalent_with_ignore_low_cardinality_disabled() {
+    fn test_column_types_are_equivalent_basic_types() {
         use crate::framework::core::infrastructure::table::{ColumnType, IntType};
 
         let string_type = ColumnType::String;
@@ -2851,7 +2853,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_types_are_equivalent_with_ignore_low_cardinality_enabled() {
+    fn test_column_types_are_equivalent_basic_types_with_flag_enabled() {
         use crate::framework::core::infrastructure::table::{ColumnType, IntType};
 
         let string_type = ColumnType::String;

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -330,12 +330,14 @@ pub fn normalize_table_for_diff(table: &Table, ignore_ops: &[IgnorableOperation]
         }
     }
 
-    // Strip LowCardinality annotations if ignored
+    // Strip LowCardinality annotations if ignored (only for String-typed columns)
     if ignore_ops.contains(&IgnorableOperation::IgnoreStringLowCardinalityDifferences) {
         for column in &mut normalized.columns {
-            column
-                .annotations
-                .retain(|(key, _)| key != "LowCardinality");
+            if column.data_type == ColumnType::String {
+                column
+                    .annotations
+                    .retain(|(key, _)| key != "LowCardinality");
+            }
         }
     }
 

--- a/apps/framework-docs-v2/content/moosestack/configuration/migrations.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/migrations.mdx
@@ -11,9 +11,18 @@ Control how Moose handles database migrations and schema changes.
 ```toml filename="moose.config.toml"
 [migration_config]
 # Operations to ignore during migration plan generation and drift detection
-# ignore_operations = ["ModifyTableTtl", "ModifyColumnTtl"]
+# ignore_operations = ["ModifyTableTtl", "ModifyColumnTtl", "ModifyPartitionBy", "IgnoreStringLowCardinalityDifferences"]
 ```
 
 | Key | Env Variable | Default | Description |
 |:----|:-------------|:--------|:------------|
 | `ignore_operations` | `MOOSE_MIGRATION_CONFIG__IGNORE_OPERATIONS` | [] | List of migration operations to ignore during plan generation. |
+
+## Available Operations
+
+| Operation | Description |
+|:----------|:------------|
+| `ModifyTableTtl` | Ignore changes to table-level TTL settings. |
+| `ModifyColumnTtl` | Ignore changes to column-level TTL settings. |
+| `ModifyPartitionBy` | Ignore changes to partition key expressions. |
+| `IgnoreStringLowCardinalityDifferences` | Treat `LowCardinality(String)` and `String` as equivalent during schema comparison. Useful when ClickHouse automatically applies `LowCardinality` to string columns. |


### PR DESCRIPTION
## Summary

- Add support for ignoring LowCardinality differences in column comparisons
- Enhance column equivalence logic to handle IgnoreStringLowCardinalityDifferences flag
- Add comprehensive test coverage for LowCardinality normalization functionality

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an ignorable operation to treat LowCardinality(String) and String as equivalent during diffs, wiring it through comparisons/normalization and adding comprehensive tests.
> 
> - **Core Diffing/Infra Map**:
>   - Extend `compute_table_columns_diff` and `columns_are_equivalent` to accept `ignore_ops`, honoring `IgnoreStringLowCardinalityDifferences`.
>   - Use ClickHouse-aware type comparison with low-cardinality normalization.
>   - Update simple diff helpers and call sites to pass `&[]` default.
> - **ClickHouse Diff Strategy**:
>   - Add `ignore_low_cardinality` to `column_types_are_equivalent`, `json_options_are_equivalent`, and `nested_are_equivalent`.
>   - Introduce `normalize_column_for_low_cardinality_ignore` to strip `LowCardinality` annotations when ignoring.
> - **ClickHouse Mod (execution/normalization)**:
>   - Add `IgnorableOperation::IgnoreStringLowCardinalityDifferences` and handle it in `normalize_table_for_diff` to strip `LowCardinality` annotations.
> - **CLI**:
>   - Update external table change detection to use new `compute_table_columns_diff(.., &[])`.
> - **Tests**:
>   - Add extensive unit/integration tests covering low-cardinality ignore behavior across columns, nested/JSON types, normalization, and table-level diffs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0109f4ec005eca0f0f891bd0ffdd15e0e02af59d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->