### PR TITLE
chore: attempt at fixing typo for the docs

### DIFF
--- a/apps/framework-docs-v2/src/app/(docs)/[...slug]/page.tsx
+++ b/apps/framework-docs-v2/src/app/(docs)/[...slug]/page.tsx
@@ -128,7 +128,7 @@ export default async function DocPage({ params, searchParams }: PageProps) {
             />
           )}
         </div>
-        <article className="prose prose-slate dark:prose-invert max-w-none w-full min-w-0">
+        <article className="prose prose-base md:prose-lg dark:prose-invert w-full">
           {content.isMDX ?
             <MDXRenderer source={content.content} />
           : <div dangerouslySetInnerHTML={{ __html: content.content }} />}

--- a/apps/framework-docs-v2/src/app/(docs)/guides/[...slug]/page.tsx
+++ b/apps/framework-docs-v2/src/app/(docs)/guides/[...slug]/page.tsx
@@ -165,7 +165,7 @@ export default async function GuidePage({ params, searchParams }: PageProps) {
               />
             )}
           </div>
-          <article className="prose prose-slate dark:prose-invert max-w-none w-full min-w-0">
+          <article className="prose prose-base md:prose-lg dark:prose-invert w-full">
             {content.isMDX ?
               <MDXRenderer source={content.content} />
             : <div dangerouslySetInnerHTML={{ __html: content.content }} />}
@@ -256,7 +256,7 @@ export default async function GuidePage({ params, searchParams }: PageProps) {
             />
           )}
         </div>
-        <article className="prose prose-slate dark:prose-invert max-w-none w-full min-w-0">
+        <article className="prose prose-base md:prose-lg dark:prose-invert w-full">
           {content.isMDX ?
             <MDXRenderer source={content.content} />
           : <div dangerouslySetInnerHTML={{ __html: content.content }} />}

--- a/apps/framework-docs-v2/src/app/templates/page.tsx
+++ b/apps/framework-docs-v2/src/app/templates/page.tsx
@@ -47,7 +47,7 @@ export default async function TemplatesPage() {
     <>
       <div className="flex w-full flex-col gap-6 pt-4">
         <DocBreadcrumbs items={breadcrumbs} />
-        <article className="prose prose-slate dark:prose-invert max-w-none w-full min-w-0">
+        <article className="prose prose-base md:prose-lg dark:prose-invert w-full">
           {content.isMDX ?
             <MDXRenderer source={content.content} />
           : <div dangerouslySetInnerHTML={{ __html: content.content }} />}

--- a/apps/framework-docs-v2/src/components/guides/step-content.tsx
+++ b/apps/framework-docs-v2/src/components/guides/step-content.tsx
@@ -13,7 +13,7 @@ export async function StepContent({ content, isMDX }: StepContentProps) {
   }
 
   return (
-    <div className="prose prose-slate dark:prose-invert max-w-none w-full min-w-0">
+    <div className="prose prose-base md:prose-lg dark:prose-invert w-full">
       {isMDX ?
         <MDXRenderer source={content} />
       : <div dangerouslySetInnerHTML={{ __html: content }} />}

--- a/apps/framework-docs-v2/src/styles/globals.css
+++ b/apps/framework-docs-v2/src/styles/globals.css
@@ -37,6 +37,9 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --text-body: 0 0% 20%;
+    --text-link: 0 0% 10%;
+    --text-link-hover: 0 0% 0%;
   }
 
   .dark {
@@ -72,6 +75,9 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --text-body: 0 0% 85%;
+    --text-link: 0 0% 100%;
+    --text-link-hover: 0 0% 95%;
   }
 }
 

--- a/apps/framework-docs-v2/tailwind.config.ts
+++ b/apps/framework-docs-v2/tailwind.config.ts
@@ -61,6 +61,11 @@ const config: Config = {
           border: "hsl(var(--sidebar-border))",
           ring: "hsl(var(--sidebar-ring))",
         },
