### PR TITLE
fix: respect table.database field in Kafka-to-ClickHouse sync

### DIFF
--- a/apps/framework-cli/src/infrastructure/processes/mod.rs
+++ b/apps/framework-cli/src/infrastructure/processes/mod.rs
@@ -71,6 +71,7 @@ pub async fn execute_changes(
                     source_kafka_topic.name.clone(),
                     source_topic.columns.clone(),
                     target_table.name.clone(),
+                    target_table.database.clone(),
                     target_table_columns,
                     metrics.clone(),
                 );
@@ -97,6 +98,7 @@ pub async fn execute_changes(
                     after_kafka_source_topic.name.clone(),
                     after_source_topic.columns.clone(),
                     after_target_table.name.clone(),
+                    after_target_table.database.clone(),
                     target_table_columns,
                     metrics.clone(),
                 );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Wires an optional target database through sync → inserter → client so inserts hit the specified DB, adds insert query builder, and updates tests/logging.
> 
> - **ClickHouse client/inserter**:
>   - `ClickHouseClient::insert` and `ClickHouseClientTrait::insert` now accept `database: Option<&str>` and default to config DB when `None`.
>   - Add `build_insert_query(database, table, columns)` and use it for INSERT construction.
>   - `Inserter` stores optional `database` and passes it to client on flush; constructor updated.
> - **Kafka→ClickHouse sync**:
>   - `start_topic_to_table`, `spawn_sync_process_core`, and `sync_kafka_to_clickhouse` accept `target_database: Option<String>` and forward it to `Inserter`.
>   - Log start message includes database when provided.
> - **Process registry**:
>   - Passes `target_table.database` to `start_topic_to_table` for sync processes.
> - **Tests**:
>   - Add tests for `build_insert_query` formatting and for `Inserter` passing `database` (both default and custom).
>   - Ensure `query_param` includes `database` when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 219a6ef4c0e04737c707176f475378e004627fcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->