### PR TITLE
setup dependabot for rust-toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Rust toolchain version (rust-toolchain.toml)
+  # This replaces the custom rust-update.yaml workflow
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "rust"
+      - "toolchain"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Dependabot config to auto-update rust-toolchain weekly from repo root with 1 open PR limit and rust/toolchain labels.
> 
> - **CI / Dependabot**:
>   - Add `.github/dependabot.yml` to enable weekly `rust-toolchain` updates from `/`, limit to 1 open PR, and apply `rust` and `toolchain` labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4e919abe509ec7cbd3864862331628f02dba313. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->