### PR TITLE
update mv docs

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/olap/model-materialized-view.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/model-materialized-view.mdx
@@ -27,7 +27,7 @@ compact
 bullets={[
     "Generates and applies destination table DDL when you update the schema in code",
     "Applies DDL in dependency order across views and tables",
-    "Backfills in dev mode when the SELECT changes",
+    "Backfills in dev mode when the MaterializedView is created or updated",
     "Hot‑reloads the view and destination table locally and keeps APIs in sync"
 ]}
 />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Materialized Views docs to clarify backfill behavior and environment differences.
> 
> - Clarifies that Moose backfills materialized view targets automatically in dev mode (on create/update) and not automatically in production; adds link to backfill guide
> - Adjusts overview and "On change" bullets to reflect dev-only backfill and dependency-ordered DDL
> - Minor phrasing tweaks; no code or API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 125030ffaf4c6b24130521284fdc8abc564711f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->