### PR TITLE
Fix MDX compilation error in static report generation guide

### DIFF
--- a/apps/framework-docs-v2/content/guides/static-report-generation.mdx
+++ b/apps/framework-docs-v2/content/guides/static-report-generation.mdx
@@ -874,8 +874,8 @@ CSV/JSON Files → Ingest API → ClickHouse Table → Materialized View → API
 | Operation | Traditional OLTP | Moose + ClickHouse |
 |-----------|------------------|-------------------|
 | Raw transaction scan | Seconds to minutes | Milliseconds |
-| Daily aggregation query | 10-30+ seconds | <100ms |
-| Report generation | Minutes (compute + format) | <1 second |
+| Daily aggregation query | 10-30+ seconds | `<100ms` |
+| Report generation | Minutes (compute + format) | `<1 second` |
 
 The pre-aggregated materialized view delivers 10-100x faster query performance, making PDF generation nearly instantaneous.
 


### PR DESCRIPTION
## Summary
- Fixed MDX compilation error caused by custom `<Note>` JSX components
- Replaced two `<Note>` component instances with standard markdown blockquote syntax

## Problem
The static report generation guide was using custom `<Note>` JSX components that caused next-mdx-remote compilation errors:
```
[Error: [next-mdx-remote] error compiling MDX:
Unexpected character `1` (U+0031) before name, expected a character that can start a name...
```

## Solution
Converted `<Note>` JSX components to standard markdown blockquotes using `>` syntax, which:
- Works universally in MDX without component registration
- Maintains the same visual intent (callout text)
- Fixes the compilation error

## Changes
- `apps/framework-docs-v2/content/guides/static-report-generation.mdx`: Replaced 2 `<Note>` components with blockquotes

## Test plan
- [x] Verified no other MDX files in the docs contain custom JSX components
- [ ] Verify the guide renders correctly in Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes MDX rendering by removing unsupported JSX and escaping angle-bracket values.
> 
> - Replaced two custom `\<Note>` components with markdown blockquotes (`> **Note:**`) in `static-report-generation.mdx`
> - Escaped `<` values in the performance table by wrapping them in backticks (e.g., ``<100ms``, ``<1 second``)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f99274c33fbefa93f0068d06c161b236892c8e90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->