+        text: {
+          body: "hsl(var(--text-body))",
+          link: "hsl(var(--text-link))",
+          "link-hover": "hsl(var(--text-link-hover))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -92,55 +97,51 @@ const config: Config = {
       typography: {
         DEFAULT: {
           css: {
-            maxWidth: "none",
-            color: "hsl(var(--foreground))",
+            fontSize: "1.0625rem",
+            color: "hsl(var(--text-body))",
+            lineHeight: "1.7",
             h1: {
-              fontSize: "2.25rem",
+              fontSize: "3rem",
+              lineHeight: "1.1",
               fontWeight: "700",
-              marginTop: "2rem",
-              marginBottom: "1rem",
+              marginTop: "0",
+              marginBottom: "1.5rem",
             },
             h2: {
-              fontSize: "1.875rem",
+              fontSize: "2rem",
+              lineHeight: "1.2",
               fontWeight: "700",
-              marginTop: "1.5rem",
-              marginBottom: "0.75rem",
+              marginTop: "2.5rem",
+              marginBottom: "1rem",
               scrollMarginTop: "5rem",
             },
             h3: {
               fontSize: "1.5rem",
+              lineHeight: "1.3",
               fontWeight: "600",
-              marginTop: "1rem",
-              marginBottom: "0.5rem",
+              marginTop: "2rem",
+              marginBottom: "0.75rem",
               scrollMarginTop: "5rem",
             },
             p: {
-              marginBottom: "1rem",
-              lineHeight: "1.75rem",
-            },
-            code: {
-              backgroundColor: "hsl(var(--muted))",
-              paddingLeft: "0.375rem",
-              paddingRight: "0.375rem",
-              paddingTop: "0.125rem",
-              paddingBottom: "0.125rem",
-              borderRadius: "0.25rem",
-              fontSize: "0.875rem",
-            },
-            pre: {
-              backgroundColor: "hsl(var(--muted))",
-              padding: "1rem",
-              borderRadius: "0.5rem",
-              overflowX: "auto",
-              marginBottom: "1rem",
-            },
-            "pre code": {
-              backgroundColor: "transparent",
-              padding: "0",
+              marginBottom: "1.25rem",
+              lineHeight: "1.7",
             },
             a: {
-              color: "hsl(var(--primary))",
+              color: "hsl(var(--text-link))",
+              textDecoration: "underline",
+              textDecorationColor: "hsl(var(--text-link) / 0.3)",
+              textUnderlineOffset: "2px",
+              "&:hover": {
+                color: "hsl(var(--text-link-hover))",
+                textDecorationColor: "hsl(var(--text-link-hover))",
+              },
+            },
+            "h1 a, h2 a, h3 a, h4 a, h5 a, h6 a": {
               textDecoration: "none",
+              "&:hover": {
+                textDecoration: "none",
+              },
             },
             "p a": {
               textDecoration: "underline",
@@ -154,6 +155,36 @@ const config: Config = {
                 textDecoration: "underline",
               },
             },
+            strong: {
+              color: "hsl(var(--foreground))",
+              fontWeight: "600",
+            },
+            code: {
+              backgroundColor: "hsl(var(--muted))",
+              color: "hsl(var(--foreground))",
+              paddingLeft: "0.375rem",
+              paddingRight: "0.375rem",
+              paddingTop: "0.25rem",
+              paddingBottom: "0.25rem",
+              borderRadius: "0.25rem",
+              fontSize: "0.875em",
+              fontWeight: "500",
+              border: "1px solid hsl(var(--border))",
+            },
+            pre: {
+              backgroundColor: "hsl(var(--muted) / 0.5)",
+              padding: "1.25rem",
+              borderRadius: "0.5rem",
+              overflowX: "auto",
+              marginTop: "1.5rem",
+              marginBottom: "1.5rem",
+              border: "1px solid hsl(var(--border))",
+            },
+            "pre code": {
+              backgroundColor: "transparent",
+              padding: "0",
+              border: "none",
+            },
             ul: {
               listStyleType: "disc",
               listStylePosition: "inside",
@@ -166,6 +197,24 @@ const config: Config = {
             },
             li: {
               marginBottom: "0.5rem",
+            },
+          },
+        },
+        lg: {
+          css: {
+            fontSize: "1.125rem",
+            lineHeight: "1.75",
+            h1: {
+              fontSize: "3rem",
+              lineHeight: "1.1",
+            },
+            h2: {
+              fontSize: "2.25rem",
+              lineHeight: "1.15",
+            },
+            h3: {
+              fontSize: "1.75rem",
+              lineHeight: "1.25",
             },
           },
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves readability and consistency of docs by updating typography and theming.
> 
> - Adds `--text-body`, `--text-link`, `--text-link-hover` CSS variables and maps them under `theme.extend.colors.text`
> - Revamps Tailwind `typography` defaults and `lg` variant (base/heading sizes, line heights, margins, link styling, strong/code/pre, lists)
> - Replaces page/step containers with `prose prose-base md:prose-lg dark:prose-invert w-full` across docs, guides, templates, and guide steps
> - No runtime logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b296906de24100c6f3ea41c2e1921898e362017a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->