### PR TITLE
Clean up hash-token output (closes PMM-686)

### DIFF
--- a/apps/framework-cli/src/cli/routines/auth.rs
+++ b/apps/framework-cli/src/cli/routines/auth.rs
@@ -28,7 +28,7 @@ pub fn generate_hash_token() {
         show_message!(
             MessageType::Info,
             Message {
-                action: "ENV API Keys".to_string(),
+                action: "ENV API Key".to_string(),
                 details: hex::encode(key1),
             }
         );

--- a/apps/framework-docs-v2/content/moosestack/apis/auth.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/auth.mdx
@@ -38,7 +38,7 @@ moose generate hash-token
 
 **Output:**
 
-- **ENV API Keys**: Hashed key for environment variables (use this in your server configuration)
+- **ENV API Key**: Hashed key for environment variables (use this in your server configuration)
 - **Bearer Token**: Plain-text token for client applications (use this in `Authorization` headers)
 
 <Callout type="info">

--- a/apps/framework-docs/src/pages/moose/apis/auth.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/auth.mdx
@@ -36,7 +36,7 @@ moose generate hash-token
 
 **Output:**
 
-- **ENV API Keys**: Hashed key for environment variables (use this in your server configuration)
+- **ENV API Key**: Hashed key for environment variables (use this in your server configuration)
 - **Bearer Token**: Plain-text token for client applications (use this in `Authorization` headers)
 
 <Callout type="info">
@@ -275,4 +275,3 @@ moose remote plan
 <Callout type="warning">
   Never commit plain-text tokens to version control. Use hashed keys in configuration files and environment variables for production.
 </Callout>
-


### PR DESCRIPTION
Remove verbose descriptions from generate hash-token output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies hash-token CLI output to concise ENV API Key and Bearer Token values, and updates auth docs to match.
> 
> - **CLI**:
>   - Streamlines `generate_hash_token` output in `apps/framework-cli/src/cli/routines/auth.rs`:
>     - Changes action to `ENV API Key` and outputs only the hex-encoded hash.
>     - `Bearer Token` now outputs only the token string.
> - **Docs**:
>   - Updates `apps/framework-docs/src/pages/moose/apis/auth.mdx` and `apps/framework-docs-v2/content/moosestack/apis/auth.mdx` to use singular `ENV API Key` and reflect simplified CLI output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 031c7d3a95f4df55cc36017d5230295d24804ccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->