### PR TITLE
group moose-cli and moose-lib PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
+      - "typescript"
       - "templates"
       - "dependencies"
+    groups:
+      moose:
+        patterns:
+          - "@514labs/moose-cli"
+          - "@514labs/moose-lib"
 
   # Python templates (any requirements.txt in templates/)
   - package-ecosystem: "pip"
@@ -34,5 +40,11 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
+      - "python"
       - "templates"
       - "dependencies"
+    groups:
+      moose:
+        patterns:
+          - "moose-cli"
+          - "moose-lib"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configures Dependabot for template packages to streamline updates.
> 
> - Adds `groups.moose` for both `npm` and `pip` templates to batch `@514labs/moose-cli`/`@514labs/moose-lib` and `moose-cli`/`moose-lib` updates
> - Adds language labels (`typescript`, `python`) to corresponding template ecosystems
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ba22c44c947a3972dddbe90dfaa24520bfeebfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->