### PR TITLE
ENG-1184: fix `moose peek` to look up tables/topics correctly

### DIFF
--- a/apps/framework-cli/src/cli/routines/peek.rs
+++ b/apps/framework-cli/src/cli/routines/peek.rs
@@ -348,7 +348,10 @@ mod tests {
         }
     }
 
-    fn create_test_topic(name: &str, version: Option<crate::framework::versions::Version>) -> Topic {
+    fn create_test_topic(
+        name: &str,
+        version: Option<crate::framework::versions::Version>,
+    ) -> Topic {
         Topic {
             name: name.to_string(),
             version,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes resource resolution and query building in `peek`.
> 
> - Resolve `tables`/`topics` by their `name` (case-insensitive) via `find_table_by_name` and `find_topic_by_name` instead of map keys
> - Error messages now include the requested name and a list of available resources when not found
> - ClickHouse SELECT uses a table's explicit `database` when provided, otherwise falls back to project default
> - Adds unit tests for lookups and database selection behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6f52f3adb6b99cf440b33e56b573794cea167ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->