### PR TITLE
fix: fix console errors on guides pages

### DIFF
--- a/apps/framework-docs-v2/content/guides/test-guides/code-blocks.mdx
+++ b/apps/framework-docs-v2/content/guides/test-guides/code-blocks.mdx
@@ -88,6 +88,29 @@ npm install -g @514labs/moose-cli
 moose --version
 ```
 
+## Long Shell Commands (Testing Horizontal Scrolling)
+
+```shell
+docker run -d --name my-container --env DATABASE_URL=postgresql://user:password@localhost:5432/mydb --env API_KEY=sk_test_1234567890abcdefghijklmnopqrstuvwxyz --env NODE_ENV=production -p 8080:8080 -v /host/path/to/data:/container/data my-image:latest
+```
+
+```bash
+curl -X POST https://api.example.com/v1/users/create \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" \
+  -d '{"name":"John Doe","email":"john@example.com","role":"admin"}'
+```
+
+```shell
+# Complex command with pipes and redirects
+cat /var/log/application.log | grep "ERROR" | awk '{print $1, $2, $NF}' | sort | uniq -c | sort -rn | head -20 > error-summary.txt
+```
+
+```bash
+# Long NPM install with specific versions
+npm install @typescript-eslint/parser@5.62.0 @typescript-eslint/eslint-plugin@5.62.0 eslint-config-next@14.0.4 eslint-plugin-react@7.33.2 eslint-plugin-react-hooks@4.6.0 --save-dev
+```
+
 ## YAML Configuration
 
 ```yaml

--- a/apps/framework-docs-v2/src/components/mdx-renderer.tsx
+++ b/apps/framework-docs-v2/src/components/mdx-renderer.tsx
@@ -47,6 +47,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypePrettyCode from "rehype-pretty-code";
 import { rehypeCodeMeta } from "@/lib/rehype-code-meta";
 import { rehypeRestoreCodeMeta } from "@/lib/rehype-restore-code-meta";
+import { ensureCodeBlockSpacing } from "@/lib/remark-code-block-spacing";
 
 interface MDXRendererProps {
   source: string;
@@ -54,6 +55,11 @@ interface MDXRendererProps {
 
 export async function MDXRenderer({ source }: MDXRendererProps) {
   "use cache";
+
+  // Preprocess content to ensure proper spacing around code blocks
+  // This prevents hydration errors from invalid HTML nesting
+  const processedSource = ensureCodeBlockSpacing(source);
+
   // Create FileTree with nested components
   const FileTreeWithSubcomponents = Object.assign(FileTree, {
     Folder: FileTreeFolder,
@@ -134,7 +140,7 @@ export async function MDXRenderer({ source }: MDXRendererProps) {
 
   return (
     <MDXRemote
-      source={source}
+      source={processedSource}
       components={components}
       options={{
         mdxOptions: {

--- a/apps/framework-docs-v2/src/components/mdx/server-code-block.tsx
+++ b/apps/framework-docs-v2/src/components/mdx/server-code-block.tsx
@@ -379,18 +379,9 @@ export function ServerInlineCode({
   if (isCodeBlock) {
     // This is a code block that should be handled by ServerCodeBlock
     // This is a fallback for when code is not wrapped in pre
-    const language = getLanguage(props as ServerCodeBlockProps);
-    const codeText = extractTextContent(children).trim();
-
-    return (
-      <div className="not-prose">
-        <CodeSnippet
-          code={codeText}
-          language={language || "plaintext"}
-          copyButton={true}
-        />
-      </div>
-    );
+    // Return inline code instead of block to avoid nesting errors
+    const textContent = extractTextContent(children).trim();
+    return <InlineCode code={textContent} className={className} />;
   }
 
   // Check for inline code with language hint: `code{:lang}`

--- a/apps/framework-docs-v2/src/lib/remark-code-block-spacing.ts
+++ b/apps/framework-docs-v2/src/lib/remark-code-block-spacing.ts
@@ -1,0 +1,38 @@
+/**
+ * Preprocesses markdown content to ensure proper spacing around code blocks
+ * This prevents MDX from wrapping code blocks in paragraph tags, which causes
+ * hydration errors due to invalid HTML nesting (<p> cannot contain <pre>)
+ *
+ * @param content - Raw markdown/MDX content
+ * @returns Processed content with proper spacing
+ */
+export function ensureCodeBlockSpacing(content: string): string {
+  const lines = content.split("\n");
+  const result: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const prevLine = i > 0 ? lines[i - 1] : "";
+    const nextLine = i < lines.length - 1 ? lines[i + 1] : "";
+
+    // If current line starts a code block and previous line has content (not blank)
+    if (line.trim().startsWith("```") && prevLine.trim() !== "") {
+      // Add blank line before code block
+      result.push("");
+    }
+
+    result.push(line);
+
+    // If current line ends a code block and next line has content (not blank)
+    if (
+      line.trim() === "```" &&
+      nextLine.trim() !== "" &&
+      !nextLine.trim().startsWith("#")
+    ) {
+      // Add blank line after code block
+      result.push("");
+    }
+  }
+
+  return result.join("\n");
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Addresses MDX code block nesting/hydration issues and expands test coverage for long commands.
> 
> - Add `ensureCodeBlockSpacing` preprocessor and use it in `MDXRenderer` (`processedSource`) to insert safe spacing around ``` fences
> - Change `ServerInlineCode` fallback to render inline instead of block when encountering `language-*` classes, avoiding invalid `<p><pre/></p>` nesting
> - Add `remark-code-block-spacing.ts` utility
> - Extend `code-blocks.mdx` with long shell/curl/npm examples to test horizontal scrolling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a69164deb80b24d62134982d1a41e4e77ea202a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->