### PR TITLE
add black formatter for python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Multi-language monorepo (Rust CLI + TypeScript/Python libraries) using PNPM work
 
 ### Python
 - **Style**: Follow PEP 8; snake_case for functions/vars, PascalCase for classes, UPPER_SNAKE_CASE for constants
+- **Formatting**: Black (line-length 88); auto-formats on commit (Husky + lint-staged)
+- **Format manually**: `black <file_or_directory>`
 - **Types**: Use type hints for function signatures and public APIs
 - **Tests**: Use pytest with fixtures and parametrize decorators
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "lint-staged": {
     "*.rs": "rustfmt --edition 2021",
     "**/*.{ts,tsx,js,jsx,json,md}": "prettier --write",
+    "*.py": "black",
     "!**/*.hbs": "echo 'Skipping Handlebars template files'"
   }
 }

--- a/packages/py-moose-lib/requirements-dev.txt
+++ b/packages/py-moose-lib/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest>=7.0.0
 pytest-cov>=4.0.0
 sqlglot[rs]>=27.16.3
+black>=24.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+# Black configuration for Python code formatting
+# This applies to all Python files in the monorepo
+
+[tool.black]
+line-length = 88
+target-version = ["py312"]
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+    # Standard excludes
+    \.eggs
+    | \.git
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+    | __pycache__
+    # Project specific excludes
+    | node_modules
+    | target
+    | \.turbo
+)/
+'''


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce Black for Python with repo-wide configuration, pre-commit formatting via lint-staged, and updated docs.
> 
> - **Tooling**:
>   - Add repo-wide Black config in `pyproject.toml` (line-length 88, `py312`, excludes).
>   - Integrate Black into pre-commit via `lint-staged` in `package.json` (`*.py: black`).
>   - Add `black>=24.0.0` to `packages/py-moose-lib/requirements-dev.txt`.
> - **Docs**:
>   - Update `AGENTS.md` Python guidelines with Black usage and manual format command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d3a5e05ba5281dbf2dbf00cf057c8e4c6b206c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->