### PR TITLE
Hide Deploy button on template cards behind feature flag

### DIFF
--- a/apps/framework-docs-v2/FLAGS_README.md
+++ b/apps/framework-docs-v2/FLAGS_README.md
@@ -25,6 +25,7 @@
 - `show-guides-section` - Controls Guides tab visibility (default: off)
 - `show-ai-section` - Controls AI tab visibility (default: off)
 - `show-data-sources-page` - Controls Data sources page visibility in navigation (default: off)
+- `show-template-deploy-button` - Show Deploy button on template cards; only turn on once Boreal template deploy is functional (default: off)
 
 ## How It Works
 

--- a/apps/framework-docs-v2/src/components/mdx/template-card.tsx
+++ b/apps/framework-docs-v2/src/components/mdx/template-card.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
+import posthog from "posthog-js";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -53,6 +54,9 @@ export function TemplateCard({ item, className }: TemplateCardProps) {
   const template = isTemplate ? (item as TemplateMetadata) : null;
   const app = !isTemplate ? (item as AppMetadata) : null;
   const [chipsExpanded, setChipsExpanded] = React.useState(false);
+  const showDeployButton = posthog.isFeatureEnabled?.(
+    "show-template-deploy-button",
+  );
 
   const categoryLabels = {
     starter: "Starter",
@@ -157,14 +161,16 @@ export function TemplateCard({ item, className }: TemplateCardProps) {
       </CardContent>
       <CardFooter className="flex flex-col gap-2 w-full">
         <div className="flex w-full items-center justify-start gap-2 mt-auto">
-          <Button variant="default" asChild>
-            <Link
-              href={`https://moose.dev/deploy?template=${isTemplate ? template!.slug : app!.slug}`}
-            >
-              <IconRocket className="h-4 w-4" />
-              Deploy
-            </Link>
-          </Button>
+          {showDeployButton && (
+            <Button variant="default" asChild>
+              <Link
+                href={`https://moose.dev/deploy?template=${isTemplate ? template!.slug : app!.slug}`}
+              >
+                <IconRocket className="h-4 w-4" />
+                Deploy
+              </Link>
+            </Button>
+          )}
           {!isTemplate && app && app.blogPost && (
             <Button variant="outline" size="icon" asChild>
               <Link


### PR DESCRIPTION
## Summary
* Hides the Deploy button on template cards behind a PostHog feature flag (`show-template-deploy-button`)
* The button currently links to a non-functional URL (404), so it should remain hidden until Boreal template deploy is functional
* Default behavior: button is hidden (flag defaults to off)

## Changes
* Added PostHog feature flag check in `template-card.tsx`
* Documented the new flag in `FLAGS_README.md`

## Test plan
- [x] Verify button is hidden by default when flag is off/not set
- [x] Verify button appears when `show-template-deploy-button` flag is enabled in PostHog

Closes ENG-1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide the Deploy button on template cards behind the `show-template-deploy-button` PostHog flag and document the flag.
> 
> - Conditionally render the Deploy button in `src/components/mdx/template-card.tsx` using `posthog.isFeatureEnabled('show-template-deploy-button')`
> - Document new `show-template-deploy-button` flag in `FLAGS_README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4099fd93abe6af11f01fabe6bd2809c36024ce35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Adds a PostHog feature flag check to conditionally hide the Deploy button on template cards, preventing access to a non-functional URL.</li>

<li>Modifies import statements and component rendering logic to ensure the button only appears when the feature flag is enabled.</li>

<li>Overall, the changes enhance user experience by preventing confusion from an inactive button, touching import statements and component rendering logic.</li>

</ul>

</div>