### PR TITLE
ENG-1633: update-days-for pypi versions

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -736,7 +736,7 @@ jobs:
       - name: Clean up PyPI and only keep the latest 80 days of moose CLI and lib
         run: |
           expect << EOF
-          spawn pypi-cleanup -u 514 -p moose-cli -d 80 -r ".*" --do-it --yes
+          spawn pypi-cleanup -u 514 -p moose-cli -d 60 -r ".*" --do-it --yes
           expect {
             "Authentication code:" {
               send "$PYPI_OTP\r"


### PR DESCRIPTION
**ENG-1633: reduced number of days old versions are kept in pypi**
we hit our limits again for the total storage in pypi.
as such, we need to reduce the number of days that we
store artifacts so that there is room for new artifacts.

our request at pypi for additional storage has been updated
with our latest woes:
https://github.com/pypi/support/issues/7991

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers moose-cli PyPI retention from 80 to 60 days in the release workflow cleanup step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f01aa3d7119cc090079a012aa9bf7276f8144f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->