### PR TITLE
pin python black formatter so CI and dev match

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install black
-        run: pip install black
+        run: pip install black==25.12.0  # Keep in sync with packages/py-moose-lib/requirements-dev.txt
       - name: Check black compliance
         run: black --check .
 

--- a/packages/py-moose-lib/requirements-dev.txt
+++ b/packages/py-moose-lib/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest>=7.0.0
 pytest-cov>=4.0.0
 sqlglot[rs]>=27.16.3
-black>=24.0.0
+black==25.12.0


### PR DESCRIPTION
[ENG-1950](https://linear.app/514/issue/ENG-1950/pin-ci-and-dev-python-black-formatter-to-match)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Pin formatter version for consistency**
> 
> - Update `.github/workflows/format.yaml` to install `black==25.12.0` instead of the latest
> - Change `packages/py-moose-lib/requirements-dev.txt` from `black>=24.0.0` to `black==25.12.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4d982977a79f66547b64d4ca2b9f7a18cffbb5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->