### PR TITLE
fix: fixing the prompt in case of externally managed tables

### DIFF
--- a/apps/framework-cli/src/cli/routines/code_generation.rs
+++ b/apps/framework-cli/src/cli/routines/code_generation.rs
@@ -25,7 +25,7 @@ pub fn prompt_user_for_remote_ch_http() -> Result<String, RoutineFailure> {
     let base = prompt_user(
         "Enter ClickHouse host and port",
         None,
-        Some("Format: https://your-service-id.region.clickhouse.cloud:8443\n  🔗 Get your URL: https://clickhouse.cloud/\n  📖 Troubleshooting: https://docs.fiveonefour.com/moose/getting-started/from-clickhouse#troubleshooting")
+        Some("Format: https://your-instance.boreal.cloud:8443\n  🔗 Get your URL: https://boreal.cloud/\n  📖 Troubleshooting: https://docs.fiveonefour.com/moose/getting-started/from-clickhouse#troubleshooting")
     )?.trim_end_matches('/').trim_start_matches("https://").to_string();
     let user = prompt_user("Enter username", Some("default"), None)?;
     let pass = prompt_user("Enter password", None, None)?;

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -119,10 +119,11 @@ pub const MIGRATION_BEFORE_STATE_FILE: &str = "./migrations/remote_state.json";
 pub const MIGRATION_AFTER_STATE_FILE: &str = "./migrations/local_infra_map.json";
 
 pub const STORE_CRED_PROMPT: &str = r#"You have externally managed tables in your code base.
-Ensure your code is up to date with `moose pull`.
+Ensure your code is up to date with `moose db pull`.
 You can also configure `moose dev` to automatically check each time you start the dev server,
 so you're not developing with out-of-date data models/schemas.
 
-In order to set this up we will need:
-1. The production URL of your moose deployment
-2. The Admin authentication token"#;
+In order to set this up we will need your ClickHouse connection details:
+1. Host and port (e.g., from Boreal)
+2. Username and password
+3. Database name"#;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refresh CLI prompts to reference Boreal ClickHouse URLs, switch guidance to `moose db pull`, and explicitly request ClickHouse host:port, credentials, and database.
> 
> - **CLI Prompts**:
>   - Update `prompt_user_for_remote_ch_http` help text to Boreal format (`https://your-instance.boreal.cloud:8443`) with new links.
> - **Config/Constants**:
>   - Revise `STORE_CRED_PROMPT` to instruct `moose db pull` and enumerate required ClickHouse details: host:port, username/password, database.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8150d90ea06f38781bc8ce868b812f302831980. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->