### PR TITLE
feat(docs): add query search params to templates search

### DIFF
--- a/apps/framework-docs-v2/src/app/templates/templates-side-nav.tsx
+++ b/apps/framework-docs-v2/src/app/templates/templates-side-nav.tsx
@@ -44,9 +44,13 @@ export function TemplatesSideNav() {
           c === "starter" || c === "framework" || c === "example",
       );
   }, [searchParams]);
+  const searchQuery = searchParams.get("q") || "";
 
   const hasActiveFilters =
-    typeFilter !== null || languageFilter !== null || categoryFilter.length > 0;
+    typeFilter !== null ||
+    languageFilter !== null ||
+    categoryFilter.length > 0 ||
+    searchQuery.trim() !== "";
 
   // Update URL params when filters change
   const updateFilters = React.useCallback(
@@ -54,6 +58,7 @@ export function TemplatesSideNav() {
       type?: TypeFilter;
       language?: LanguageFilter;
       category?: CategoryFilter;
+      q?: string;
     }) => {
       const params = new URLSearchParams(searchParams.toString());
 
@@ -81,13 +86,21 @@ export function TemplatesSideNav() {
         }
       }
 
+      if (updates.q !== undefined) {
+        if (updates.q === "") {
+          params.delete("q");
+        } else {
+          params.set("q", updates.q);
+        }
+      }
+
       router.push(`${pathname}?${params.toString()}`);
     },
     [router, pathname, searchParams],
   );
 
   const clearFilters = () => {
-    updateFilters({ type: null, language: null, category: [] });
+    updateFilters({ type: null, language: null, category: [], q: "" });
   };
 
   return (


### PR DESCRIPTION
- Sync search query to URL using 'q' param
- Initialize search input from URL on page load
- Support browser back/forward navigation
- Debounce URL updates (300ms) for better UX
- Clear 'q' param in sidebar's Clear Filters action

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements URL-synced search for templates with debounced updates and integrated clearing.
> 
> - TemplateGrid: initialize from `q`, debounce updates to URL (300ms), keep input state in sync with back/forward, clear `q` immediately, and push without scrolling
> - TemplatesSideNav: treat `q` as an active filter, include `q` in `updateFilters`, and reset `q` in `clearFilters`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b25a8e5cc21660dfd9dae66f944bd474d2050515. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Introduces a new feature that syncs the search query with the URL by using a 'q' parameter.</li>

<li>Refines the filter logic in the templates side navigation.</li>

<li>Adds support for debouncing and immediate clearing of the query parameter in the template grid, handling input state and URL updates efficiently.</li>

<li>Overall summary: Introduces enhancements to search functionality in templates side navigation and template grid, adding URL synchronization with 'q' parameter, debouncing, and query clearing for a more responsive and intuitive search experience.</li>

</ul>

</div>