### PR TITLE
ENG-1478 - fix: requiring .npmrc in pnpm builds

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -121,7 +121,7 @@ WORKDIR /monorepo
 # Copy workspace configuration files
 COPY pnpm-workspace.yaml ./
 COPY package.json ./
-COPY .npmrc ./
+COPY .npmr[c] ./
 {}
 
 # Copy workspace package directories (will be replaced with actual patterns)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure the generated monorepo Dockerfile copies `.npmrc` into the build context to support pnpm installs.
> 
> - **CLI Docker packager**:
>   - Update monorepo TypeScript Dockerfile template to copy `.npmrc` (`COPY .npmr[c] ./`) alongside `pnpm-workspace.yaml` and `package.json` for proper pnpm behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94dc42194d609224636172f1904ee412e951936f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->