### PR TITLE
Add initContainer support for moose prod

### DIFF
--- a/apps/framework-cli-e2e/test/init-container.test.ts
+++ b/apps/framework-cli-e2e/test/init-container.test.ts
@@ -1,0 +1,322 @@
+/// <reference types="node" />
+/// <reference types="mocha" />
+/// <reference types="chai" />
+/**
+ * E2E tests for Init Container support (--exit-after-init flag)
+ *
+ * Tests verify that:
+ * - `moose prod --exit-after-init` completes infrastructure setup and exits cleanly
+ * - Subsequent `moose prod` starts without redundant infrastructure setup
+ * - Running `--exit-after-init` multiple times is idempotent
+ * - Migration failures are handled gracefully
+ * - Normal `moose prod` (without flag) still works as before
+ */
+
+import { spawn, ChildProcess, execSync } from "child_process";
+import { expect } from "chai";
+import * as fs from "fs";
+import * as path from "path";
+import { promisify } from "util";
+import { createClient, ClickHouseClient } from "@clickhouse/client";
+
+import { TIMEOUTS, CLICKHOUSE_CONFIG, SERVER_CONFIG } from "./constants";
+
+import {
+  waitForServerStart,
+  waitForInfrastructureReady,
+  createTempTestDirectory,
+  cleanupTestSuite,
+  performGlobalCleanup,
+  stopDevProcess,
+} from "./utils";
+
+const execAsync = promisify(require("child_process").exec);
+
+const CLI_PATH = path.resolve(__dirname, "../../../target/debug/moose-cli");
+const TEMPLATE_SOURCE_DIR = path.resolve(
+  __dirname,
+  "../../../templates/typescript-tests",
+);
+
+/**
+ * Environment variables needed for the typescript-tests template
+ */
+const TEST_ENV = {
+  ...process.env,
+  TEST_AWS_ACCESS_KEY_ID: "test-access-key",
+  TEST_AWS_SECRET_ACCESS_KEY: "test-secret-key",
+  MOOSE_DEV__SUPPRESS_DEV_SETUP_PROMPT: "true",
+  MOOSE_ADMIN_TOKEN:
+    "deadbeefdeadbeefdeadbeefdeadbeef.0123456789abcdef0123456789abcdef",
+};
+
+/**
+ * Helper to wait for a process to exit and return its exit code
+ */
+async function waitForProcessExit(
+  process: ChildProcess,
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+
+    process.stdout?.on("data", (data) => {
+      stdout += data.toString();
+      console.log("[STDOUT]", data.toString().trim());
+    });
+
+    process.stderr?.on("data", (data) => {
+      stderr += data.toString();
+      console.log("[STDERR]", data.toString().trim());
+    });
+
+    const timeout = setTimeout(() => {
+      process.kill("SIGKILL");
+      reject(new Error(`Process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    process.on("exit", (code) => {
+      clearTimeout(timeout);
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+
+    process.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Sets up a fresh test project from the typescript-tests template
+ */
+async function setupTestProject(testName: string): Promise<{
+  testProjectDir: string;
+  projectName: string;
+}> {
+  const uniqueName = `init-${testName
+    .replace(/[^a-z0-9-]/gi, "-")
+    .toLowerCase()
+    .slice(0, 25)}`;
+  const testProjectDir = createTempTestDirectory(uniqueName);
+  const projectName = path.basename(testProjectDir).toLowerCase();
+
+  console.log(`\n=== Setting up test project for: ${testName} ===`);
+  console.log(`Project name: ${projectName}`);
+  console.log(`Test directory: ${testProjectDir}`);
+
+  // Copy template
+  fs.cpSync(TEMPLATE_SOURCE_DIR, testProjectDir, { recursive: true });
+  console.log("✓ Template copied");
+
+  // Update package.json name for unique Docker project name
+  const packageJsonPath = path.join(testProjectDir, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+  packageJson.name = projectName;
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  console.log(`✓ Updated package.json name to: ${projectName}`);
+
+  // Install dependencies
+  console.log("Installing dependencies...");
+  await execAsync("npm install", { cwd: testProjectDir });
+  console.log("✓ Dependencies installed");
+
+  return { testProjectDir, projectName };
+}
+
+// Global setup - clean Docker state from previous runs
+before(async function () {
+  this.timeout(TIMEOUTS.GLOBAL_CLEANUP_MS);
+  console.log(
+    "Running global setup for init container tests - cleaning Docker state...",
+  );
+  await performGlobalCleanup();
+});
+
+describe("Init Container Support (--exit-after-init)", function () {
+  before(async function () {
+    console.log("\n=== Init Container Tests - Starting ===");
+  });
+
+  describe("Basic functionality", function () {
+    it("should complete with --exit-after-init and allow main container to start", async function () {
+      this.timeout(TIMEOUTS.TEST_SETUP_MS * 2);
+
+      const { testProjectDir, projectName } = await setupTestProject(
+        "basic-flow",
+      );
+      let mainProcess: ChildProcess | null = null;
+
+      try {
+        // Step 1: Run init container (moose prod --start-include-dependencies --exit-after-init)
+        console.log("\n--- Step 1: Running init container ---");
+        const initProcess = spawn(
+          CLI_PATH,
+          ["prod", "--start-include-dependencies", "--exit-after-init"],
+          {
+            stdio: "pipe",
+            cwd: testProjectDir,
+            env: TEST_ENV,
+          },
+        );
+
+        const initResult = await waitForProcessExit(
+          initProcess,
+          TIMEOUTS.SERVER_STARTUP_MS,
+        );
+        console.log(`Init process exit code: ${initResult.exitCode}`);
+
+        expect(initResult.exitCode).to.equal(0);
+        expect(initResult.stdout).to.include("infrastructure initialization");
+        console.log("✓ Init container completed successfully");
+
+        // Step 2: Run main container (moose prod without --exit-after-init)
+        // Docker containers should still be running from the init container
+        console.log("\n--- Step 2: Running main container ---");
+        mainProcess = spawn(CLI_PATH, ["prod"], {
+          stdio: "pipe",
+          cwd: testProjectDir,
+          env: TEST_ENV,
+        });
+
+        await waitForServerStart(
+          mainProcess,
+          TIMEOUTS.SERVER_STARTUP_MS,
+          "production mode",
+          SERVER_CONFIG.url,
+        );
+        console.log("✓ Main container started");
+
+        // Step 3: Verify server is functional
+        console.log("\n--- Step 3: Verifying server functionality ---");
+        const healthResponse = await fetch(`${SERVER_CONFIG.url}/health`);
+        expect(healthResponse.ok).to.be.true;
+        console.log("✓ Health endpoint responds OK");
+
+        // Step 4: Verify plan shows no changes (infra already set up)
+        console.log("\n--- Step 4: Verifying no redundant setup ---");
+        const { stdout: planOutput } = await execAsync(
+          `"${CLI_PATH}" plan --url "${SERVER_CONFIG.url}" --json`,
+          { cwd: testProjectDir, env: TEST_ENV },
+        );
+        const plan = JSON.parse(planOutput);
+
+        // Changes should be empty or minimal since init already ran
+        const olapChanges = plan.changes?.olap_changes ?? [];
+        const streamingChanges = plan.changes?.streaming_engine_changes ?? [];
+        console.log(`OLAP changes: ${olapChanges.length}`);
+        console.log(`Streaming changes: ${streamingChanges.length}`);
+
+        // In a properly set up system, there should be no pending changes
+        expect(olapChanges.length).to.equal(0);
+        expect(streamingChanges.length).to.equal(0);
+        console.log("✓ No redundant infrastructure changes needed");
+      } finally {
+        if (mainProcess) {
+          await stopDevProcess(mainProcess);
+        }
+        await cleanupTestSuite(null, testProjectDir, projectName, {
+          logPrefix: "basic-flow",
+        });
+      }
+    });
+
+    it("should handle idempotent --exit-after-init calls", async function () {
+      this.timeout(TIMEOUTS.TEST_SETUP_MS * 2);
+
+      const { testProjectDir, projectName } = await setupTestProject(
+        "idempotent",
+      );
+
+      try {
+        // First init call
+        console.log("\n--- First --exit-after-init call ---");
+        const firstInit = spawn(
+          CLI_PATH,
+          ["prod", "--start-include-dependencies", "--exit-after-init"],
+          {
+            stdio: "pipe",
+            cwd: testProjectDir,
+            env: TEST_ENV,
+          },
+        );
+
+        const firstResult = await waitForProcessExit(
+          firstInit,
+          TIMEOUTS.SERVER_STARTUP_MS,
+        );
+        expect(firstResult.exitCode).to.equal(0);
+        console.log("✓ First init completed");
+
+        // Second init call (should also succeed)
+        console.log("\n--- Second --exit-after-init call ---");
+        const secondInit = spawn(
+          CLI_PATH,
+          ["prod", "--exit-after-init"], // Docker already running
+          {
+            stdio: "pipe",
+            cwd: testProjectDir,
+            env: TEST_ENV,
+          },
+        );
+
+        const secondResult = await waitForProcessExit(
+          secondInit,
+          TIMEOUTS.SERVER_STARTUP_MS,
+        );
+        expect(secondResult.exitCode).to.equal(0);
+        console.log("✓ Second init completed (idempotent)");
+      } finally {
+        await cleanupTestSuite(null, testProjectDir, projectName, {
+          logPrefix: "idempotent",
+        });
+      }
+    });
+  });
+
+  describe("Backwards compatibility", function () {
+    it("should work without --exit-after-init (normal prod)", async function () {
+      this.timeout(TIMEOUTS.TEST_SETUP_MS);
+
+      const { testProjectDir, projectName } = await setupTestProject(
+        "backwards-compat",
+      );
+      let mooseProcess: ChildProcess | null = null;
+
+      try {
+        // Run normal moose prod (without --exit-after-init)
+        console.log("\n--- Running normal moose prod ---");
+        mooseProcess = spawn(
+          CLI_PATH,
+          ["prod", "--start-include-dependencies"],
+          {
+            stdio: "pipe",
+            cwd: testProjectDir,
+            env: TEST_ENV,
+          },
+        );
+
+        await waitForServerStart(
+          mooseProcess,
+          TIMEOUTS.SERVER_STARTUP_MS,
+          "production mode",
+          SERVER_CONFIG.url,
+        );
+        console.log("✓ Normal moose prod started");
+
+        // Verify server is functional
+        const healthResponse = await fetch(`${SERVER_CONFIG.url}/health`);
+        expect(healthResponse.ok).to.be.true;
+        console.log("✓ Server is functional");
+      } finally {
+        if (mooseProcess) {
+          await stopDevProcess(mooseProcess);
+        }
+        await cleanupTestSuite(null, testProjectDir, projectName, {
+          logPrefix: "backwards-compat",
+        });
+      }
+    });
+  });
+});

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -877,6 +877,7 @@ pub async fn top_command_handler(
         },
         Commands::Prod {
             start_include_dependencies,
+            exit_after_init,
         } => {
             info!("Running prod command");
             info!("Moose Version: {}", CLI_VERSION);
@@ -936,14 +937,20 @@ pub async fn top_command_handler(
                 HashMap::new(),
             );
 
-            routines::start_production_mode(&settings, project_arc, arc_metrics, redis_client)
-                .await
-                .map_err(|e| {
-                    RoutineFailure::error(Message {
-                        action: "Prod".to_string(),
-                        details: format!("Failed to start production mode: {e:?}"),
-                    })
-                })?;
+            routines::start_production_mode(
+                &settings,
+                project_arc,
+                arc_metrics,
+                redis_client,
+                *exit_after_init,
+            )
+            .await
+            .map_err(|e| {
+                RoutineFailure::error(Message {
+                    action: "Prod".to_string(),
+                    details: format!("Failed to start production mode: {e:?}"),
+                })
+            })?;
 
             wait_for_usage_capture(capture_handle).await;
 

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -130,6 +130,10 @@ pub enum Commands {
         /// Include and manage dependencies (ClickHouse, Redpanda, etc.) using Docker containers
         #[arg(long)]
         start_include_dependencies: bool,
+
+        /// Exit after infrastructure initialization (for Kubernetes init containers)
+        #[arg(long)]
+        exit_after_init: bool,
     },
     /// Generates helpers for your data models (i.e. sdk, api tokens)
     Generate(GenerateArgs),

--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -635,6 +635,7 @@ pub async fn start_development_mode(
 /// * `project` - Arc wrapped Project instance containing configuration
 /// * `metrics` - Arc wrapped Metrics instance for monitoring
 /// * `redis_client` - Arc and Mutex wrapped RedisClient for caching
+/// * `exit_after_init` - If true, exit after infrastructure setup (for Kubernetes init containers)
 ///
 /// # Returns
 /// * `anyhow::Result<()>` - Success or error result
@@ -643,6 +644,7 @@ pub async fn start_production_mode(
     project: Arc<Project>,
     metrics: Arc<Metrics>,
     redis_client: Arc<RedisClient>,
+    exit_after_init: bool,
 ) -> anyhow::Result<()> {
     display::show_message_wrapper(
         MessageType::Success,
@@ -725,6 +727,19 @@ pub async fn start_production_mode(
     state_storage
         .store_infrastructure_map(&plan.target_infra_map)
         .await?;
+
+    // Exit early if requested (for Kubernetes init containers)
+    if exit_after_init {
+        info!("Infrastructure initialization complete. Exiting (--exit-after-init).");
+        display::show_message_wrapper(
+            MessageType::Success,
+            Message {
+                action: "Completed".to_string(),
+                details: "infrastructure initialization (--exit-after-init)".to_string(),
+            },
+        );
+        return Ok(());
+    }
 
     let infra_map: &'static InfrastructureMap = Box::leak(Box::new(plan.target_infra_map));
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces init-container support for production runs by allowing infra setup to complete and the process to exit cleanly.
> 
> - Adds `--exit-after-init` flag to `moose prod` (CLI and command wiring) and plumbs through to `routines::start_production_mode`
> - `start_production_mode` now stores the infra map and, when `exit_after_init` is true, returns early after initialization with a success message
> - New E2E tests (`init-container.test.ts`) cover basic flow, idempotent repeated runs, and backward compatibility with normal `prod`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d802454ef2e511401376ce09e84bf7a074a176e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->