### PR TITLE
boreal section on mcp template

### DIFF
--- a/templates/typescript-mcp/template.config.toml
+++ b/templates/typescript-mcp/template.config.toml
@@ -47,8 +47,8 @@ short_description = "Deploy an AI chat app that can query your data"
 [[boreal.setup_commands]]
 command = "moose generate hash-token --json"
 outputs = [
-  { env_var = "MOOSE_AUTHENTICATION__ADMIN_API_KEY", json_path = "api_key_hash" },
-  { env_var = "MOOSE_ADMIN_TOKEN", json_path = "bearer_token" }
+  { env_var = "MCP_API_KEY", json_path = "api_key_hash" },
+  { env_var = "MCP_API_TOKEN", json_path = "bearer_token" }
 ]
 
 # Env vars user must provide


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Boreal one-click deploy config to the TypeScript MCP template.
> 
> - **Enable Boreal deploy** via new `[boreal]` section with `enabled = true`, `display_name`, and `short_description` in `templates/typescript-mcp/template.config.toml`
> - **Automated setup**: adds `[[boreal.setup_commands]]` running `moose generate hash-token --json`, mapping outputs to `MCP_API_KEY` and `MCP_API_TOKEN`
> - **Required env var**: declares `[[boreal.env_vars]]` for `ANTHROPIC_API_KEY` (secret, required)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ce987220b166717fe823ea8d3c0dfb86a35553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->