### PR TITLE
ENG-1633: update-error-message-for-failed pypi cleanup

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -735,8 +735,13 @@ jobs:
 
       - name: Clean up PyPI and only keep the latest 80 days of moose CLI and lib
         run: |
-          expect << 'EOF'
-          spawn pypi-cleanup -u 514 -p moose-cli -d 80 -r ".*" --do-it --yes
+          # Function to run pypi-cleanup with error handling
+          cleanup_package() {
+            local package_name=$1
+            local days=$2
+
+            expect << EOF
+          spawn pypi-cleanup -u 514 -p ${package_name} -d ${days} -r ".*" --do-it --yes
           expect {
             "Authentication code:" {
               send "$env(PYPI_OTP)\r"
@@ -752,32 +757,22 @@ jobs:
           catch wait result
           set exit_code [lindex $result 3]
           if {$exit_code != 0} {
-            puts "ERROR: pypi-cleanup for moose-cli failed with exit code $exit_code"
-            exit $exit_code
+            puts "ERROR: pypi-cleanup for ${package_name} failed with exit code $exit_code"
+            puts ""
+            puts "This is most likely due to PyPI device authentication."
+            puts "Please check your email for a message from noreply@pypi.org"
+            puts "with the subject line 'Unrecognized login to your PyPI account'."
+            puts "Click the confirmation link in that email to authorize this device."
+            puts ""
+            puts "For more details, see: https://pypi.org/help/#utfkey"
+            exit \$exit_code
           }
           EOF
-
-          expect << 'EOF'
-          spawn pypi-cleanup -u 514 -p moose-lib -d 100 -r ".*" --do-it --yes
-          expect {
-            "Authentication code:" {
-              send "$env(PYPI_OTP)\r"
-              exp_continue
-            }
-            "No releases were found" {
-              # Nothing to do, this is fine
-            }
-            eof
           }
 
-          # Check exit status
-          catch wait result
-          set exit_code [lindex $result 3]
-          if {$exit_code != 0} {
-            puts "ERROR: pypi-cleanup for moose-lib failed with exit code $exit_code"
-            exit $exit_code
-          }
-          EOF
+          # Clean up both packages
+          cleanup_package "moose-cli" 80
+          cleanup_package "moose-lib" 80
 
         env:
           PYPI_CLEANUP_PASSWORD: ${{ steps.op-load-secret.outputs.PYPI_CLEANUP_PASSWORD }}


### PR DESCRIPTION
**ENG-1633: updated cleanup-pypi step with instructions on resolving its failures**
fixing this was a pain in the rear.
as such, instructions! so that the next rear is safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the PyPI cleanup workflow into a reusable function, adds detailed failure guidance, and standardizes retention to 80 days for both moose-cli and moose-lib.
> 
> - **GitHub Actions (`.github/workflows/release-cli.yaml`)**:
>   - **PyPI cleanup step**:
>     - Refactor into `cleanup_package` function using `expect` to DRY repeated blocks.
>     - Enhance error output with device authentication instructions and help link.
>     - Run for both `moose-cli` and `moose-lib` via function calls.
>     - Standardize retention to 80 days for `moose-lib` (was 100).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed6d803744a13b48fd9ef0290bcfc4488d7f14ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->