### PR TITLE
feat: add apollo to the docs

### DIFF
--- a/apps/framework-docs-v2/IMPLEMENTATION.md
+++ b/apps/framework-docs-v2/IMPLEMENTATION.md
@@ -124,18 +124,11 @@ apps/framework-docs-v2/
 - Tracks: page views, navigation, code copies, search queries
 - Debug mode in development
 
-**Custom Metrics SDK Wrapper:**
-- Wraps PostHog with custom event types
-- Sends to internal endpoint: `https://moosefood.514.dev/ingest/DocsEvent`
-- Tracking events:
-  - Page views with language context
-  - Documentation snippet copies
-  - Search queries and result clicks
-  - Navigation patterns
-  - Session management
-
-**Event Types:**
-- `DocsEvent` interface with eventType, language, path, metadata
+**Tracking Events:**
+- Page views with language context
+- Documentation snippet copies
+- Search queries and result clicks
+- Navigation patterns
 - Auto-tracks code copying from code blocks
 - Non-blocking analytics (won't disrupt UX on failure)
 

--- a/apps/framework-docs-v2/src/app/layout.tsx
+++ b/apps/framework-docs-v2/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Suspense } from "react";
 import "@/styles/globals.css";
 import { VercelToolbar } from "@vercel/toolbar/next";
+import { Apollo } from "@/components/apollo";
 import { CommonRoom } from "@/components/common-room";
 import { LanguageProviderWrapper } from "@/components/language-provider-wrapper";
 import { TopNavWithFlags } from "@/components/navigation/top-nav-with-flags";
@@ -29,6 +30,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
+        <Apollo />
         <CommonRoom />
         <ScrollRestoration />
         <ThemeProvider

