### PR TITLE
Add ability to disable deep healthcheck

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -856,8 +856,8 @@ async fn health_route(
         });
     }
 
-    // Spawn Consumption API check (if enabled)
-    if project.features.apis {
+    // Spawn Consumption API check (if enabled and not disabled by env var)
+    if project.features.apis && !*MOOSE_DISABLE_CONSUMPTION_HEALTHCHECK {
         let consumption_api_port = project.http_server_config.proxy_port;
         join_set.spawn(async move {
             let health_url = format!(
@@ -1469,6 +1469,10 @@ fn get_env_var(s: &str) -> Option<String> {
 lazy_static! {
     static ref MOOSE_CONSUMPTION_API_KEY: Option<String> = get_env_var("MOOSE_CONSUMPTION_API_KEY");
     static ref MOOSE_INGEST_API_KEY: Option<String> = get_env_var("MOOSE_INGEST_API_KEY");
+    static ref MOOSE_DISABLE_CONSUMPTION_HEALTHCHECK: bool =
+        get_env_var("MOOSE_DISABLE_CONSUMPTION_HEALTHCHECK")
+            .map(|v| v.to_lowercase() == "true" || v == "1")
+            .unwrap_or(false);
 }
 
 async fn check_authorization(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `MOOSE_DISABLE_CONSUMPTION_HEALTHCHECK` to optionally skip the Consumption API health check and updates the health route to honor it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1788ce8fe67afcdd616103c86b332995d5740304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->