### PR TITLE
ENG-1633: fix error

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -707,7 +707,7 @@ jobs:
     name: Cleanup PyPI
     runs-on: ubuntu-latest
     # Only run for release builds (main branch), not CI builds
-    if: ${{ !inputs.dry-run && needs.version.outputs.is_ci_build == 'false' }}
+    # if: ${{ !inputs.dry-run && needs.version.outputs.is_ci_build == 'false' }}
     needs:
       - version
     # Add explicit permissions
@@ -743,6 +743,10 @@ jobs:
             expect << EOF
           spawn pypi-cleanup -u 514 -p ${package_name} -d ${days} -r ".*" --do-it --yes
           expect {
+            "Password:" {
+              send "\$env(PYPI_CLEANUP_PASSWORD)\r"
+              exp_continue
+            }
             "Authentication code:" {
               send "\$env(PYPI_OTP)\r"
               exp_continue


### PR DESCRIPTION
**ENG-1633: these escapes were necessary**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts PyPI cleanup workflow to properly handle password/OTP prompts and escapes, and comments out the job run condition.
> 
> - **GitHub Actions (`.github/workflows/release-cli.yaml`)**:
>   - **PyPI cleanup job `cleanup-pypi`**:
>     - Comment out the `if` condition that limited runs to release builds.
>     - Update `expect` script in cleanup step:
>       - Add handling for `"Password:"` prompt using `PYPI_CLEANUP_PASSWORD`.
>       - Correctly escape env variable references (e.g., `\$env(...)`) and result indexing in Tcl.
>       - Ensure non-zero exit handling reports the proper exit code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e471ea289742a0c9940cfb392e9b5616df31571b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->