### PR TITLE
skip release workflow for dependabot PRs

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   version:
     concurrency: release
-    if: ${{ ! contains(github.event.head_commit.message , '[no-release]') && ! startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+    if: ${{ ! contains(github.event.head_commit.message , '[no-release]') && ! startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: "write"


### PR DESCRIPTION
this means PRs created by dependabot will not create CI builds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Adds `github.actor != 'dependabot[bot]'` to `jobs.version.if` in `.github/workflows/release-cli.yaml`, skipping versioning/release steps on Dependabot pushes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c960a452e419ad47b8fb5eca3b9c8589973517dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->