### PR TITLE
Passthrough URL Search Params

### DIFF
--- a/packages/ts-moose-lib/src/consumption-apis/runner.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/runner.ts
@@ -204,7 +204,7 @@ const apiHandler = async (
       const queryClient = new QueryClient(clickhouseClient, fileName);
       let result =
         isDmv2 ?
-          await userFuncModule(paramsObject, {
+          await userFuncModule(url.searchParams, {
             client: new MooseClient(queryClient, temporalClient),
             sql: sql,
             jwt: jwtPayload,

--- a/packages/ts-moose-lib/src/consumption-apis/typiaValidation.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/typiaValidation.ts
@@ -350,6 +350,8 @@ const transformNewApi = (
   const handlerFunc = node.arguments[1];
 
   // Create a new handler function that includes validation
+  // params is typed as 'any' because it receives URLSearchParams from runner.ts
+  // but the Api constructor expects (params: T, ...) - the type conversion happens via typia
   const wrappedHandler = factory.createArrowFunction(
     undefined,
     undefined,
@@ -359,7 +361,7 @@ const transformNewApi = (
         undefined,
         factory.createIdentifier("params"),
         undefined,
-        undefined,
+        factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
         undefined,
       ),
       factory.createParameterDeclaration(
@@ -367,7 +369,7 @@ const transformNewApi = (
         undefined,
         factory.createIdentifier("utils"),
         undefined,
-        undefined,
+        factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
         undefined,
       ),
     ],

--- a/packages/ts-moose-lib/src/consumption-apis/typiaValidation.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/typiaValidation.ts
@@ -400,31 +400,8 @@ const transformNewApi = (
             ts.NodeFlags.Const,
           ),
         ),
-        // const searchParams = new URLSearchParams(params as any)
-        factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createIdentifier("searchParams"),
-                undefined,
-                undefined,
-                factory.createNewExpression(
-                  factory.createIdentifier("URLSearchParams"),
-                  undefined,
-                  [
-                    factory.createAsExpression(
-                      factory.createIdentifier("params"),
-                      factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-            ts.NodeFlags.Const,
-          ),
-        ),
-        // const processedParams = assertGuard(searchParams)
+        // const processedParams = assertGuard(params)
+        // params is already URLSearchParams passed from runner.ts
         factory.createVariableStatement(
           undefined,
           factory.createVariableDeclarationList(
@@ -436,7 +413,7 @@ const transformNewApi = (
                 factory.createCallExpression(
                   factory.createIdentifier("assertGuard"),
                   undefined,
-                  [factory.createIdentifier("searchParams")],
+                  [factory.createIdentifier("params")],
                 ),
               ),
             ],


### PR DESCRIPTION
Summary

  Fixes a bug where array query parameters (e.g., ?fields=a&fields=b) were incorrectly joined into a single comma-separated string ("a,b") instead of being parsed as an array (["a", "b"]).

  Problem

  When passing repeated query parameters to consumption APIs, the values were silently corrupted:

  curl '/api/example?fields=a&fields=b'
  # Expected: { fields: ["a", "b"] }
  # Actual:   { fields: ["a,b"] }  ← Bug: one element with comma

  This caused:
  - Silent data corruption for string[] params
  - Validation failures for enum arrays ("name,email" is not a valid enum)
  - Parse errors for number[] params ("1,2,3" can't parse as number)

  Root Cause

  The data flow had a redundant conversion that lost array information:

  URL: ?fields=a&fields=b
          ↓
  runner.ts: { fields: ["a", "b"] }           ✅ Correct
          ↓
  typiaValidation.ts: new URLSearchParams({fields: ["a","b"]})
          ↓
  URLSearchParams calls .toString() on arrays → "a,b"   ❌ Bug
          ↓
  typia validates: sees ["a,b"] instead of ["a", "b"]   ❌

  Solution

  Pass the original URLSearchParams directly to typia, skipping the redundant reconstruction:

  URL: ?fields=a&fields=b
          ↓
  url.searchParams (native URLSearchParams)   ✅
          ↓
  typia.http.createAssertQuery<T>()           ✅ Uses getAll() internally
          ↓
  Returns typed { fields: ["a", "b"] }        ✅

  Changes

  - runner.ts: Pass url.searchParams directly for dmv2 APIs instead of parsed object
  - typiaValidation.ts: Remove URLSearchParams reconstruction, use assertGuard(params) directly

  What This Unlocks

  Array query parameters now work correctly:
  - ?status=active&status=pending → status: ["active", "pending"]
  - ?ids=1&ids=2&ids=3 → ids: [1, 2, 3] (with type coercion)
  - ?fields=name&fields=email → fields: ("name" | "email")[]

  Test Plan

  # String array
  curl '/api/test?fields=a&fields=b'
  # Returns: { fields: ["a", "b"], fieldCount: 2 }

  # Enum array  
  curl '/api/test?fields=name&fields=email'
  # Returns: { fields: ["name", "email"] }  (no validation error)

  # Number array with type coercion
  curl '/api/test?ids=1&ids=2&ids=3'
  # Returns: { ids: [1, 2, 3], sum: 6 }