### PR TITLE
Spread Object Level lifecycle

### DIFF
--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -257,8 +257,11 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
       const streamConfig = {
         destination: undefined,
         ...(typeof config.deadLetterQueue === "object" ?
-          config.deadLetterQueue
-        : {}),
+          {
+            ...config.deadLetterQueue,
+            lifeCycle: config.deadLetterQueue.lifeCycle ?? config.lifeCycle,
+          }
+        : { lifeCycle: config.lifeCycle }),
         ...(config.version && { version: config.version }),
       };
       this.deadLetterQueue = new DeadLetterQueue<T>(


### PR DESCRIPTION
Previously this format was failing to propagate lifecycle to table
```export const SomePipeline = new IngestPipeline<SomeType>("FooPipeline", {
    table: {
        engine: ClickHouseEngines.MergeTree,
        orderByFields: ['session']
    },
    stream: true,
    ingestApi: true,
    version: "0.0",
    lifeCycle: LifeCycle.DELETION_PROTECTED
});

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates top-level `lifeCycle` to `table`, `stream`, and `deadLetterQueue` when not explicitly set, and adds tests covering propagation and overrides.
> 
> - **SDK (`packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts`)**:
>   - Propagate top-level `lifeCycle` to component configs when omitted:
>     - `table`: set `lifeCycle` to `config.table.lifeCycle ?? config.lifeCycle` for object configs; include `lifeCycle` when `table: true`.
>     - `stream`: set `lifeCycle` to `config.stream.lifeCycle ?? config.lifeCycle` for object configs; include `lifeCycle` when `stream: true`.
>     - `deadLetterQueue`: set `lifeCycle` to `config.deadLetterQueue.lifeCycle ?? config.lifeCycle` for object configs; include `lifeCycle` when `deadLetterQueue: true`.
> - **Tests (`packages/ts-moose-lib/tests/ingestPipeline-lifecycle.test.ts`)**:
>   - Add comprehensive tests verifying `lifeCycle` propagation, per-component overrides, boolean config cases, and absence when unspecified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ad6022466cc1a3b0204960695952a500cba8cce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->