### PR TITLE
ENG-1633: cleanup-pypi throws errors

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -735,11 +735,11 @@ jobs:
 
       - name: Clean up PyPI and only keep the latest 80 days of moose CLI and lib
         run: |
-          expect << EOF
-          spawn pypi-cleanup -u 514 -p moose-cli -d 60 -r ".*" --do-it --yes
+          expect << 'EOF'
+          spawn pypi-cleanup -u 514 -p moose-cli -d 80 -r ".*" --do-it --yes
           expect {
             "Authentication code:" {
-              send "$PYPI_OTP\r"
+              send "$env(PYPI_OTP)\r"
               exp_continue
             }
             "No releases were found" {
@@ -747,19 +747,35 @@ jobs:
             }
             eof
           }
+
+          # Check exit status
+          catch wait result
+          set exit_code [lindex $result 3]
+          if {$exit_code != 0} {
+            puts "ERROR: pypi-cleanup for moose-cli failed with exit code $exit_code"
+            exit $exit_code
+          }
           EOF
 
-          expect << EOF
+          expect << 'EOF'
           spawn pypi-cleanup -u 514 -p moose-lib -d 100 -r ".*" --do-it --yes
           expect {
             "Authentication code:" {
-              send "$PYPI_OTP\r"
+              send "$env(PYPI_OTP)\r"
               exp_continue
             }
             "No releases were found" {
               # Nothing to do, this is fine
             }
             eof
+          }
+
+          # Check exit status
+          catch wait result
+          set exit_code [lindex $result 3]
+          if {$exit_code != 0} {
+            puts "ERROR: pypi-cleanup for moose-lib failed with exit code $exit_code"
+            exit $exit_code
           }
           EOF
 


### PR DESCRIPTION
**ENG-1633: cleanup-pypi throws errors when it encounters them**
this step was previously failing silently, leading me to believe that
publishing was failing due to not having space... when in-fact if we
were cleaning up appropriately, we may have space for new artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make PyPI cleanup fail on errors, fix OTP handling in Expect, and change moose-cli retention to 80 days.
> 
> - **CI Workflow (`.github/workflows/release-cli.yaml`)**:
>   - **PyPI cleanup job**:
>     - Update `pypi-cleanup` for `moose-cli` to keep last `80` days (was `60`).
>     - Use single-quoted heredocs (`'EOF'`) and reference OTP via `send "$env(PYPI_OTP)\r"` within Expect.
>     - Add exit-code checks after each `pypi-cleanup` run for `moose-cli` and `moose-lib`, emitting errors and failing the step when non-zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a852b1cbf4584ae804a5b0df7c4eb8185593740f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->