### PR TITLE
chore: pin all templates to moose 0.6.309 and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,29 @@ updates:
     labels:
       - "rust"
       - "toolchain"
+
+  # =============================================================================
+  # Templates - Monitor all dependencies using glob patterns
+  # =============================================================================
+
+  # TypeScript templates (any package.json in templates/)
+  - package-ecosystem: "npm"
+    directories:
+      - "/templates/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "templates"
+      - "dependencies"
+
+  # Python templates (any requirements.txt in templates/)
+  - package-ecosystem: "pip"
+    directories:
+      - "/templates/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "templates"
+      - "dependencies"

--- a/templates/ads-b-frontend/moose/package.json
+++ b/templates/ads-b-frontend/moose/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/ads-b/package.json
+++ b/templates/ads-b/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/brainwaves/apps/brainmoose/package.json
+++ b/templates/brainwaves/apps/brainmoose/package.json
@@ -7,14 +7,14 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "axios": "^1.7.9",
     "dotenv": "^16.4.5",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/github-dev-trends/apps/moose-backend/package.json
+++ b/templates/github-dev-trends/apps/moose-backend/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "@octokit/rest": "^21.1.1",
     "axios": "^1.7.7",
     "dotenv": "^16.4.7",
@@ -16,7 +16,7 @@
     "moose-objects": "workspace:*"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12",
     "@octokit/types": "^14.1.0"
   },

--- a/templates/github-dev-trends/packages/moose-objects/package.json
+++ b/templates/github-dev-trends/packages/moose-objects/package.json
@@ -13,7 +13,7 @@
     "ts-patch": "^3.3.0"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "typia": "^9.6.1"
   }
 }

--- a/templates/live-heartrate-leaderboard/requirements.txt
+++ b/templates/live-heartrate-leaderboard/requirements.txt
@@ -5,5 +5,5 @@ python-dateutil>=2.8.2
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests>=2.31.0
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309

--- a/templates/live-heartrate-leaderboard/setup.py
+++ b/templates/live-heartrate-leaderboard/setup.py
@@ -7,8 +7,8 @@ setup(
         "kafka-python-ng==2.2.2",
         "clickhouse_connect==0.7.16",
         "requests==2.32.4",
-        "moose-cli==0.4.100",
-        "moose-lib==0.4.100",
+        "moose-cli==0.6.309",
+        "moose-lib==0.6.309",
         "streamlit>=1.32.0",
     ],
 )

--- a/templates/next-app-empty/moose/package.json
+++ b/templates/next-app-empty/moose/package.json
@@ -7,13 +7,13 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "@514labs/moose-cli": "latest"
+    "@514labs/moose-cli": "0.6.309"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/python-cluster/requirements.txt
+++ b/templates/python-cluster/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309
 faker
 sqlglot[rs]>=27.16.3

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,5 +1,5 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309

--- a/templates/python-experimental/requirements.txt
+++ b/templates/python-experimental/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309
 faker
 sqlglot[rs]>=27.16.3

--- a/templates/python-fastapi-client-only/requirements.txt
+++ b/templates/python-fastapi-client-only/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309
 faker
 fastapi[standard]

--- a/templates/python-fastapi/requirements.txt
+++ b/templates/python-fastapi/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309
 faker
 fastapi[standard]

--- a/templates/python-tests/requirements.txt
+++ b/templates/python-tests/requirements.txt
@@ -1,8 +1,8 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309
 faker
 sqlglot[rs]>=27.16.3
 fastapi[standard]

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli
-moose-lib
+moose-cli==0.6.309
+moose-lib==0.6.309
 faker
 sqlglot[rs]>=27.16.3

--- a/templates/typescript-cluster/package.json
+++ b/templates/typescript-cluster/package.json
@@ -8,7 +8,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"

--- a/templates/typescript-empty/package.json
+++ b/templates/typescript-empty/package.json
@@ -10,11 +10,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "axios": "^1.7.7",
     "express": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -15,7 +15,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/express": "^5.0.3",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"

--- a/templates/typescript-fastify/package.json
+++ b/templates/typescript-fastify/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "axios": "^1.7.7",
     "fastify": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -15,7 +15,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },

--- a/templates/typescript-mcp/packages/moosestack-service/package.json
+++ b/templates/typescript-mcp/packages/moosestack-service/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "@514labs/express-pbkdf2-api-key-auth": "^1.0.4",
     "@cfworker/json-schema": "4.1.1",
     "@modelcontextprotocol/sdk": "1.24.2",
@@ -18,7 +18,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/express": "^5.0.3",
     "@types/node": "^20.12.12"
   }

--- a/templates/typescript-migrate-test/migration/package.json
+++ b/templates/typescript-migrate-test/migration/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-migrate-test/package.json
+++ b/templates/typescript-migrate-test/package.json
@@ -10,11 +10,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-tests/package.json
+++ b/templates/typescript-tests/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "@koa/router": "^13.1.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.7",
@@ -22,7 +22,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@faker-js/faker": "^9.7.0",
     "@types/express": "^5.0.3",
     "@types/koa": "^2.15.0",

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -10,14 +10,14 @@
     "generate-runtime": "tspc app/index.ts"
   },
   "dependencies": {
-    "@514labs/moose-lib": "latest",
+    "@514labs/moose-lib": "0.6.309",
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "latest",
+    "@514labs/moose-cli": "0.6.309",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },


### PR DESCRIPTION
Pin all template moose-lib and moose-cli dependencies to version 0.6.309 to decouple template releases from moose releases. This ensures users get predictable, tested version combinations when running moose init.

Configure Dependabot to monitor moose package versions in all template directories using glob patterns (/templates/**) on a weekly basis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes template dependency versions and sets up automated updates.
> 
> - Pin `@514labs/moose-lib` and `@514labs/moose-cli` to `0.6.309` across all TypeScript `package.json` files and Python `requirements.txt`/`setup.py` in `templates/`
> - Add `.github/dependabot.yml` to monitor `rust-toolchain`, and all template `npm`/`pip` dependencies using `directories: /templates/**` on a weekly schedule
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d11bc4b56492fe91021c1dfc1ed5b710e0b3fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->