--- a/apps/framework-docs-v2/src/components/apollo.tsx
+++ b/apps/framework-docs-v2/src/components/apollo.tsx
@@ -1,0 +1,37 @@
+import Script from "next/script";
+
+declare global {
+  interface Window {
+    trackingFunctions?: {
+      onLoad: (config: { appId: string }) => void;
+    };
+  }
+}
+
+export function Apollo() {
+  if (process.env.NODE_ENV !== "production") {
+    return null;
+  }
+
+  return (
+    <Script
+      id="apollo-init"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
+(function initApollo() {
+  var n = Math.random().toString(36).substring(7);
+  var o = document.createElement("script");
+  o.src = "https://assets.apollo.io/micro/website-tracker/tracker.iife.js?nocache=" + n;
+  o.async = true;
+  o.defer = true;
+  o.onload = function() {
+    window.trackingFunctions.onLoad({ appId: "66316b76c8e6ae01afde8c2d" });
+  };
+  document.head.appendChild(o);
+})();
+        `.trim(),
+      }}
+    />
+  );
+}

--- a/apps/framework-docs-v2/src/lib/analytics.ts
+++ b/apps/framework-docs-v2/src/lib/analytics.ts
@@ -2,13 +2,6 @@
 
 import posthog from "posthog-js";
 
-export interface DocsEvent {
-  eventType: string;
-  language: "typescript" | "python";
-  path: string;
-  metadata?: Record<string, unknown>;
-}
-
 export interface CodeCopyEvent {
   code: string;
   language: string;
@@ -23,7 +16,6 @@ export interface SearchEvent {
 
 class Analytics {
   private initialized = false;
-  private mooseEndpoint = "https://moosefood.514.dev/ingest/DocsEvent";
 
   init() {
     if (this.initialized || typeof window === "undefined") return;
@@ -54,16 +46,6 @@ class Analytics {
   pageView(path: string, language: "typescript" | "python") {
     this.init();
 
-    const event: DocsEvent = {
-      eventType: "page_view",
-      language,
-      path,
-      metadata: {
-        timestamp: new Date().toISOString(),
-        referrer: typeof window !== "undefined" ? document.referrer : "",
-      },
-    };
-
     // Send to PostHog
     if (posthog) {
       posthog.capture("$pageview", {
@@ -72,9 +54,6 @@ class Analytics {
         path,
       });
     }
-
-    // Send to internal Moose endpoint
-    this.sendToMoose(event);
   }
 
   /**
@@ -82,17 +61,6 @@ class Analytics {
    */
   codeCopy(event: CodeCopyEvent) {
     this.init();
-
-    const docsEvent: DocsEvent = {
-      eventType: "code_copy",
-      language: event.language as "typescript" | "python",
-      path: event.page,
-      metadata: {
-        codeSnippet: event.code.substring(0, 200), // Truncate for storage
-        codeLanguage: event.language,
-        timestamp: new Date().toISOString(),
-      },
-    };
 
     // Send to PostHog
     if (posthog) {
@@ -102,9 +70,6 @@ class Analytics {
         code_length: event.code.length,
       });
     }
-
-    // Send to internal Moose endpoint
-    this.sendToMoose(docsEvent);
   }
 
   /**
@@ -112,17 +77,6 @@ class Analytics {
    */
   search(event: SearchEvent) {
     this.init();
-
-    const docsEvent: DocsEvent = {
-      eventType: "search",
-      language: event.language,
-      path: typeof window !== "undefined" ? window.location.pathname : "",
-      metadata: {
-        query: event.query,
-        resultCount: event.resultCount,
-        timestamp: new Date().toISOString(),
-      },
-    };
 
     // Send to PostHog
     if (posthog) {
@@ -132,9 +86,6 @@ class Analytics {
         language: event.language,
       });
     }
-
-    // Send to internal Moose endpoint
-    this.sendToMoose(docsEvent);
   }
 
   /**
@@ -147,16 +98,6 @@ class Analytics {
   ) {
     this.init();
 
-    const docsEvent: DocsEvent = {
-      eventType: "nav_click",
-      language,
-      path: fromPath,
-      metadata: {
-        destination: toPath,
-        timestamp: new Date().toISOString(),
-      },
-    };
-
     // Send to PostHog
     if (posthog) {
       posthog.capture("Navigation Click", {
@@ -165,59 +106,6 @@ class Analytics {
         language,
       });
     }
-
-    // Send to internal Moose endpoint
-    this.sendToMoose(docsEvent);
-  }
-
-  /**
-   * Send event to internal Moose endpoint
-   */
-  private async sendToMoose(event: DocsEvent) {
-    if (typeof window === "undefined") return;
-
-    // Skip sending to Moose in development
-    if (process.env.NODE_ENV === "development") {
-      console.log("[Analytics] Skipping Moose in dev:", event.eventType);
-      return;
-    }
-
-    try {
-      await fetch(this.mooseEndpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          ...event,
-          timestamp: new Date().toISOString(),
-          sessionId: this.getSessionId(),
-          userAgent: navigator.userAgent,
-        }),
-        // Don't wait for response
-        keepalive: true,
-      });
-    } catch (error) {
-      // Silently fail - don't disrupt user experience
-      console.error("Failed to send analytics event:", error);
-    }
-  }
-
-  /**
-   * Get or create session ID
-   */
-  private getSessionId(): string {
-    if (typeof window === "undefined") return "";
-
-    const storageKey = "moose_docs_session_id";
-    let sessionId = sessionStorage.getItem(storageKey);
-
-    if (!sessionId) {
-      sessionId = `${Date.now()}-${Math.random().toString(36).substring(7)}`;
-      sessionStorage.setItem(storageKey, sessionId);
-    }
-
-    return sessionId;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces Apollo website tracking and simplifies client analytics to rely solely on PostHog.
> 
> - Adds `Apollo` component that loads Apollo tracker script (production-only) and injects it in `src/app/layout.tsx`
> - Refactors `src/lib/analytics.ts`: removes `DocsEvent`, internal Moose ingest endpoint, session handling, and related code; retains PostHog events for page views, code copies, searches, and navigation
> - Updates `IMPLEMENTATION.md` analytics section to reflect streamlined tracking events
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19eb4c0d4140087e4fb14a9133af83332efc5499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->