### PR TITLE
Add workflow push event demo

### DIFF
--- a/templates/typescript/app/workflows/generator.ts
+++ b/templates/typescript/app/workflows/generator.ts
@@ -12,8 +12,32 @@ interface FooWorkflow {
 // Create OLAP Table
 const workflowTable = new OlapTable<FooWorkflow>("FooWorkflow");
 
-export const ingest = new Task<null, void>("ingest", {
+// onComplete task that runs after ingest finishes
+// Demonstrates how to schedule follow-up actions when a workflow task completes
+const notifyComplete = new Task<number, void>("notifyComplete", {
+  run: async ({ input }) => {
+    console.log(
+      `✅ Workflow completed! Successfully ingested ${input} records`,
+    );
+
+    // This is where you can trigger any post-completion actions:
+    // - Send a webhook notification to an external service
+    // - Post an event to trigger another workflow
+    // - Update a status dashboard
+    // - Send alerts or notifications
+    // - Example:
+    //   await fetch("https://your-webhook-endpoint.com/workflow-complete", {
+    //     method: "POST",
+    //     body: JSON.stringify({ recordsIngested: input, timestamp: Date.now() })
+    //   });
+  },
+  retries: 2,
+  timeout: "10s",
+});
+
+export const ingest = new Task<null, number>("ingest", {
   run: async () => {
+    let recordCount = 0;
     for (let i = 0; i < 1000; i++) {
       const foo: Foo = {
         primaryKey: faker.string.uuid(),
@@ -40,6 +64,8 @@ export const ingest = new Task<null, void>("ingest", {
           workflowTable.insert([
             { id: "1", success: false, message: response.statusText },
           ]);
+        } else {
+          recordCount++;
         }
       } catch (error) {
         console.log(`Error ingesting record ${i}: ${error}`);
@@ -57,7 +83,9 @@ export const ingest = new Task<null, void>("ingest", {
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
     }
+    return recordCount;
   },
+  onComplete: [notifyComplete],
   retries: 3,
   timeout: "30s",
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a completion hook and success-count reporting to the generator workflow.
> 
> - Adds `notifyComplete` task (retries: 2, timeout: 10s) to run on `ingest` completion, logging the total ingested count and serving as a placeholder for webhooks/alerts
> - Changes `ingest` to return `number` (previously `void`), tracking `recordCount` for successful responses and wiring `onComplete: [notifyComplete]`
> - Preserves OLAP logging of failures/progress in `FooWorkflow` table; no changes to workflow configuration aside from the new completion hook
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3048135459a34d11ef97085c1f49ff799ffc2c45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request modifies the 'ingest' task to return the count of successfully ingested records, improving tracking of ingestion success.</li>

<li>Introduces a new 'notifyComplete' task to log the total ingested count and can trigger follow-up actions.</li>

<li>Minor updates to the lockfile ensure compatibility across different platforms.</li>

<li>Overall, this pull request enhances the ingestion workflow, introduces new logging capabilities, and updates the lockfile for compatibility.</li>

</ul>

</div>