### PR TITLE
ENG-1678: fail-cleanup-pypi-step-but continue pipeline

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -708,6 +708,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for release builds (main branch), not CI builds
     # if: ${{ !inputs.dry-run && needs.version.outputs.is_ci_build == 'false' }}
+    continue-on-error: true
     needs:
       - version
     # Add explicit permissions
@@ -735,6 +736,10 @@ jobs:
 
       - name: Clean up PyPI and only keep the latest 80 days of moose CLI and lib
         run: |
+          # Disable set -e so we can continue even if one package cleanup fails
+          set +e
+          ERROR_CODE=0
+
           # Function to run pypi-cleanup with error handling
           cleanup_package() {
             local package_name=$1
@@ -772,11 +777,27 @@ jobs:
             exit \$exit_code
           }
           EOF
+            local exit_code=$?
+            if [ $exit_code -ne 0 ]; then
+              echo "::error::pypi-cleanup for ${package_name} failed with exit code $exit_code"
+              echo ""
+              echo "This is most likely due to PyPI device authentication."
+              echo "Please check your email for a message from noreply@pypi.org"
+              echo "with the subject line 'Unrecognized login to your PyPI account'."
+              echo "Click the confirmation link in that email to authorize this device."
+              echo "For more details, see: https://pypi.org/help/#utfkey"
+              ERROR_CODE=1
+            fi
           }
 
-          # Clean up both packages
+          # Clean up both packages (both will run even if first fails)
           cleanup_package "moose-cli" 80
           cleanup_package "moose-lib" 80
+
+          # Fail the step if any error occurred
+          if [ $ERROR_CODE -eq 1 ]; then
+            exit 1
+          fi
 
         env:
           PYPI_CLEANUP_PASSWORD: ${{ steps.op-load-secret.outputs.PYPI_CLEANUP_PASSWORD }}


### PR DESCRIPTION
**ENG-1678: the cleaup-pypi step should be allowed to fail, but continue the pipeline**
due to a change in pypi auth, devices must be authenticated to perform actions.
since this job runs in GHA, the machine is non deterministic and the IPs tend to change.

this makes the step unrealiable in automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `release-cli` workflow to mark `cleanup-pypi` as continue-on-error and add guarded cleanup logic that attempts both packages, surfaces failures, and guides on PyPI device auth.
> 
> - **CI Workflow (`.github/workflows/release-cli.yaml`)**:
>   - **`cleanup-pypi` job**:
>     - Set `continue-on-error: true` so pipeline continues if cleanup fails.
>     - Wrap `pypi-cleanup` in `expect` with exit-code capture; aggregate errors via `ERROR_CODE`.
>     - Attempt cleanup for both `moose-cli` and `moose-lib` regardless of the first failure.
>     - Add detailed failure logs with guidance related to PyPI device authentication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa81ae082f2adf258f654f4fb3d3e09871cd419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->