### PR TITLE
fix: anthropic key is an env var the frontend needs, not moosestack

### DIFF
--- a/templates/typescript-mcp/template.config.toml
+++ b/templates/typescript-mcp/template.config.toml
@@ -48,12 +48,8 @@ short_description = "Deploy an AI chat app that can query your data"
 command = "moose generate hash-token --json"
 outputs = [
   { env_var = "MCP_API_KEY", json_path = "api_key_hash" },
-  { env_var = "MCP_API_TOKEN", json_path = "bearer_token" }
+  { env_var = "MCP_API_TOKEN", json_path = "bearer_token" },
 ]
 
 # Env vars user must provide
 [[boreal.env_vars]]
-name = "ANTHROPIC_API_KEY"
-label = "Anthropic API Key"
-secret = true
-required = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes unnecessary Boreal-provided env var and minor formatting cleanup.
> 
> - Removes `ANTHROPIC_API_KEY` from `boreal.env_vars` in `templates/typescript-mcp/template.config.toml`
> - Adds trailing comma in `boreal.setup_commands.outputs` list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e92c3b8205917b79ea866ee2a2db5c99b0c421bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->