### PR TITLE
feat(seed): show row count in seed command output (closes PMM-832)

### DIFF
--- a/apps/framework-cli/src/cli/routines/seed_data.rs
+++ b/apps/framework-cli/src/cli/routines/seed_data.rs
@@ -479,7 +479,7 @@ pub async fn handle_seed_command(
             Ok(RoutineSuccess::success(Message::new(
                 "Seeded".to_string(),
                 format!(
-                    "Seeded '{}' from '{}'\n{}\n\nVerify exact counts with:\n  moose query \"SELECT name AS table, total_rows FROM system.tables WHERE database = currentDatabase() ORDER BY total_rows DESC\"",
+                    "Seeded '{}' from '{}'\n{}\n\nVerify row counts with:\n  moose query \"SELECT name AS table, sum(rows) AS total_rows FROM system.parts WHERE database = currentDatabase() AND active = 1 GROUP BY name ORDER BY total_rows DESC\"",
                     local_db_name,
                     remote_db_name,
                     summary.join("\n")


### PR DESCRIPTION
Display the number of rows copied for each table when running `moose seed clickhouse`, giving users visibility into what was seeded.

Note: The row count reflects the expected rows based on batch limits, not a post-insert verification query against the local table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the CLI feedback after seeding by guiding users to validate results.
> 
> - Updates final `Seeded` message in `seed_data.rs` to include a `moose query` command that reports per-table total rows from `system.parts`
> - No functional changes to seeding logic; output text only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6816901bab5ce23c7a312ff8ff410173c8907506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Updates the output message of the seed command to display the number of rows copied from the remote source for each table.</li>

<li>Modifies the output message in seed_data.rs to instruct users to verify row counts using an improved query that aggregates rows with sum(rows) instead of showing exact counts.</li>

<li>Updates the message to reflect expected row counts based on batch limits rather than post-insert verification.</li>

<li>Improves user feedback by clearly indicating the progress of the seeding process.</li>

<li>Does not affect the underlying seeding logic.</li>

<li>Overall, enhances the seed command by refining CLI feedback and message format to provide more informative output, fostering a better user experience while keeping the underlying seeding logic intact.</li>

</ul>

</div>