### PR TITLE
Attempt to fix pypi-cleanup

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -726,8 +726,6 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           PYPI_TOKEN: "op://drqe7p6legi6ug2ijq2fnrkmjq/PyPi Token/password"
-          PYPI_CLEANUP_PASSWORD: "op://drqe7p6legi6ug2ijq2fnrkmjq/PyPI/new_password"
-          PYPI_OTP: "op://drqe7p6legi6ug2ijq2fnrkmjq/PyPI/Saved on pypi.org/one-time password?attribute=otp"
 
       - name: Clean up PyPI and only keep the latest 80 days of moose CLI and lib
         run: |
@@ -741,14 +739,10 @@ jobs:
             local days=$2
 
             expect << EOF
-          spawn pypi-cleanup -u 514 -p ${package_name} -d ${days} -r ".*" --do-it --yes
+          spawn pypi-cleanup -u __token__ -p ${package_name} -d ${days} -r ".*" --do-it --yes
           expect {
             "Password:" {
-              send "\$env(PYPI_CLEANUP_PASSWORD)\r"
-              exp_continue
-            }
-            "Authentication code:" {
-              send "\$env(PYPI_OTP)\r"
+              send "\$env(PYPI_TOKEN)\r"
               exp_continue
             }
             "No releases were found" {
@@ -763,12 +757,8 @@ jobs:
           if {\$exit_code != 0} {
             puts "ERROR: pypi-cleanup for ${package_name} failed with exit code \$exit_code"
             puts ""
-            puts "This is most likely due to PyPI device authentication."
-            puts "Please check your email for a message from noreply@pypi.org"
-            puts "with the subject line 'Unrecognized login to your PyPI account'."
-            puts "Click the confirmation link in that email to authorize this device."
-            puts ""
-            puts "For more details, see: https://pypi.org/help/#utfkey"
+            puts "Check that the PYPI_TOKEN is valid and has permissions to delete releases."
+            puts "For more details, see: https://pypi.org/help/"
             exit \$exit_code
           }
           EOF
@@ -776,11 +766,8 @@ jobs:
             if [ $exit_code -ne 0 ]; then
               echo "::error::pypi-cleanup for ${package_name} failed with exit code $exit_code"
               echo ""
-              echo "This is most likely due to PyPI device authentication."
-              echo "Please check your email for a message from noreply@pypi.org"
-              echo "with the subject line 'Unrecognized login to your PyPI account'."
-              echo "Click the confirmation link in that email to authorize this device."
-              echo "For more details, see: https://pypi.org/help/#utfkey"
+              echo "Check that the PYPI_TOKEN is valid and has permissions to delete releases."
+              echo "For more details, see: https://pypi.org/help/"
               ERROR_CODE=1
             fi
           }
@@ -795,5 +782,4 @@ jobs:
           fi
 
         env:
-          PYPI_CLEANUP_PASSWORD: ${{ steps.op-load-secret.outputs.PYPI_CLEANUP_PASSWORD }}
-          PYPI_OTP: ${{ steps.op-load-secret.outputs.PYPI_OTP }}
+          PYPI_TOKEN: ${{ steps.op-load-secret.outputs.PYPI_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves PyPI cleanup to token-based authentication for reliability and simplicity.
> 
> - In `release-cli.yaml` `cleanup-pypi` job, use `pypi-cleanup` with `-u __token__` and `PYPI_TOKEN` instead of user/password + OTP
> - Remove `PYPI_CLEANUP_PASSWORD` and `PYPI_OTP` secrets and related prompts; send `PYPI_TOKEN` at password prompt
> - Simplify failure messaging to reference token validity/permissions
> - Update env wiring to expose only `PYPI_TOKEN` from 1Password
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 802ad92bb7d45479ef670f8c53693c6471e63510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->