### PR TITLE
Refreshable MVs

### DIFF
--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -1302,13 +1302,14 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
         it("should create refreshable MVs with correct REFRESH configurations (TS)", async function () {
           this.timeout(TIMEOUTS.TEST_SETUP_MS);
 
-          // Test 1: HourlyStats_MV - REFRESH EVERY 1 HOUR
+          // Test 1: HourlyStats_MV - REFRESH EVERY 1 HOUR OFFSET 5 MINUTE
           const hourlyResult = await verifyMaterializedViewRefreshConfig(
             "HourlyStats_MV",
             {
               intervalType: "EVERY",
               intervalValue: 1,
               intervalUnit: "HOUR",
+              offset: "5 MINUTE", // OFFSET is valid with EVERY
             },
             "local",
           );
@@ -1318,14 +1319,14 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
             );
           }
 
-          // Test 2: DailyStats_MV - REFRESH AFTER 30 MINUTE OFFSET 5 MINUTE
+          // Test 2: DailyStats_MV - REFRESH AFTER 30 MINUTE (no offset - OFFSET only valid with EVERY)
           const dailyResult = await verifyMaterializedViewRefreshConfig(
             "DailyStats_MV",
             {
               intervalType: "AFTER",
               intervalValue: 30,
               intervalUnit: "MINUTE",
-              offset: "5 MINUTE",
+              // Note: No offset - OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER
             },
             "local",
           );

--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -70,7 +70,12 @@ import {
 } from "./utils";
 import { triggerWorkflow } from "./utils/workflow-utils";
 import { geoPayloadPy, geoPayloadTs } from "./utils/geo-payload";
-import { verifyTableIndexes, getTableDDL } from "./utils/database-utils";
+import {
+  verifyTableIndexes,
+  getTableDDL,
+  verifyMaterializedViewRefreshConfig,
+  verifyIncrementalMaterializedView,
+} from "./utils/database-utils";
 import { createClient } from "@clickhouse/client";
 
 const testLogger = logger.scope("templates-test");
@@ -1292,6 +1297,89 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
             // When includeTimestamp=true, the response should include query_time from NOW()
             expect(json[0]).to.have.property("query_time");
           });
+        });
+
+        it("should create refreshable MVs with correct REFRESH configurations (TS)", async function () {
+          this.timeout(TIMEOUTS.TEST_SETUP_MS);
+
+          // Test 1: HourlyStats_MV - REFRESH EVERY 1 HOUR
+          const hourlyResult = await verifyMaterializedViewRefreshConfig(
+            "HourlyStats_MV",
+            {
+              intervalType: "EVERY",
+              intervalValue: 1,
+              intervalUnit: "HOUR",
+            },
+            "local",
+          );
+          if (!hourlyResult.valid) {
+            throw new Error(
+              `HourlyStats_MV refresh config validation failed: ${hourlyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 2: DailyStats_MV - REFRESH AFTER 30 MINUTE OFFSET 5 MINUTE
+          const dailyResult = await verifyMaterializedViewRefreshConfig(
+            "DailyStats_MV",
+            {
+              intervalType: "AFTER",
+              intervalValue: 30,
+              intervalUnit: "MINUTE",
+              offset: "5 MINUTE",
+            },
+            "local",
+          );
+          if (!dailyResult.valid) {
+            throw new Error(
+              `DailyStats_MV refresh config validation failed: ${dailyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 3: WeeklyRollup_MV - REFRESH EVERY 1 DAY DEPENDS ON DailyStats_MV APPEND
+          const weeklyResult = await verifyMaterializedViewRefreshConfig(
+            "WeeklyRollup_MV",
+            {
+              intervalType: "EVERY",
+              intervalValue: 1,
+              intervalUnit: "DAY",
+              dependsOn: ["DailyStats_MV"],
+              append: true,
+            },
+            "local",
+          );
+          if (!weeklyResult.valid) {
+            throw new Error(
+              `WeeklyRollup_MV refresh config validation failed: ${weeklyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 4: RandomizedStats_MV - REFRESH EVERY 5 MINUTE RANDOMIZE FOR 30 SECOND
+          const randomizedResult = await verifyMaterializedViewRefreshConfig(
+            "RandomizedStats_MV",
+            {
+              intervalType: "EVERY",
+              intervalValue: 5,
+              intervalUnit: "MINUTE",
+              randomize: "30 SECOND",
+            },
+            "local",
+          );
+          if (!randomizedResult.valid) {
+            throw new Error(
+              `RandomizedStats_MV refresh config validation failed: ${randomizedResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 5: IncrementalStats_MV - should NOT have REFRESH clause (incremental MV)
+          const incrementalResult = await verifyIncrementalMaterializedView(
+            "IncrementalStats_MV",
+            "local",
+          );
+          if (!incrementalResult.valid) {
+            throw new Error(
+              `IncrementalStats_MV should be incremental (no REFRESH) but validation failed: ${incrementalResult.errors.join(", ")}`,
+            );
+          }
         });
 
         it("should ingest geometry types into a single GeoTypes table (TS)", async function () {

--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -1386,93 +1386,6 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
           }
         });
 
-        it("should create refreshable MVs with correct REFRESH configurations (Py)", async function () {
-          if (config.language !== "python" || !config.isTestsVariant) {
-            this.skip();
-          }
-          this.timeout(TIMEOUTS.TEST_SETUP_MS);
-
-          // Test 1: hourly_stats_mv - REFRESH EVERY 1 HOUR OFFSET 5 MINUTE
-          const hourlyResult = await verifyMaterializedViewRefreshConfig(
-            "hourly_stats_mv",
-            {
-              intervalType: "EVERY",
-              intervalValue: 1,
-              intervalUnit: "HOUR",
-              offset: "5 MINUTE", // OFFSET is valid with EVERY
-            },
-            "local",
-          );
-          if (!hourlyResult.valid) {
-            throw new Error(
-              `hourly_stats_mv refresh config validation failed: ${hourlyResult.errors.join(", ")}`,
-            );
-          }
-
-          // Test 2: daily_stats_mv - REFRESH AFTER 30 MINUTE (no offset - OFFSET only valid with EVERY)
-          const dailyResult = await verifyMaterializedViewRefreshConfig(
-            "daily_stats_mv",
-            {
-              intervalType: "AFTER",
-              intervalValue: 30,
-              intervalUnit: "MINUTE",
-              // Note: No offset - OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER
-            },
-            "local",
-          );
-          if (!dailyResult.valid) {
-            throw new Error(
-              `daily_stats_mv refresh config validation failed: ${dailyResult.errors.join(", ")}`,
-            );
-          }
-
-          // Test 3: weekly_rollup_mv - REFRESH EVERY 1 DAY DEPENDS ON daily_stats_mv APPEND
-          const weeklyResult = await verifyMaterializedViewRefreshConfig(
-            "weekly_rollup_mv",
-            {
-              intervalType: "EVERY",
-              intervalValue: 1,
-              intervalUnit: "DAY",
-              dependsOn: ["daily_stats_mv"],
-              append: true,
-            },
-            "local",
-          );
-          if (!weeklyResult.valid) {
-            throw new Error(
-              `weekly_rollup_mv refresh config validation failed: ${weeklyResult.errors.join(", ")}`,
-            );
-          }
-
-          // Test 4: randomized_stats_mv - REFRESH EVERY 5 MINUTE RANDOMIZE FOR 30 SECOND
-          const randomizedResult = await verifyMaterializedViewRefreshConfig(
-            "randomized_stats_mv",
-            {
-              intervalType: "EVERY",
-              intervalValue: 5,
-              intervalUnit: "MINUTE",
-              randomize: "30 SECOND",
-            },
-            "local",
-          );
-          if (!randomizedResult.valid) {
-            throw new Error(
-              `randomized_stats_mv refresh config validation failed: ${randomizedResult.errors.join(", ")}`,
-            );
-          }
-
-          // Test 5: incremental_stats_mv - should NOT have REFRESH clause (incremental MV)
-          const incrementalResult = await verifyIncrementalMaterializedView(
-            "incremental_stats_mv",
-            "local",
-          );
-          if (!incrementalResult.valid) {
-            throw new Error(
-              `incremental_stats_mv should be incremental (no REFRESH) but validation failed: ${incrementalResult.errors.join(", ")}`,
-            );
-          }
-        });
-
         it("should ingest geometry types into a single GeoTypes table (TS)", async function () {
           const id = randomUUID();
           await withRetries(
@@ -2321,6 +2234,90 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
           );
           await waitForDBWrite(devProcess!, "GeoTypes", 1, 60_000, "local");
           await verifyClickhouseData("GeoTypes", id, "id", "local");
+        });
+
+        it("should create refreshable MVs with correct REFRESH configurations (Py)", async function () {
+          this.timeout(TIMEOUTS.TEST_SETUP_MS);
+
+          // Test 1: hourly_stats_mv - REFRESH EVERY 1 HOUR OFFSET 5 MINUTE
+          const hourlyResult = await verifyMaterializedViewRefreshConfig(
+            "hourly_stats_mv",
+            {
+              intervalType: "EVERY",
+              intervalValue: 1,
+              intervalUnit: "HOUR",
+              offset: "5 MINUTE", // OFFSET is valid with EVERY
+            },
+            "local",
+          );
+          if (!hourlyResult.valid) {
+            throw new Error(
+              `hourly_stats_mv refresh config validation failed: ${hourlyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 2: daily_stats_mv - REFRESH AFTER 30 MINUTE (no offset - OFFSET only valid with EVERY)
+          const dailyResult = await verifyMaterializedViewRefreshConfig(
+            "daily_stats_mv",
+            {
+              intervalType: "AFTER",
+              intervalValue: 30,
+              intervalUnit: "MINUTE",
+              // Note: No offset - OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER
+            },
+            "local",
+          );
+          if (!dailyResult.valid) {
+            throw new Error(
+              `daily_stats_mv refresh config validation failed: ${dailyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 3: weekly_rollup_mv - REFRESH EVERY 1 DAY DEPENDS ON daily_stats_mv APPEND
+          const weeklyResult = await verifyMaterializedViewRefreshConfig(
+            "weekly_rollup_mv",
+            {
+              intervalType: "EVERY",
+              intervalValue: 1,
+              intervalUnit: "DAY",
+              dependsOn: ["daily_stats_mv"],
+              append: true,
+            },
+            "local",
+          );
+          if (!weeklyResult.valid) {
+            throw new Error(
+              `weekly_rollup_mv refresh config validation failed: ${weeklyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 4: randomized_stats_mv - REFRESH EVERY 5 MINUTE RANDOMIZE FOR 30 SECOND
+          const randomizedResult = await verifyMaterializedViewRefreshConfig(
+            "randomized_stats_mv",
+            {
+              intervalType: "EVERY",
+              intervalValue: 5,
+              intervalUnit: "MINUTE",
+              randomize: "30 SECOND",
+            },
+            "local",
+          );
+          if (!randomizedResult.valid) {
+            throw new Error(
+              `randomized_stats_mv refresh config validation failed: ${randomizedResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 5: incremental_stats_mv - should NOT have REFRESH clause (incremental MV)
+          const incrementalResult = await verifyIncrementalMaterializedView(
+            "incremental_stats_mv",
+            "local",
+          );
+          if (!incrementalResult.valid) {
+            throw new Error(
+              `incremental_stats_mv should be incremental (no REFRESH) but validation failed: ${incrementalResult.errors.join(", ")}`,
+            );
+          }
         });
 
         it("should send array transform results as individual Kafka messages (PY)", async function () {

--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -1300,6 +1300,9 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
         });
 
         it("should create refreshable MVs with correct REFRESH configurations (TS)", async function () {
+          if (config.language !== "typescript" || !config.isTestsVariant) {
+            this.skip();
+          }
           this.timeout(TIMEOUTS.TEST_SETUP_MS);
 
           // Test 1: HourlyStats_MV - REFRESH EVERY 1 HOUR OFFSET 5 MINUTE
@@ -1379,6 +1382,93 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
           if (!incrementalResult.valid) {
             throw new Error(
               `IncrementalStats_MV should be incremental (no REFRESH) but validation failed: ${incrementalResult.errors.join(", ")}`,
+            );
+          }
+        });
+
+        it("should create refreshable MVs with correct REFRESH configurations (Py)", async function () {
+          if (config.language !== "python" || !config.isTestsVariant) {
+            this.skip();
+          }
+          this.timeout(TIMEOUTS.TEST_SETUP_MS);
+
+          // Test 1: hourly_stats_mv - REFRESH EVERY 1 HOUR OFFSET 5 MINUTE
+          const hourlyResult = await verifyMaterializedViewRefreshConfig(
+            "hourly_stats_mv",
+            {
+              intervalType: "EVERY",
+              intervalValue: 1,
+              intervalUnit: "HOUR",
+              offset: "5 MINUTE", // OFFSET is valid with EVERY
+            },
+            "local",
+          );
+          if (!hourlyResult.valid) {
+            throw new Error(
+              `hourly_stats_mv refresh config validation failed: ${hourlyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 2: daily_stats_mv - REFRESH AFTER 30 MINUTE (no offset - OFFSET only valid with EVERY)
+          const dailyResult = await verifyMaterializedViewRefreshConfig(
+            "daily_stats_mv",
+            {
+              intervalType: "AFTER",
+              intervalValue: 30,
+              intervalUnit: "MINUTE",
+              // Note: No offset - OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER
+            },
+            "local",
+          );
+          if (!dailyResult.valid) {
+            throw new Error(
+              `daily_stats_mv refresh config validation failed: ${dailyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 3: weekly_rollup_mv - REFRESH EVERY 1 DAY DEPENDS ON daily_stats_mv APPEND
+          const weeklyResult = await verifyMaterializedViewRefreshConfig(
+            "weekly_rollup_mv",
+            {
+              intervalType: "EVERY",
+              intervalValue: 1,
+              intervalUnit: "DAY",
+              dependsOn: ["daily_stats_mv"],
+              append: true,
+            },
+            "local",
+          );
+          if (!weeklyResult.valid) {
+            throw new Error(
+              `weekly_rollup_mv refresh config validation failed: ${weeklyResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 4: randomized_stats_mv - REFRESH EVERY 5 MINUTE RANDOMIZE FOR 30 SECOND
+          const randomizedResult = await verifyMaterializedViewRefreshConfig(
+            "randomized_stats_mv",
+            {
+              intervalType: "EVERY",
+              intervalValue: 5,
+              intervalUnit: "MINUTE",
+              randomize: "30 SECOND",
+            },
+            "local",
+          );
+          if (!randomizedResult.valid) {
+            throw new Error(
+              `randomized_stats_mv refresh config validation failed: ${randomizedResult.errors.join(", ")}`,
+            );
+          }
+
+          // Test 5: incremental_stats_mv - should NOT have REFRESH clause (incremental MV)
+          const incrementalResult = await verifyIncrementalMaterializedView(
+            "incremental_stats_mv",
+            "local",
+          );
+          if (!incrementalResult.valid) {
+            throw new Error(
+              `incremental_stats_mv should be incremental (no REFRESH) but validation failed: ${incrementalResult.errors.join(", ")}`,
             );
           }
         });

--- a/apps/framework-cli-e2e/test/utils/database-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/database-utils.ts
@@ -708,7 +708,6 @@ export const getMaterializedViewDDL = async (
   mvName: string,
   database?: string,
 ): Promise<string> => {
-  const fullMvName = database ? `\`${database}\`.\`${mvName}\`` : mvName;
   const client = createClient(CLICKHOUSE_CONFIG);
   try {
     const result = await client.query({

--- a/apps/framework-cli/src/cli/routines/migrate.rs
+++ b/apps/framework-cli/src/cli/routines/migrate.rs
@@ -340,6 +340,7 @@ fn validate_table_databases_and_clusters(
             }
             SerializableOlapOperation::CreateMaterializedView { .. }
             | SerializableOlapOperation::DropMaterializedView { .. }
+            | SerializableOlapOperation::AlterMaterializedViewRefresh { .. }
             | SerializableOlapOperation::CreateView { .. }
             | SerializableOlapOperation::DropView { .. } => {
                 // Moose does not have cluster support for MV/View, skip validation

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -914,6 +914,76 @@ impl<T: OlapOperations + Sync> InfraRealityChecker<T> {
 }
 
 #[cfg(test)]
+mod materialized_view_diff_tests {
+    use super::MaterializedViewDiff;
+
+    #[test]
+    fn test_can_alter_refresh_only_change() {
+        let diff = MaterializedViewDiff {
+            select_changed: false,
+            target_changed: false,
+            kind_changed: false,
+            refresh_config_changed: true,
+            source_tables_changed: false,
+        };
+        assert!(diff.can_alter());
+        assert!(!diff.requires_recreate());
+    }
+
+    #[test]
+    fn test_cannot_alter_when_select_changed() {
+        let diff = MaterializedViewDiff {
+            select_changed: true,
+            target_changed: false,
+            kind_changed: false,
+            refresh_config_changed: true,
+            source_tables_changed: false,
+        };
+        assert!(!diff.can_alter());
+        assert!(diff.requires_recreate());
+    }
+
+    #[test]
+    fn test_cannot_alter_when_target_changed() {
+        let diff = MaterializedViewDiff {
+            select_changed: false,
+            target_changed: true,
+            kind_changed: false,
+            refresh_config_changed: false,
+            source_tables_changed: false,
+        };
+        assert!(!diff.can_alter());
+        assert!(diff.requires_recreate());
+    }
+
+    #[test]
+    fn test_cannot_alter_when_kind_changed() {
+        let diff = MaterializedViewDiff {
+            select_changed: false,
+            target_changed: false,
+            kind_changed: true,
+            refresh_config_changed: false,
+            source_tables_changed: false,
+        };
+        assert!(!diff.can_alter());
+        assert!(diff.requires_recreate());
+    }
+
+    #[test]
+    fn test_no_changes() {
+        let diff = MaterializedViewDiff {
+            select_changed: false,
+            target_changed: false,
+            kind_changed: false,
+            refresh_config_changed: false,
+            source_tables_changed: false,
+        };
+        assert!(!diff.can_alter());
+        assert!(!diff.requires_recreate());
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::cli::local_webserver::LocalWebserverConfig;

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -180,8 +180,8 @@ pub fn materialized_view_diff(
     // Kind changed if one has refresh_config and the other doesn't
     let kind_changed = old.is_refreshable() != new.is_refreshable();
 
-    // Check if SELECT SQL changed
-    let select_changed = !sql_is_equivalent(&old.select_sql, &new.select_sql, default_database);
+    // Check if SELECT SQL changed (must be pre-normalized via ClickHouse + Rust db prefix stripping)
+    let select_changed = old.select_sql != new.select_sql;
 
     // Check if target table changed
     let target_changed = normalize_table_name(&old.target_table, default_database)

--- a/apps/framework-cli/src/framework/core/infrastructure/materialized_view.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/materialized_view.rs
@@ -5,13 +5,19 @@
 //!
 //! A MaterializedView consists of:
 //! - A SELECT query that defines the transformation
-//! - Source tables/views that the SELECT reads from
+//! - Source tables/views that the SELECT reads from (for incremental MVs)
 //! - A target table where data is written
+//! - A kind that specifies whether the MV is incremental or refreshable
+//!
+//! Two types of materialized views are supported:
+//! - **Incremental (trigger-based)**: Run on every insert to source tables
+//! - **Refreshable**: Run on a schedule (REFRESH EVERY/AFTER)
 //!
 //! This structured representation allows for:
 //! - Better schema introspection
 //! - More accurate change detection
 //! - Clearer dependency tracking
+//! - Efficient updates via ALTER TABLE MODIFY REFRESH for refresh-only changes
 
 use protobuf::MessageField;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -19,8 +25,11 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::framework::core::partial_infrastructure_map::LifeCycle;
 use crate::proto::infrastructure_map::LifeCycle as ProtoLifeCycle;
 use crate::proto::infrastructure_map::{
-    MaterializedView as ProtoMaterializedView, SelectQuery as ProtoSelectQuery,
-    TableReference as ProtoTableReference,
+    materialized_view_kind::Kind as ProtoMvKind, refresh_interval::Interval_type as IntervalType,
+    IncrementalConfig as ProtoIncrementalConfig, MaterializedView as ProtoMaterializedView,
+    MaterializedViewKind as ProtoMaterializedViewKind, RefreshDuration as ProtoRefreshDuration,
+    RefreshInterval as ProtoRefreshInterval, RefreshableConfig as ProtoRefreshableConfig,
+    SelectQuery as ProtoSelectQuery, TableReference as ProtoTableReference,
 };
 
 use super::table::Metadata;
@@ -102,14 +111,195 @@ where
     Option::<T>::deserialize(d).map(|opt| opt.unwrap_or_default())
 }
 
+/// Refresh interval specification for refreshable materialized views.
+///
+/// ClickHouse supports two refresh modes:
+/// - `Every`: Periodic refresh at fixed intervals (REFRESH EVERY 1 hour)
+/// - `After`: Refresh after interval since last refresh completed (REFRESH AFTER 30 minutes)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum RefreshInterval {
+    /// REFRESH EVERY <interval> - periodic refresh at fixed times
+    #[serde(rename = "every")]
+    Every {
+        /// Interval in seconds
+        interval: u64,
+    },
+    /// REFRESH AFTER <interval> - refresh after interval since last refresh
+    #[serde(rename = "after")]
+    After {
+        /// Interval in seconds
+        interval: u64,
+    },
+}
+
+impl RefreshInterval {
+    /// Create an "EVERY" interval from seconds
+    pub fn every(seconds: u64) -> Self {
+        Self::Every { interval: seconds }
+    }
+
+    /// Create an "AFTER" interval from seconds
+    pub fn after(seconds: u64) -> Self {
+        Self::After { interval: seconds }
+    }
+
+    /// Create an "EVERY" interval from hours
+    pub fn every_hours(hours: u64) -> Self {
+        Self::Every {
+            interval: hours * 3600,
+        }
+    }
+
+    /// Create an "EVERY" interval from minutes
+    pub fn every_minutes(minutes: u64) -> Self {
+        Self::Every {
+            interval: minutes * 60,
+        }
+    }
+
+    /// Create an "AFTER" interval from hours
+    pub fn after_hours(hours: u64) -> Self {
+        Self::After {
+            interval: hours * 3600,
+        }
+    }
+
+    /// Create an "AFTER" interval from minutes
+    pub fn after_minutes(minutes: u64) -> Self {
+        Self::After {
+            interval: minutes * 60,
+        }
+    }
+
+    /// Convert to proto representation
+    pub fn to_proto(&self) -> ProtoRefreshInterval {
+        match self {
+            RefreshInterval::Every { interval } => ProtoRefreshInterval {
+                interval_type: Some(IntervalType::Every(ProtoRefreshDuration {
+                    seconds: *interval,
+                    special_fields: Default::default(),
+                })),
+                special_fields: Default::default(),
+            },
+            RefreshInterval::After { interval } => ProtoRefreshInterval {
+                interval_type: Some(IntervalType::After(ProtoRefreshDuration {
+                    seconds: *interval,
+                    special_fields: Default::default(),
+                })),
+                special_fields: Default::default(),
+            },
+        }
+    }
+
+    /// Create from proto representation
+    pub fn from_proto(proto: ProtoRefreshInterval) -> Option<Self> {
+        match proto.interval_type {
+            Some(IntervalType::Every(dur)) => Some(RefreshInterval::Every {
+                interval: dur.seconds,
+            }),
+            Some(IntervalType::After(dur)) => Some(RefreshInterval::After {
+                interval: dur.seconds,
+            }),
+            None => None,
+        }
+    }
+}
+
+/// Configuration for refreshable materialized views.
+///
+/// Refreshable MVs execute their SELECT query on a schedule rather than
+/// on every insert to source tables.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshableConfig {
+    /// The refresh interval (EVERY or AFTER)
+    pub interval: RefreshInterval,
+    /// Optional offset from the interval start in seconds (OFFSET 5 minutes)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+    /// Optional randomization window in seconds (RANDOMIZE FOR 10 seconds)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub randomize: Option<u64>,
+    /// Other MVs this one depends on (DEPENDS ON other_mv1, other_mv2)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    /// Whether to use APPEND mode (vs full refresh)
+    #[serde(default)]
+    pub append: bool,
+}
+
+impl RefreshableConfig {
+    /// Create a new refreshable config with just an interval
+    pub fn new(interval: RefreshInterval) -> Self {
+        Self {
+            interval,
+            offset: None,
+            randomize: None,
+            depends_on: Vec::new(),
+            append: false,
+        }
+    }
+
+    /// Convert to proto representation
+    pub fn to_proto(&self) -> ProtoRefreshableConfig {
+        ProtoRefreshableConfig {
+            interval: MessageField::some(self.interval.to_proto()),
+            offset: self
+                .offset
+                .map(|secs| ProtoRefreshDuration {
+                    seconds: secs,
+                    special_fields: Default::default(),
+                })
+                .into(),
+            randomize: self
+                .randomize
+                .map(|secs| ProtoRefreshDuration {
+                    seconds: secs,
+                    special_fields: Default::default(),
+                })
+                .into(),
+            depends_on: self.depends_on.clone(),
+            append: self.append,
+            special_fields: Default::default(),
+        }
+    }
+
+    /// Create from proto representation
+    pub fn from_proto(proto: ProtoRefreshableConfig) -> Option<Self> {
+        let interval = proto
+            .interval
+            .into_option()
+            .and_then(RefreshInterval::from_proto)?;
+
+        Some(Self {
+            interval,
+            offset: proto.offset.into_option().map(|d| d.seconds),
+            randomize: proto.randomize.into_option().map(|d| d.seconds),
+            depends_on: proto.depends_on,
+            append: proto.append,
+        })
+    }
+}
+
+// Note: MaterializedViewKind enum has been removed in favor of a simpler model.
+// If refresh_config is Some, it's a refreshable MV; if None, it's incremental.
+// This is cleaner and avoids an empty IncrementalConfig marker type.
+
+
 /// Represents a ClickHouse Materialized View.
 ///
 /// A MaterializedView is a special view that:
-/// 1. Runs a SELECT query whenever data is inserted into source tables
-/// 2. Writes the transformed results to a target table
+/// 1. Runs a SELECT query whenever data is inserted into source tables (incremental)
+/// 2. Or runs on a schedule (refreshable)
+/// 3. Writes the transformed results to a target table
 ///
 /// Unlike regular views, MVs persist data and can significantly speed up
 /// queries at the cost of storage and insert-time computation.
+///
+/// Two types of materialized views are supported:
+/// - **Incremental**: Triggered on every insert to source tables (refresh_config is None)
+/// - **Refreshable**: Runs on a schedule (refresh_config is Some)
 ///
 /// The structure is flat to match JSON output from TypeScript/Python moose-lib.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,7 +315,11 @@ pub struct MaterializedView {
     /// The raw SELECT SQL statement
     pub select_sql: String,
 
-    /// Names of source tables/views referenced in the SELECT
+    /// Names of source tables/views referenced in the SELECT.
+    /// This field is used for BOTH incremental and refreshable MVs:
+    /// - For incremental MVs: these tables trigger the MV on insert
+    /// - For refreshable MVs: these tables are read during scheduled refresh (data lineage)
+    #[serde(default)]
     pub source_tables: Vec<String>,
 
     /// Name of the target table where transformed data is written
@@ -143,10 +337,16 @@ pub struct MaterializedView {
     /// Controls whether Moose can drop or modify the MV automatically.
     #[serde(default, deserialize_with = "deserialize_nullable_as_default")]
     pub life_cycle: LifeCycle,
+
+    /// Refresh configuration for refreshable MVs.
+    /// If Some, this is a refreshable MV that runs on a schedule.
+    /// If None, this is an incremental MV triggered by inserts to source_tables.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub refresh_config: Option<RefreshableConfig>,
 }
 
 impl MaterializedView {
-    /// Creates a new MaterializedView
+    /// Creates a new incremental MaterializedView
     pub fn new(
         name: impl Into<String>,
         select_sql: impl Into<String>,
@@ -162,7 +362,64 @@ impl MaterializedView {
             target_database: None,
             metadata: None,
             life_cycle: LifeCycle::FullyManaged,
+            refresh_config: None, // Incremental MV
         }
+    }
+
+    /// Creates a new incremental MaterializedView (alias for new)
+    pub fn new_incremental(
+        name: impl Into<String>,
+        select_sql: impl Into<String>,
+        source_tables: Vec<String>,
+        target_table: impl Into<String>,
+    ) -> Self {
+        Self::new(name, select_sql, source_tables, target_table)
+    }
+
+    /// Creates a new refreshable MaterializedView
+    ///
+    /// Note: `source_tables` should list the tables read by the SELECT for data lineage tracking.
+    pub fn new_refreshable(
+        name: impl Into<String>,
+        select_sql: impl Into<String>,
+        source_tables: Vec<String>,
+        target_table: impl Into<String>,
+        refresh_config: RefreshableConfig,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            database: None,
+            select_sql: select_sql.into(),
+            source_tables,
+            target_table: target_table.into(),
+            target_database: None,
+            metadata: None,
+            life_cycle: LifeCycle::FullyManaged,
+            refresh_config: Some(refresh_config),
+        }
+    }
+
+    /// Returns true if this is an incremental (trigger-based) MV
+    pub fn is_incremental(&self) -> bool {
+        self.refresh_config.is_none()
+    }
+
+    /// Returns true if this is a refreshable (scheduled) MV
+    pub fn is_refreshable(&self) -> bool {
+        self.refresh_config.is_some()
+    }
+
+    /// Returns the source tables for this MV.
+    /// Both incremental and refreshable MVs have source tables - the tables
+    /// referenced in the SELECT query. For incremental MVs these also serve
+    /// as triggers; for refreshable MVs they track data lineage.
+    pub fn get_source_tables(&self) -> &[String] {
+        &self.source_tables
+    }
+
+    /// Returns the refreshable config if this is a refreshable MV
+    pub fn refreshable_config(&self) -> Option<&RefreshableConfig> {
+        self.refresh_config.as_ref()
     }
 
     /// Returns a unique identifier for this MV
@@ -189,14 +446,82 @@ impl MaterializedView {
         }
     }
 
+    /// Format seconds as a ClickHouse interval string (e.g., "1 HOUR", "30 MINUTE")
+    fn format_seconds(secs: u64) -> String {
+        if secs % 86400 == 0 && secs >= 86400 {
+            format!("{} DAY", secs / 86400)
+        } else if secs % 3600 == 0 && secs >= 3600 {
+            format!("{} HOUR", secs / 3600)
+        } else if secs % 60 == 0 && secs >= 60 {
+            format!("{} MINUTE", secs / 60)
+        } else {
+            format!("{} SECOND", secs)
+        }
+    }
+
+    /// Format the REFRESH clause for refreshable MVs
+    fn format_refresh_clause(config: &RefreshableConfig) -> String {
+        let mut parts = Vec::new();
+
+        // Add interval type
+        match &config.interval {
+            RefreshInterval::Every { interval } => {
+                parts.push(format!("EVERY {}", Self::format_seconds(*interval)));
+            }
+            RefreshInterval::After { interval } => {
+                parts.push(format!("AFTER {}", Self::format_seconds(*interval)));
+            }
+        }
+
+        // Add optional OFFSET
+        if let Some(offset) = config.offset {
+            parts.push(format!("OFFSET {}", Self::format_seconds(offset)));
+        }
+
+        // Add optional RANDOMIZE FOR
+        if let Some(randomize) = config.randomize {
+            parts.push(format!("RANDOMIZE FOR {}", Self::format_seconds(randomize)));
+        }
+
+        // Add optional DEPENDS ON
+        if !config.depends_on.is_empty() {
+            parts.push(format!("DEPENDS ON {}", config.depends_on.join(", ")));
+        }
+
+        // Add optional APPEND
+        if config.append {
+            parts.push("APPEND".to_string());
+        }
+
+        parts.join(" ")
+    }
+
     /// Generates the CREATE MATERIALIZED VIEW SQL statement
     pub fn to_create_sql(&self) -> String {
+        let refresh_clause = match self.refreshable_config() {
+            Some(config) => format!(" REFRESH {}", Self::format_refresh_clause(config)),
+            None => String::new(),
+        };
+
         format!(
-            "CREATE MATERIALIZED VIEW IF NOT EXISTS {} TO {} AS {}",
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS {}{} TO {} AS {}",
             self.quoted_name(),
+            refresh_clause,
             self.quoted_target_table(),
             self.select_sql
         )
+    }
+
+    /// Generates the ALTER TABLE MODIFY REFRESH SQL statement.
+    /// Only valid for refreshable MVs.
+    pub fn to_alter_refresh_sql(&self) -> Option<String> {
+        self.refreshable_config().map(|config| {
+            format!(
+                "ALTER TABLE {} MODIFY REFRESH {}",
+                self.quoted_name(),
+                Self::format_refresh_clause(config)
+            )
+        })
     }
 
     /// Generates the DROP VIEW SQL statement
@@ -206,23 +531,53 @@ impl MaterializedView {
 
     /// Short display string for logging/UI
     pub fn short_display(&self) -> String {
-        format!("MaterializedView: {} -> {}", self.name, self.target_table)
+        let kind_str = if self.is_refreshable() {
+            " (refreshable)"
+        } else {
+            ""
+        };
+        format!(
+            "MaterializedView{}: {} -> {}",
+            kind_str, self.name, self.target_table
+        )
     }
 
     /// Expanded display string with more details
     pub fn expanded_display(&self) -> String {
-        format!(
-            "MaterializedView: {} (sources: {:?}) -> {}",
-            self.name, self.source_tables, self.target_table
-        )
+        match self.refreshable_config() {
+            Some(config) => {
+                let interval_str = match &config.interval {
+                    RefreshInterval::Every { interval } => {
+                        format!("EVERY {}", Self::format_seconds(*interval))
+                    }
+                    RefreshInterval::After { interval } => {
+                        format!("AFTER {}", Self::format_seconds(*interval))
+                    }
+                };
+                format!(
+                    "MaterializedView: {} (refresh: {}) -> {}",
+                    self.name, interval_str, self.target_table
+                )
+            }
+            None => {
+                format!(
+                    "MaterializedView: {} (sources: {:?}) -> {}",
+                    self.name,
+                    self.get_source_tables(),
+                    self.target_table
+                )
+            }
+        }
     }
 
     /// Convert to proto representation
     pub fn to_proto(&self) -> ProtoMaterializedView {
+        // Get source tables from the effective kind
+        let source_tables_for_select = self.get_source_tables();
+
         let select_query = ProtoSelectQuery {
             sql: self.select_sql.clone(),
-            source_tables: self
-                .source_tables
+            source_tables: source_tables_for_select
                 .iter()
                 .map(|t| ProtoTableReference {
                     database: None,
@@ -237,6 +592,21 @@ impl MaterializedView {
             database: self.target_database.clone(),
             table: self.target_table.clone(),
             special_fields: Default::default(),
+        };
+
+        // Convert refresh_config to proto's MaterializedViewKind format
+        let proto_kind = match &self.refresh_config {
+            None => ProtoMaterializedViewKind {
+                kind: Some(ProtoMvKind::Incremental(ProtoIncrementalConfig {
+                    source_tables: Vec::new(), // Deprecated, source_tables are in select_query
+                    special_fields: Default::default(),
+                })),
+                special_fields: Default::default(),
+            },
+            Some(config) => ProtoMaterializedViewKind {
+                kind: Some(ProtoMvKind::Refreshable(config.to_proto())),
+                special_fields: Default::default(),
+            },
         };
 
         ProtoMaterializedView {
@@ -261,6 +631,7 @@ impl MaterializedView {
                 LifeCycle::DeletionProtected => ProtoLifeCycle::DELETION_PROTECTED.into(),
                 LifeCycle::ExternallyManaged => ProtoLifeCycle::EXTERNALLY_MANAGED.into(),
             },
+            kind: MessageField::some(proto_kind),
             special_fields: Default::default(),
         }
     }
@@ -269,17 +640,22 @@ impl MaterializedView {
     pub fn from_proto(proto: ProtoMaterializedView) -> Self {
         let (select_sql, source_tables) = proto
             .select_query
+            .as_ref()
             .map(|sq| {
                 (
-                    sq.sql,
-                    sq.source_tables.into_iter().map(|t| t.table).collect(),
+                    sq.sql.clone(),
+                    sq.source_tables
+                        .iter()
+                        .map(|t| t.table.clone())
+                        .collect::<Vec<_>>(),
                 )
             })
             .unwrap_or_default();
 
         let (target_table, target_database) = proto
             .target_table
-            .map(|t| (t.table, t.database))
+            .as_ref()
+            .map(|t| (t.table.clone(), t.database.clone()))
             .unwrap_or_default();
 
         let metadata = proto.metadata.into_option().map(|m| Metadata {
@@ -300,6 +676,14 @@ impl MaterializedView {
             ProtoLifeCycle::EXTERNALLY_MANAGED => LifeCycle::ExternallyManaged,
         };
 
+        // Parse refresh_config from proto's MaterializedViewKind
+        // If Incremental or missing, refresh_config is None
+        // If Refreshable, extract the config
+        let refresh_config = proto.kind.into_option().and_then(|kind| match kind.kind {
+            Some(ProtoMvKind::Refreshable(config)) => RefreshableConfig::from_proto(config),
+            _ => None, // Incremental or missing -> None
+        });
+
         Self {
             name: proto.name,
             database: proto.database,
@@ -309,6 +693,7 @@ impl MaterializedView {
             target_database,
             metadata,
             life_cycle,
+            refresh_config,
         }
     }
 }
@@ -346,12 +731,25 @@ impl MaterializedView {
 
 impl DataLineage for MaterializedView {
     fn pulls_data_from(&self, default_database: &str) -> Vec<InfrastructureSignature> {
-        self.source_tables
+        // Both incremental and refreshable MVs have source tables for data lineage
+        let mut signatures: Vec<InfrastructureSignature> = self
+            .get_source_tables()
             .iter()
             .map(|t| InfrastructureSignature::Table {
                 id: Self::table_reference_to_id(t, default_database),
             })
-            .collect()
+            .collect();
+
+        // For refreshable MVs, also add dependencies on other MVs (DEPENDS ON clause)
+        if let Some(config) = &self.refresh_config {
+            for dep in &config.depends_on {
+                signatures.push(InfrastructureSignature::MaterializedView {
+                    id: format!("{}_{}", default_database, dep),
+                });
+            }
+        }
+
+        signatures
     }
 
     fn pushes_data_to(&self, default_database: &str) -> Vec<InfrastructureSignature> {
@@ -397,6 +795,115 @@ mod tests {
         assert!(sql.contains("`user_stats_mv`"));
         assert!(sql.contains("TO `user_stats`"));
         assert!(sql.contains("SELECT user_id, count(*) as cnt FROM events GROUP BY user_id"));
+        // Incremental MV should not have REFRESH clause
+        assert!(!sql.contains("REFRESH"));
+    }
+
+    #[test]
+    fn test_refreshable_mv_create_sql_every() {
+        let refresh_config = RefreshableConfig {
+            interval: RefreshInterval::every(3600), // 1 hour
+            offset: Some(300),                      // 5 minutes
+            randomize: None,
+            depends_on: Vec::new(),
+            append: false,
+        };
+
+        let mv = MaterializedView::new_refreshable(
+            "hourly_stats_mv",
+            "SELECT count(*) as cnt FROM events",
+            vec!["events".to_string()],
+            "hourly_stats",
+            refresh_config,
+        );
+
+        let sql = mv.to_create_sql();
+        assert!(sql.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS"));
+        assert!(sql.contains("`hourly_stats_mv`"));
+        assert!(sql.contains("REFRESH EVERY 1 HOUR OFFSET 5 MINUTE"));
+        assert!(sql.contains("TO `hourly_stats`"));
+    }
+
+    #[test]
+    fn test_refreshable_mv_create_sql_after() {
+        let refresh_config = RefreshableConfig {
+            interval: RefreshInterval::after(1800), // 30 minutes
+            offset: None,
+            randomize: Some(60), // 1 minute
+            depends_on: vec!["other_mv".to_string()],
+            append: true,
+        };
+
+        let mv = MaterializedView::new_refreshable(
+            "derived_mv",
+            "SELECT * FROM other_mv",
+            vec!["other_mv".to_string()],
+            "derived_table",
+            refresh_config,
+        );
+
+        let sql = mv.to_create_sql();
+        assert!(sql.contains("REFRESH AFTER 30 MINUTE"));
+        assert!(sql.contains("RANDOMIZE FOR 1 MINUTE"));
+        assert!(sql.contains("DEPENDS ON other_mv"));
+        assert!(sql.contains("APPEND"));
+    }
+
+    #[test]
+    fn test_refreshable_mv_alter_refresh_sql() {
+        let refresh_config = RefreshableConfig::new(RefreshInterval::every(7200)); // 2 hours
+
+        let mv = MaterializedView::new_refreshable(
+            "hourly_stats_mv",
+            "SELECT count(*) as cnt FROM events",
+            vec!["events".to_string()],
+            "hourly_stats",
+            refresh_config,
+        );
+
+        let alter_sql = mv.to_alter_refresh_sql();
+        assert!(alter_sql.is_some());
+        let sql = alter_sql.unwrap();
+        assert!(sql.contains("ALTER TABLE `hourly_stats_mv` MODIFY REFRESH EVERY 2 HOUR"));
+    }
+
+    #[test]
+    fn test_incremental_mv_no_alter_refresh() {
+        let mv = MaterializedView::new(
+            "user_stats_mv",
+            "SELECT user_id, count(*) as cnt FROM events GROUP BY user_id",
+            vec!["events".to_string()],
+            "user_stats",
+        );
+
+        // Incremental MVs should not support ALTER REFRESH
+        assert!(mv.to_alter_refresh_sql().is_none());
+    }
+
+    #[test]
+    fn test_materialized_view_is_incremental() {
+        let mv = MaterializedView::new(
+            "mv",
+            "SELECT * FROM events",
+            vec!["events".to_string()],
+            "target",
+        );
+        assert!(mv.is_incremental());
+        assert!(!mv.is_refreshable());
+    }
+
+    #[test]
+    fn test_materialized_view_is_refreshable() {
+        let refresh_config = RefreshableConfig::new(RefreshInterval::every(3600));
+        let mv = MaterializedView::new_refreshable(
+            "mv",
+            "SELECT * FROM events",
+            vec!["events".to_string()],
+            "target",
+            refresh_config,
+        );
+        assert!(!mv.is_incremental());
+        assert!(mv.is_refreshable());
     }
 
     #[test]
@@ -413,6 +920,38 @@ mod tests {
 
         let pushes = mv.pushes_data_to("local");
         assert_eq!(pushes.len(), 1);
+    }
+
+    #[test]
+    fn test_refreshable_mv_data_lineage_with_depends_on() {
+        let refresh_config = RefreshableConfig {
+            interval: RefreshInterval::every(3600),
+            offset: None,
+            randomize: None,
+            depends_on: vec!["other_mv".to_string(), "another_mv".to_string()],
+            append: false,
+        };
+
+        let mv = MaterializedView::new_refreshable(
+            "derived_mv",
+            "SELECT * FROM target_table",
+            vec!["target_table".to_string()],
+            "derived_table",
+            refresh_config,
+        );
+
+        let pulls = mv.pulls_data_from("local");
+        // Should include the source tables AND the dependent MVs
+        assert_eq!(pulls.len(), 3);
+        assert!(pulls.contains(&InfrastructureSignature::Table {
+            id: "local_target_table".to_string()
+        }));
+        assert!(pulls.contains(&InfrastructureSignature::MaterializedView {
+            id: "local_other_mv".to_string()
+        }));
+        assert!(pulls.contains(&InfrastructureSignature::MaterializedView {
+            id: "local_another_mv".to_string()
+        }));
     }
 
     #[test]
@@ -578,5 +1117,116 @@ mod tests {
         assert!(!json.contains("select_sql"));
         assert!(!json.contains("source_tables"));
         assert!(!json.contains("target_table"));
+    }
+
+    #[test]
+    fn test_materialized_view_serde_incremental() {
+        let mv = MaterializedView::new(
+            "test_mv",
+            "SELECT * FROM source",
+            vec!["source".to_string()],
+            "target",
+        );
+
+        let json = serde_json::to_string(&mv).unwrap();
+        // Incremental MVs should NOT have a refreshConfig field (it's None and skipped)
+        assert!(!json.contains("refreshConfig"));
+
+        // Round-trip
+        let deserialized: MaterializedView = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_incremental());
+        assert!(!deserialized.is_refreshable());
+        assert_eq!(deserialized.get_source_tables(), &["source".to_string()]);
+    }
+
+    #[test]
+    fn test_materialized_view_serde_refreshable() {
+        let refresh_config = RefreshableConfig {
+            interval: RefreshInterval::every(3600),
+            offset: Some(300),
+            randomize: None,
+            depends_on: vec!["dep1".to_string()],
+            append: true,
+        };
+
+        let mv = MaterializedView::new_refreshable(
+            "test_mv",
+            "SELECT * FROM source",
+            vec!["source".to_string()],
+            "target",
+            refresh_config,
+        );
+
+        let json = serde_json::to_string(&mv).unwrap();
+        // Refreshable MVs should have a refreshConfig field
+        assert!(json.contains("refreshConfig"));
+        // The interval should have type discriminator
+        assert!(json.contains(r#""type":"every""#));
+
+        // Round-trip
+        let deserialized: MaterializedView = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_refreshable());
+        assert!(!deserialized.is_incremental());
+        let config = deserialized.refreshable_config().unwrap();
+        assert_eq!(config.offset, Some(300));
+        assert_eq!(config.depends_on, vec!["dep1".to_string()]);
+        assert!(config.append);
+    }
+
+    #[test]
+    fn test_format_seconds() {
+        // Test various duration formats
+        assert_eq!(MaterializedView::format_seconds(30), "30 SECOND");
+        assert_eq!(MaterializedView::format_seconds(60), "1 MINUTE");
+        assert_eq!(MaterializedView::format_seconds(90), "90 SECOND");
+        assert_eq!(MaterializedView::format_seconds(3600), "1 HOUR");
+        assert_eq!(MaterializedView::format_seconds(7200), "2 HOUR");
+        assert_eq!(MaterializedView::format_seconds(86400), "1 DAY");
+        assert_eq!(MaterializedView::format_seconds(172800), "2 DAY");
+    }
+
+    #[test]
+    fn test_backward_compat_no_kind_field() {
+        // Test deserialization without kind field (backward compatibility)
+        let json = r#"{
+            "name": "test_mv",
+            "selectSql": "SELECT * FROM source",
+            "sourceTables": ["source"],
+            "targetTable": "target"
+        }"#;
+
+        let mv: MaterializedView = serde_json::from_str(json).unwrap();
+        // Should default to incremental with source_tables from the field
+        assert!(mv.is_incremental());
+        assert_eq!(mv.get_source_tables(), &["source".to_string()]);
+    }
+
+    #[test]
+    fn test_deserialize_from_sdk_format() {
+        // Test deserializing JSON as sent by TypeScript/Python SDKs
+        let json = r#"{
+            "name": "hourly_stats_mv",
+            "selectSql": "SELECT count(*) FROM events",
+            "sourceTables": ["events"],
+            "targetTable": "hourly_stats",
+            "refreshConfig": {
+                "interval": { "type": "every", "interval": 3600 },
+                "offset": 300,
+                "dependsOn": ["other_mv"],
+                "append": false
+            }
+        }"#;
+
+        let mv: MaterializedView = serde_json::from_str(json).unwrap();
+        assert!(mv.is_refreshable());
+        let config = mv.refreshable_config().unwrap();
+        assert_eq!(config.offset, Some(300));
+        assert_eq!(config.depends_on, vec!["other_mv".to_string()]);
+        assert!(!config.append);
+
+        match &config.interval {
+            RefreshInterval::Every { interval } => assert_eq!(*interval, 3600),
+            _ => panic!("Expected Every interval"),
+        }
     }
 }

--- a/apps/framework-cli/src/framework/core/infrastructure/materialized_view.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/materialized_view.rs
@@ -512,6 +512,13 @@ impl MaterializedView {
         )
     }
 
+    /// Returns the REFRESH clause (e.g. "REFRESH EVERY 1 HOUR OFFSET 5 MINUTE")
+    /// for use in CREATE MATERIALIZED VIEW statements. Returns None for incremental MVs.
+    pub fn refresh_clause(&self) -> Option<String> {
+        self.refreshable_config()
+            .map(|config| format!("REFRESH {}", Self::format_refresh_clause(config)))
+    }
+
     /// Generates the ALTER TABLE MODIFY REFRESH SQL statement.
     /// Only valid for refreshable MVs.
     pub fn to_alter_refresh_sql(&self) -> Option<String> {

--- a/apps/framework-cli/src/framework/core/infrastructure/materialized_view.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/materialized_view.rs
@@ -448,11 +448,11 @@ impl MaterializedView {
 
     /// Format seconds as a ClickHouse interval string (e.g., "1 HOUR", "30 MINUTE")
     fn format_seconds(secs: u64) -> String {
-        if secs % 86400 == 0 && secs >= 86400 {
+        if secs.is_multiple_of(86400) && secs >= 86400 {
             format!("{} DAY", secs / 86400)
-        } else if secs % 3600 == 0 && secs >= 3600 {
+        } else if secs.is_multiple_of(3600) && secs >= 3600 {
             format!("{} HOUR", secs / 3600)
-        } else if secs % 60 == 0 && secs >= 60 {
+        } else if secs.is_multiple_of(60) && secs >= 60 {
             format!("{} MINUTE", secs / 60)
         } else {
             format!("{} SECOND", secs)

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2880,20 +2880,18 @@ impl InfrastructureMap {
     }
 
     /// Parses a REFRESH clause from a CREATE MATERIALIZED VIEW statement.
-    /// Returns Some(RefreshableConfig) if a REFRESH clause is found, None otherwise.
-    ///
-    /// Supported formats:
-    /// - REFRESH EVERY <n> <unit> (e.g., "REFRESH EVERY 1 MINUTE")
-    /// - REFRESH AFTER <n> <unit> (e.g., "REFRESH AFTER 30 SECOND")
     /// Parses the REFRESH clause from a CREATE MATERIALIZED VIEW statement.
     /// Extracts: interval (EVERY/AFTER), OFFSET, RANDOMIZE, DEPENDS ON, and APPEND.
     ///
-    /// Example SQL patterns:
-    /// - REFRESH EVERY 1 HOUR
-    /// - REFRESH AFTER 30 MINUTE OFFSET 5 MINUTE
-    /// - REFRESH EVERY 1 DAY RANDOMIZE FOR 10 SECOND
-    /// - REFRESH EVERY 1 HOUR DEPENDS ON other_mv
-    /// - REFRESH EVERY 1 DAY DEPENDS ON mv1, mv2 APPEND
+    /// Returns Some(RefreshableConfig) if a REFRESH clause is found, None otherwise.
+    ///
+    /// # Example SQL patterns
+    ///
+    /// - `REFRESH EVERY 1 HOUR`
+    /// - `REFRESH AFTER 30 MINUTE OFFSET 5 MINUTE`
+    /// - `REFRESH EVERY 1 DAY RANDOMIZE FOR 10 SECOND`
+    /// - `REFRESH EVERY 1 HOUR DEPENDS ON other_mv`
+    /// - `REFRESH EVERY 1 DAY DEPENDS ON mv1, mv2 APPEND`
     fn parse_refresh_clause(sql: &str) -> Option<RefreshableConfig> {
         use regex::Regex;
         use std::sync::LazyLock;

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2937,6 +2937,8 @@ impl InfrastructureMap {
             target_database: parsed.target_database,
             metadata,
             life_cycle: crate::framework::core::partial_infrastructure_map::LifeCycle::FullyManaged,
+            // Legacy MVs from SqlResource are always incremental (no refresh_config)
+            refresh_config: None,
         })
     }
 

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2932,8 +2932,9 @@ impl InfrastructureMap {
 
         // Pattern to match DEPENDS ON <mv_list>
         // MV names can be: mv_name, `mv_name`, database.mv_name, `database`.`mv_name`
+        // The .+? is non-greedy and will match until the suffix pattern matches
         static DEPENDS_ON_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"(?i)DEPENDS\s+ON\s+([^T]+?)(?:\s+TO\s+|\s+APPEND|\s*$)")
+            Regex::new(r"(?i)DEPENDS\s+ON\s+(.+?)(?:\s+TO\s+|\s+APPEND|\s*$)")
                 .expect("DEPENDS_ON_PATTERN regex should compile")
         });
 
@@ -4528,6 +4529,96 @@ mod tests {
             table_removals, 1,
             "When respect_life_cycle=false, drops should not be blocked"
         );
+    }
+}
+
+#[cfg(test)]
+mod parse_refresh_clause_tests {
+    use super::InfrastructureMap;
+    use crate::framework::core::infrastructure::materialized_view::RefreshInterval;
+
+    #[test]
+    fn test_depends_on_with_names_containing_t() {
+        // This test verifies the fix for the regex bug where [^T]+? would fail
+        // to match MV names containing 't' like "test_mv", "my_table", etc.
+        let sql = "REFRESH EVERY 1 HOUR DEPENDS ON test_mv TO `local`.`target_table`";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(config.depends_on, vec!["test_mv"]);
+    }
+
+    #[test]
+    fn test_depends_on_multiple_mvs_with_t() {
+        let sql = "REFRESH EVERY 1 DAY DEPENDS ON test_mv, my_table, another_one APPEND";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(
+            config.depends_on,
+            vec!["test_mv", "my_table", "another_one"]
+        );
+        assert!(config.append);
+    }
+
+    #[test]
+    fn test_depends_on_with_backticks() {
+        let sql = "REFRESH EVERY 1 HOUR DEPENDS ON `test_mv`, `local`.`table_name` TO target";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        // The database prefix should be stripped
+        assert_eq!(config.depends_on, vec!["test_mv", "table_name"]);
+    }
+
+    #[test]
+    fn test_depends_on_at_end_of_string() {
+        let sql = "REFRESH EVERY 1 HOUR DEPENDS ON DailyStats_MV";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(config.depends_on, vec!["DailyStats_MV"]);
+    }
+
+    #[test]
+    fn test_basic_refresh_every() {
+        let sql = "REFRESH EVERY 1 HOUR";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert!(matches!(
+            config.interval,
+            RefreshInterval::Every { interval: 3600 }
+        ));
+    }
+
+    #[test]
+    fn test_basic_refresh_after() {
+        let sql = "REFRESH AFTER 30 MINUTE";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert!(matches!(
+            config.interval,
+            RefreshInterval::After { interval: 1800 }
+        ));
+    }
+
+    #[test]
+    fn test_offset_only_valid_with_every() {
+        let sql = "REFRESH EVERY 1 HOUR OFFSET 5 MINUTE";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(config.offset, Some(300)); // 5 minutes in seconds
+    }
+
+    #[test]
+    fn test_randomize() {
+        let sql = "REFRESH EVERY 5 MINUTE RANDOMIZE FOR 30 SECOND";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(config.randomize, Some(30));
+    }
+
+    #[test]
+    fn test_full_config() {
+        let sql =
+            "REFRESH EVERY 1 DAY OFFSET 1 HOUR RANDOMIZE FOR 5 MINUTE DEPENDS ON mv1, mv2 APPEND";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert!(matches!(
+            config.interval,
+            RefreshInterval::Every { interval: 86400 }
+        ));
+        assert_eq!(config.offset, Some(3600));
+        assert_eq!(config.randomize, Some(300));
+        assert_eq!(config.depends_on, vec!["mv1", "mv2"]);
+        assert!(config.append);
     }
 }
 

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2879,7 +2879,6 @@ impl InfrastructureMap {
         })
     }
 
-    /// Parses a REFRESH clause from a CREATE MATERIALIZED VIEW statement.
     /// Parses the REFRESH clause from a CREATE MATERIALIZED VIEW statement.
     /// Extracts: interval (EVERY/AFTER), OFFSET, RANDOMIZE, DEPENDS ON, and APPEND.
     ///
@@ -2896,19 +2895,7 @@ impl InfrastructureMap {
         use regex::Regex;
         use std::sync::LazyLock;
 
-        // Helper to convert value + unit to seconds
-        fn to_seconds(value: u64, unit: &str) -> Option<u64> {
-            match unit.to_uppercase().as_str() {
-                "SECOND" => Some(value),
-                "MINUTE" => Some(value * 60),
-                "HOUR" => Some(value * 3600),
-                "DAY" => Some(value * 86400),
-                "WEEK" => Some(value * 604800),
-                "MONTH" => Some(value * 2592000), // Approximate: 30 days
-                "YEAR" => Some(value * 31536000), // Approximate: 365 days
-                _ => None,
-            }
-        }
+        use crate::framework::core::infrastructure::materialized_view::{Duration, TimeUnit};
 
         // Pattern to match REFRESH EVERY/AFTER <n> <unit>
         static REFRESH_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
@@ -2947,28 +2934,30 @@ impl InfrastructureMap {
         let caps = REFRESH_PATTERN.captures(sql)?;
         let mode = caps.get(1)?.as_str().to_uppercase();
         let value: u64 = caps.get(2)?.as_str().parse().ok()?;
-        let unit = caps.get(3)?.as_str();
-
-        let seconds = to_seconds(value, unit)?;
+        let unit_str = caps.get(3)?.as_str();
+        let unit = TimeUnit::parse(unit_str)?;
 
         let interval = match mode.as_str() {
-            "EVERY" => RefreshInterval::Every { interval: seconds },
-            "AFTER" => RefreshInterval::After { interval: seconds },
+            "EVERY" => RefreshInterval::Every {
+                value,
+                unit: unit.clone(),
+            },
+            "AFTER" => RefreshInterval::After { value, unit },
             _ => return None,
         };
 
         // Parse optional OFFSET
         let offset = OFFSET_PATTERN.captures(sql).and_then(|caps| {
             let value: u64 = caps.get(1)?.as_str().parse().ok()?;
-            let unit = caps.get(2)?.as_str();
-            to_seconds(value, unit)
+            let unit = TimeUnit::parse(caps.get(2)?.as_str())?;
+            Some(Duration::new(value, unit))
         });
 
         // Parse optional RANDOMIZE
         let randomize = RANDOMIZE_PATTERN.captures(sql).and_then(|caps| {
             let value: u64 = caps.get(1)?.as_str().parse().ok()?;
-            let unit = caps.get(2)?.as_str();
-            to_seconds(value, unit)
+            let unit = TimeUnit::parse(caps.get(2)?.as_str())?;
+            Some(Duration::new(value, unit))
         });
 
         // Parse optional DEPENDS ON
@@ -4535,7 +4524,9 @@ mod tests {
 #[cfg(test)]
 mod parse_refresh_clause_tests {
     use super::InfrastructureMap;
-    use crate::framework::core::infrastructure::materialized_view::RefreshInterval;
+    use crate::framework::core::infrastructure::materialized_view::{
+        Duration, RefreshInterval, TimeUnit,
+    };
 
     #[test]
     fn test_depends_on_with_names_containing_t() {
@@ -4576,34 +4567,40 @@ mod parse_refresh_clause_tests {
     fn test_basic_refresh_every() {
         let sql = "REFRESH EVERY 1 HOUR";
         let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
-        assert!(matches!(
+        assert_eq!(
             config.interval,
-            RefreshInterval::Every { interval: 3600 }
-        ));
+            RefreshInterval::Every {
+                value: 1,
+                unit: TimeUnit::Hour
+            }
+        );
     }
 
     #[test]
     fn test_basic_refresh_after() {
         let sql = "REFRESH AFTER 30 MINUTE";
         let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
-        assert!(matches!(
+        assert_eq!(
             config.interval,
-            RefreshInterval::After { interval: 1800 }
-        ));
+            RefreshInterval::After {
+                value: 30,
+                unit: TimeUnit::Minute
+            }
+        );
     }
 
     #[test]
     fn test_offset_only_valid_with_every() {
         let sql = "REFRESH EVERY 1 HOUR OFFSET 5 MINUTE";
         let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
-        assert_eq!(config.offset, Some(300)); // 5 minutes in seconds
+        assert_eq!(config.offset, Some(Duration::new(5, TimeUnit::Minute)));
     }
 
     #[test]
     fn test_randomize() {
         let sql = "REFRESH EVERY 5 MINUTE RANDOMIZE FOR 30 SECOND";
         let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
-        assert_eq!(config.randomize, Some(30));
+        assert_eq!(config.randomize, Some(Duration::new(30, TimeUnit::Second)));
     }
 
     #[test]
@@ -4611,14 +4608,40 @@ mod parse_refresh_clause_tests {
         let sql =
             "REFRESH EVERY 1 DAY OFFSET 1 HOUR RANDOMIZE FOR 5 MINUTE DEPENDS ON mv1, mv2 APPEND";
         let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
-        assert!(matches!(
+        assert_eq!(
             config.interval,
-            RefreshInterval::Every { interval: 86400 }
-        ));
-        assert_eq!(config.offset, Some(3600));
-        assert_eq!(config.randomize, Some(300));
+            RefreshInterval::Every {
+                value: 1,
+                unit: TimeUnit::Day
+            }
+        );
+        assert_eq!(config.offset, Some(Duration::new(1, TimeUnit::Hour)));
+        assert_eq!(config.randomize, Some(Duration::new(5, TimeUnit::Minute)));
         assert_eq!(config.depends_on, vec!["mv1", "mv2"]);
         assert!(config.append);
+    }
+
+    #[test]
+    fn test_month_year_units() {
+        let sql = "REFRESH EVERY 1 MONTH";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(
+            config.interval,
+            RefreshInterval::Every {
+                value: 1,
+                unit: TimeUnit::Month
+            }
+        );
+
+        let sql = "REFRESH EVERY 1 YEAR";
+        let config = InfrastructureMap::parse_refresh_clause(sql).expect("Should parse");
+        assert_eq!(
+            config.interval,
+            RefreshInterval::Every {
+                value: 1,
+                unit: TimeUnit::Year
+            }
+        );
     }
 }
 

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -46,7 +46,9 @@ use super::partial_infrastructure_map::LifeCycle;
 use super::partial_infrastructure_map::PartialInfrastructureMap;
 use crate::cli::display::{show_message_wrapper, Message, MessageType};
 use crate::framework::core::infra_reality_checker::find_table_from_infra_map;
-use crate::framework::core::infrastructure::materialized_view::MaterializedView;
+use crate::framework::core::infrastructure::materialized_view::{
+    MaterializedView, RefreshInterval, RefreshableConfig,
+};
 use crate::framework::core::infrastructure_map::Change::Added;
 use crate::framework::core::lifecycle_filter;
 use crate::framework::languages::SupportedLanguages;
@@ -2877,6 +2879,133 @@ impl InfrastructureMap {
         })
     }
 
+    /// Parses a REFRESH clause from a CREATE MATERIALIZED VIEW statement.
+    /// Returns Some(RefreshableConfig) if a REFRESH clause is found, None otherwise.
+    ///
+    /// Supported formats:
+    /// - REFRESH EVERY <n> <unit> (e.g., "REFRESH EVERY 1 MINUTE")
+    /// - REFRESH AFTER <n> <unit> (e.g., "REFRESH AFTER 30 SECOND")
+    /// Parses the REFRESH clause from a CREATE MATERIALIZED VIEW statement.
+    /// Extracts: interval (EVERY/AFTER), OFFSET, RANDOMIZE, DEPENDS ON, and APPEND.
+    ///
+    /// Example SQL patterns:
+    /// - REFRESH EVERY 1 HOUR
+    /// - REFRESH AFTER 30 MINUTE OFFSET 5 MINUTE
+    /// - REFRESH EVERY 1 DAY RANDOMIZE FOR 10 SECOND
+    /// - REFRESH EVERY 1 HOUR DEPENDS ON other_mv
+    /// - REFRESH EVERY 1 DAY DEPENDS ON mv1, mv2 APPEND
+    fn parse_refresh_clause(sql: &str) -> Option<RefreshableConfig> {
+        use regex::Regex;
+        use std::sync::LazyLock;
+
+        // Helper to convert value + unit to seconds
+        fn to_seconds(value: u64, unit: &str) -> Option<u64> {
+            match unit.to_uppercase().as_str() {
+                "SECOND" => Some(value),
+                "MINUTE" => Some(value * 60),
+                "HOUR" => Some(value * 3600),
+                "DAY" => Some(value * 86400),
+                "WEEK" => Some(value * 604800),
+                "MONTH" => Some(value * 2592000), // Approximate: 30 days
+                "YEAR" => Some(value * 31536000), // Approximate: 365 days
+                _ => None,
+            }
+        }
+
+        // Pattern to match REFRESH EVERY/AFTER <n> <unit>
+        static REFRESH_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"(?i)REFRESH\s+(EVERY|AFTER)\s+(\d+)\s+(SECOND|MINUTE|HOUR|DAY|WEEK|MONTH|YEAR)",
+            )
+            .expect("REFRESH_PATTERN regex should compile")
+        });
+
+        // Pattern to match OFFSET <n> <unit>
+        static OFFSET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"(?i)OFFSET\s+(\d+)\s+(SECOND|MINUTE|HOUR|DAY|WEEK|MONTH|YEAR)")
+                .expect("OFFSET_PATTERN regex should compile")
+        });
+
+        // Pattern to match RANDOMIZE FOR <n> <unit>
+        static RANDOMIZE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"(?i)RANDOMIZE\s+FOR\s+(\d+)\s+(SECOND|MINUTE|HOUR|DAY|WEEK|MONTH|YEAR)")
+                .expect("RANDOMIZE_PATTERN regex should compile")
+        });
+
+        // Pattern to match DEPENDS ON <mv_list>
+        // MV names can be: mv_name, `mv_name`, database.mv_name, `database`.`mv_name`
+        static DEPENDS_ON_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"(?i)DEPENDS\s+ON\s+([^T]+?)(?:\s+TO\s+|\s+APPEND|\s*$)")
+                .expect("DEPENDS_ON_PATTERN regex should compile")
+        });
+
+        // Pattern to match APPEND
+        static APPEND_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"(?i)\bAPPEND\b").expect("APPEND_PATTERN regex should compile")
+        });
+
+        // Parse the main interval (required)
+        let caps = REFRESH_PATTERN.captures(sql)?;
+        let mode = caps.get(1)?.as_str().to_uppercase();
+        let value: u64 = caps.get(2)?.as_str().parse().ok()?;
+        let unit = caps.get(3)?.as_str();
+
+        let seconds = to_seconds(value, unit)?;
+
+        let interval = match mode.as_str() {
+            "EVERY" => RefreshInterval::Every { interval: seconds },
+            "AFTER" => RefreshInterval::After { interval: seconds },
+            _ => return None,
+        };
+
+        // Parse optional OFFSET
+        let offset = OFFSET_PATTERN.captures(sql).and_then(|caps| {
+            let value: u64 = caps.get(1)?.as_str().parse().ok()?;
+            let unit = caps.get(2)?.as_str();
+            to_seconds(value, unit)
+        });
+
+        // Parse optional RANDOMIZE
+        let randomize = RANDOMIZE_PATTERN.captures(sql).and_then(|caps| {
+            let value: u64 = caps.get(1)?.as_str().parse().ok()?;
+            let unit = caps.get(2)?.as_str();
+            to_seconds(value, unit)
+        });
+
+        // Parse optional DEPENDS ON
+        let depends_on = DEPENDS_ON_PATTERN
+            .captures(sql)
+            .map(|caps| {
+                let mv_list = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+                // Split by comma, trim whitespace, remove backticks and database prefixes
+                mv_list
+                    .split(',')
+                    .map(|s| {
+                        let trimmed = s.trim().replace('`', "");
+                        // Remove database prefix if present (e.g., "local.MV_name" -> "MV_name")
+                        if let Some(dot_pos) = trimmed.rfind('.') {
+                            trimmed[dot_pos + 1..].to_string()
+                        } else {
+                            trimmed
+                        }
+                    })
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        // Parse optional APPEND
+        let append = APPEND_PATTERN.is_match(sql);
+
+        Some(RefreshableConfig {
+            interval,
+            offset,
+            randomize,
+            depends_on,
+            append,
+        })
+    }
+
     /// Attempts to migrate a SqlResource to a MaterializedView.
     /// Returns None if the SqlResource is not a moose-lib generated materialized view.
     pub fn try_migrate_sql_resource_to_mv(
@@ -2887,6 +3016,12 @@ impl InfrastructureMap {
 
         // Must have exactly one setup and one teardown statement
         if sql_resource.setup.len() != 1 || sql_resource.teardown.len() != 1 {
+            tracing::debug!(
+                "MV migration failed for '{}': setup={}, teardown={} (expected 1 each)",
+                sql_resource.name,
+                sql_resource.setup.len(),
+                sql_resource.teardown.len()
+            );
             return None;
         }
 
@@ -2895,19 +3030,47 @@ impl InfrastructureMap {
 
         // Check teardown matches moose-lib pattern
         if !teardown_sql.starts_with("DROP VIEW IF EXISTS") {
+            tracing::debug!(
+                "MV migration failed for '{}': teardown doesn't start with DROP VIEW IF EXISTS. Got: {}",
+                sql_resource.name,
+                &teardown_sql[..std::cmp::min(50, teardown_sql.len())]
+            );
             return None;
         }
 
         // Check setup matches moose-lib MV pattern
         if !setup_sql.starts_with("CREATE MATERIALIZED VIEW IF NOT EXISTS") {
+            tracing::debug!(
+                "MV migration failed for '{}': setup doesn't start with CREATE MATERIALIZED VIEW IF NOT EXISTS. Got: {}",
+                sql_resource.name,
+                &setup_sql[..std::cmp::min(80, setup_sql.len())]
+            );
             return None;
         }
         if !setup_sql.contains(" TO ") {
+            tracing::debug!(
+                "MV migration failed for '{}': setup doesn't contain ' TO '",
+                sql_resource.name
+            );
             return None;
         }
 
         // Parse the CREATE MATERIALIZED VIEW statement
-        let parsed = parse_create_materialized_view(setup_sql).ok()?;
+        let parsed = match parse_create_materialized_view(setup_sql) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::debug!(
+                    "MV migration failed for '{}': parse error: {:?}. SQL: {}",
+                    sql_resource.name,
+                    e,
+                    &setup_sql[..std::cmp::min(200, setup_sql.len())]
+                );
+                return None;
+            }
+        };
+
+        // Parse REFRESH clause if present (for refreshable MVs)
+        let refresh_config = Self::parse_refresh_clause(setup_sql);
 
         // Convert source tables to unqualified names for consistency
         let source_tables: Vec<String> = parsed
@@ -2937,8 +3100,7 @@ impl InfrastructureMap {
             target_database: parsed.target_database,
             metadata,
             life_cycle: crate::framework::core::partial_infrastructure_map::LifeCycle::FullyManaged,
-            // Legacy MVs from SqlResource are always incremental (no refresh_config)
-            refresh_config: None,
+            refresh_config,
         })
     }
 

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -243,9 +243,8 @@ pub enum SerializableOlapOperation {
         target_database: Option<String>,
         /// The SELECT SQL statement
         select_sql: String,
-        /// Optional full CREATE SQL (includes REFRESH clause for refreshable MVs)
-        /// If provided, this is used instead of building the SQL from individual fields
-        create_sql: Option<String>,
+        /// Optional REFRESH clause for refreshable MVs (e.g. "REFRESH EVERY 1 HOUR")
+        refresh_clause: Option<String>,
     },
     /// Drop a materialized view
     DropMaterializedView {
@@ -794,7 +793,7 @@ pub async fn execute_atomic_operation(
             target_table,
             target_database,
             select_sql,
-            create_sql,
+            refresh_clause,
         } => {
             execute_create_materialized_view(
                 db_name,
@@ -803,7 +802,7 @@ pub async fn execute_atomic_operation(
                 target_table,
                 target_database.as_deref(),
                 select_sql,
-                create_sql.as_deref(),
+                refresh_clause.as_deref(),
                 client,
             )
             .await?;
@@ -1577,26 +1576,24 @@ async fn execute_create_materialized_view(
     target_table: &str,
     target_database: Option<&str>,
     select_sql: &str,
-    create_sql: Option<&str>,
+    refresh_clause: Option<&str>,
     client: &ConfiguredDBClient,
 ) -> Result<(), ClickhouseChangesError> {
     let target_db = view_database.unwrap_or(db_name);
 
-    // Use full CREATE SQL if provided (for refreshable MVs), otherwise build it
-    let sql = if let Some(full_sql) = create_sql {
-        full_sql.to_string()
-    } else {
-        // Strip any existing backticks from target_table to avoid double-backticks
-        let clean_target_table = strip_backticks(target_table);
-        let to_target = match target_database {
-            Some(tdb) => format!("`{}`.`{}`", tdb, clean_target_table),
-            None => format!("`{}`.`{}`", target_db, clean_target_table),
-        };
-        format!(
-            "CREATE MATERIALIZED VIEW IF NOT EXISTS `{}`.`{}` TO {} AS {}",
-            target_db, view_name, to_target, select_sql
-        )
+    // Strip any existing backticks from target_table to avoid double-backticks
+    let clean_target_table = strip_backticks(target_table);
+    let to_target = match target_database {
+        Some(tdb) => format!("`{}`.`{}`", tdb, clean_target_table),
+        None => format!("`{}`.`{}`", target_db, clean_target_table),
     };
+    let refresh = refresh_clause
+        .map(|r| format!(" {}", r))
+        .unwrap_or_default();
+    let sql = format!(
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS `{}`.`{}`{} TO {} AS {}",
+        target_db, view_name, refresh, to_target, select_sql
+    );
 
     tracing::info!("Creating materialized view: {}.{}", target_db, view_name);
     tracing::debug!("MV SQL: {}", sql);

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -365,7 +365,8 @@ fn extract_cluster_name(op: &AtomicOlapOperation) -> Option<&str> {
         | AtomicOlapOperation::CreateMaterializedView { .. }
         | AtomicOlapOperation::DropMaterializedView { .. }
         | AtomicOlapOperation::CreateView { .. }
-        | AtomicOlapOperation::DropView { .. } => None,
+        | AtomicOlapOperation::DropView { .. }
+        | AtomicOlapOperation::AlterMaterializedViewRefresh { .. } => None,
     }
 }
 

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -2735,6 +2735,14 @@ static MATERIALIZED_VIEW_TO_PATTERN: LazyLock<regex::Regex> = LazyLock::new(|| {
         .expect("MATERIALIZED_VIEW_TO_PATTERN regex should compile")
 });
 
+static MATERIALIZED_VIEW_REFRESH_PATTERN: LazyLock<regex::Regex> = LazyLock::new(|| {
+    // Pattern to extract REFRESH clause from CREATE MATERIALIZED VIEW
+    // Matches: REFRESH EVERY/AFTER <interval> [OFFSET ...] [RANDOMIZE ...] [DEPENDS ON ...] [APPEND]
+    // The clause ends at TO or at column definitions (parenthesis)
+    regex::Regex::new(r"(?i)(REFRESH\s+(?:EVERY|AFTER)\s+[^(]+?)(?:\s+TO\s+|\s*\()")
+        .expect("MATERIALIZED_VIEW_REFRESH_PATTERN regex should compile")
+});
+
 /// Reconstructs a SqlResource from a materialized view's CREATE statement
 ///
 /// # Arguments
@@ -2765,6 +2773,12 @@ fn reconstruct_sql_resource_from_mv(
             ))
         })?;
 
+    // Extract REFRESH clause if present (for refreshable MVs)
+    let refresh_clause = MATERIALIZED_VIEW_REFRESH_PATTERN
+        .captures(&create_query)
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str().trim().to_string());
+
     // Extract pushes_data_to (target table for MV)
     let (target_base_name, _version) = extract_version_from_table_name(&target_table);
     let (target_db, target_name_only) = split_qualified_name(&target_base_name);
@@ -2783,11 +2797,18 @@ fn reconstruct_sql_resource_from_mv(
         id: target_qualified_id,
     }];
 
-    // Reconstruct with MV-specific CREATE statement
-    let setup_raw = format!(
-        "CREATE MATERIALIZED VIEW IF NOT EXISTS {} TO {} AS {}",
-        name, target_table, as_select
-    );
+    // Reconstruct with MV-specific CREATE statement, preserving REFRESH clause if present
+    let setup_raw = if let Some(refresh) = refresh_clause {
+        format!(
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS {} {} TO {} AS {}",
+            name, refresh, target_table, as_select
+        )
+    } else {
+        format!(
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS {} TO {} AS {}",
+            name, target_table, as_select
+        )
+    };
 
     reconstruct_sql_resource_common(
         name,

--- a/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
+++ b/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
@@ -421,7 +421,9 @@ impl AtomicOlapOperation {
                 SerializableOlapOperation::AlterMaterializedViewRefresh {
                     name: mv.name.clone(),
                     database: mv.database.clone(),
-                    refresh_sql: mv.to_alter_refresh_sql().unwrap_or_default(),
+                    refresh_sql: mv
+                        .to_alter_refresh_sql()
+                        .expect("AlterMaterializedViewRefresh requires refresh_config"),
                 }
             }
         }

--- a/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
+++ b/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
@@ -394,12 +394,7 @@ impl AtomicOlapOperation {
                     target_table: mv.target_table.clone(),
                     target_database: mv.target_database.clone(),
                     select_sql: mv.select_sql.clone(),
-                    // For refreshable MVs, include the full CREATE SQL with REFRESH clause
-                    create_sql: if mv.is_refreshable() {
-                        Some(mv.to_create_sql())
-                    } else {
-                        None
-                    },
+                    refresh_clause: mv.refresh_clause(),
                 }
             }
             AtomicOlapOperation::DropMaterializedView { mv, .. } => {

--- a/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
+++ b/apps/framework-cli/src/infrastructure/olap/ddl_ordering.rs
@@ -192,6 +192,13 @@ pub enum AtomicOlapOperation {
         /// Dependency information
         dependency_info: DependencyInfo,
     },
+    /// Alter the refresh config of a refreshable materialized view
+    AlterMaterializedViewRefresh {
+        /// The materialized view to alter
+        mv: crate::framework::core::infrastructure::materialized_view::MaterializedView,
+        /// Dependency information
+        dependency_info: DependencyInfo,
+    },
 }
 
 impl AtomicOlapOperation {
@@ -387,6 +394,12 @@ impl AtomicOlapOperation {
                     target_table: mv.target_table.clone(),
                     target_database: mv.target_database.clone(),
                     select_sql: mv.select_sql.clone(),
+                    // For refreshable MVs, include the full CREATE SQL with REFRESH clause
+                    create_sql: if mv.is_refreshable() {
+                        Some(mv.to_create_sql())
+                    } else {
+                        None
+                    },
                 }
             }
             AtomicOlapOperation::DropMaterializedView { mv, .. } => {
@@ -404,6 +417,13 @@ impl AtomicOlapOperation {
                 name: view.name.clone(),
                 database: view.database.clone(),
             },
+            AtomicOlapOperation::AlterMaterializedViewRefresh { mv, .. } => {
+                SerializableOlapOperation::AlterMaterializedViewRefresh {
+                    name: mv.name.clone(),
+                    database: mv.database.clone(),
+                    refresh_sql: mv.to_alter_refresh_sql().unwrap_or_default(),
+                }
+            }
         }
     }
 
@@ -484,6 +504,11 @@ impl AtomicOlapOperation {
                     id: mv.id(default_database),
                 }
             }
+            AtomicOlapOperation::AlterMaterializedViewRefresh { mv, .. } => {
+                InfrastructureSignature::MaterializedView {
+                    id: mv.id(default_database),
+                }
+            }
         }
     }
 
@@ -548,6 +573,9 @@ impl AtomicOlapOperation {
                 dependency_info, ..
             }
             | AtomicOlapOperation::DropView {
+                dependency_info, ..
+            }
+            | AtomicOlapOperation::AlterMaterializedViewRefresh {
                 dependency_info, ..
             } => Some(dependency_info),
         }
@@ -1128,30 +1156,48 @@ fn handle_materialized_view_remove(mv: &MaterializedView, default_database: &str
     OperationPlan::teardown(vec![teardown_op])
 }
 
-/// Handles updating a materialized view operation
+/// Handles updating a materialized view operation.
+/// Uses the diff to determine whether to ALTER or DROP/CREATE.
 fn handle_materialized_view_update(
     before: &MaterializedView,
     after: &MaterializedView,
     default_database: &str,
 ) -> OperationPlan {
-    let before_pulls = before.pulls_data_from(default_database);
-    let before_pushes = before.pushes_data_to(default_database);
-    let teardown_op = AtomicOlapOperation::DropMaterializedView {
-        mv: before.clone(),
-        dependency_info: create_dependency_info(before_pulls, before_pushes),
-    };
+    use crate::framework::core::infra_reality_checker::materialized_view_diff;
 
-    let after_pulls = after.pulls_data_from(default_database);
-    let after_pushes = after.pushes_data_to(default_database);
-    let setup_op = AtomicOlapOperation::CreateMaterializedView {
-        mv: after.clone(),
-        dependency_info: create_dependency_info(after_pulls, after_pushes),
-    };
+    let diff = materialized_view_diff(before, after, default_database);
 
-    let mut plan = OperationPlan::new();
-    plan.teardown_ops.push(teardown_op);
-    plan.setup_ops.push(setup_op);
-    plan
+    // If only refresh config changed and it's a refreshable MV, use ALTER
+    if diff.can_alter() && after.is_refreshable() {
+        let after_pulls = after.pulls_data_from(default_database);
+        let after_pushes = after.pushes_data_to(default_database);
+        let alter_op = AtomicOlapOperation::AlterMaterializedViewRefresh {
+            mv: after.clone(),
+            dependency_info: create_dependency_info(after_pulls, after_pushes),
+        };
+
+        OperationPlan::setup(vec![alter_op])
+    } else {
+        // Otherwise, DROP and CREATE
+        let before_pulls = before.pulls_data_from(default_database);
+        let before_pushes = before.pushes_data_to(default_database);
+        let teardown_op = AtomicOlapOperation::DropMaterializedView {
+            mv: before.clone(),
+            dependency_info: create_dependency_info(before_pulls, before_pushes),
+        };
+
+        let after_pulls = after.pulls_data_from(default_database);
+        let after_pushes = after.pushes_data_to(default_database);
+        let setup_op = AtomicOlapOperation::CreateMaterializedView {
+            mv: after.clone(),
+            dependency_info: create_dependency_info(after_pulls, after_pushes),
+        };
+
+        let mut plan = OperationPlan::new();
+        plan.teardown_ops.push(teardown_op);
+        plan.setup_ops.push(setup_op);
+        plan
+    }
 }
 
 /// Handles adding a custom view operation

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -240,8 +240,50 @@ message View {
   optional Metadata metadata = 4;
 }
 
+// Duration for refresh intervals (stored as seconds)
+message RefreshDuration {
+  uint64 seconds = 1;
+}
+
+// Refresh interval specification for refreshable MVs
+message RefreshInterval {
+  oneof interval_type {
+    RefreshDuration every = 1;  // REFRESH EVERY - periodic refresh
+    RefreshDuration after = 2;  // REFRESH AFTER - refresh after interval since last
+  }
+}
+
+// Configuration for refreshable materialized views
+message RefreshableConfig {
+  RefreshInterval interval = 1;
+  optional RefreshDuration offset = 2;
+  optional RefreshDuration randomize = 3;
+  repeated string depends_on = 4;
+  bool append = 5;
+}
+
+// Configuration for incremental (trigger-based) materialized views.
+// This is now an empty marker type - source tables are on select_query.source_tables
+// for BOTH incremental and refreshable MVs. The field is kept for wire format compatibility.
+message IncrementalConfig {
+  // Deprecated: source_tables are now on select_query.source_tables
+  // Kept for backward compatibility with existing serialized data.
+  message SourceTable {
+    string name = 1;
+  }
+  repeated SourceTable source_tables = 1 [deprecated = true];
+}
+
+// MV kind discriminator
+message MaterializedViewKind {
+  oneof kind {
+    IncrementalConfig incremental = 1;
+    RefreshableConfig refreshable = 2;
+  }
+}
+
 // ClickHouse Materialized View that writes transformed data to a target table.
-// MVs run the SELECT query on insert and persist results.
+// MVs can be either incremental (triggered on insert) or refreshable (scheduled).
 message MaterializedView {
   // Name of the materialized view
   string name = 1;
@@ -255,6 +297,8 @@ message MaterializedView {
   optional Metadata metadata = 5;
   // Lifecycle management policy for the materialized view
   LifeCycle life_cycle = 6;
+  // MV kind: incremental or refreshable (new in v2)
+  MaterializedViewKind kind = 7;
 }
 
 message TopicToTableSyncProcess {

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -263,11 +263,15 @@ message RefreshableConfig {
 }
 
 // Configuration for incremental (trigger-based) materialized views.
-// This is now an empty marker type - source tables are on select_query.source_tables
-// for BOTH incremental and refreshable MVs. The field is kept for wire format compatibility.
+// Incremental MVs execute their SELECT on every insert to source tables.
+//
+// Note: Source tables are stored in select_query.source_tables for BOTH
+// incremental and refreshable MVs. This provides consistent data lineage
+// tracking - for incremental MVs these tables trigger the MV, for refreshable
+// MVs they represent what tables are read during scheduled refresh.
 message IncrementalConfig {
-  // Deprecated: source_tables are now on select_query.source_tables
-  // Kept for backward compatibility with existing serialized data.
+  // Legacy field - source_tables are now in select_query.source_tables.
+  // Kept for backward wire compatibility. Do not use for new code.
   message SourceTable {
     string name = 1;
   }

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -240,9 +240,10 @@ message View {
   optional Metadata metadata = 4;
 }
 
-// Duration for refresh intervals (stored as seconds)
+// Duration for refresh intervals (value + unit)
 message RefreshDuration {
-  uint64 seconds = 1;
+  uint64 value = 1;
+  string unit = 2;
 }
 
 // Refresh interval specification for refreshable MVs

--- a/packages/py-moose-lib/moose_lib/dmv2/__init__.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/__init__.py
@@ -70,6 +70,14 @@ from .view import (
 from .materialized_view import (
     MaterializedViewOptions,
     MaterializedView,
+    RefreshableMaterializedViewOptions,
+    RefreshableMaterializedView,
+    RefreshConfig,
+    RefreshInterval,
+    RefreshIntervalEvery,
+    RefreshIntervalAfter,
+    Duration,
+    TimeUnit,
 )
 
 from .workflow import (
@@ -165,6 +173,14 @@ __all__ = [
     "View",
     "MaterializedViewOptions",
     "MaterializedView",
+    "RefreshableMaterializedViewOptions",
+    "RefreshableMaterializedView",
+    "RefreshConfig",
+    "RefreshInterval",
+    "RefreshIntervalEvery",
+    "RefreshIntervalAfter",
+    "Duration",
+    "TimeUnit",
     # Workflow
     "TaskContext",
     "TaskConfig",

--- a/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
@@ -5,12 +5,12 @@ This module provides classes for defining Materialized Views,
 including their SQL statements, target tables, and dependencies.
 
 Two types of materialized views are supported:
-- **Incremental**: Triggered on every insert to source tables (when refresh_config is NOT set)
-- **Refreshable**: Runs on a schedule (when refresh_config IS set)
+- **MaterializedView**: Incremental MV triggered on every insert to source tables
+- **RefreshableMaterializedView**: Scheduled MV that runs on a refresh interval
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional, Union, Generic, List
+from typing import Any, Literal, Optional, Union, Generic, List, TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
@@ -95,6 +95,7 @@ class RefreshConfig:
         >>> config = RefreshConfig(
         ...     interval=RefreshIntervalEvery(1, "hour"),
         ...     offset=Duration(5, "minute"),
+        ...     depends_on=[hourly_stats_mv],  # Type-safe: only accepts RefreshableMaterializedView
         ... )
     """
 
@@ -104,37 +105,47 @@ class RefreshConfig:
     """Optional offset from interval start"""
     randomize: Optional[Duration] = None
     """Optional randomization window"""
+    depends_on: List["RefreshableMaterializedView"] = field(default_factory=list)
+    """Other refreshable MVs this one depends on. Only accepts RefreshableMaterializedView objects."""
+    append: bool = False
+    """Use APPEND mode instead of full refresh"""
+
+
+@dataclass
+class ResolvedRefreshConfig:
+    """
+    Internal representation of RefreshConfig with depends_on resolved to string names.
+    """
+
+    interval: RefreshInterval
+    """The refresh interval (EVERY or AFTER)"""
+    offset: Optional[Duration] = None
+    """Optional offset from interval start"""
+    randomize: Optional[Duration] = None
+    """Optional randomization window"""
     depends_on: List[str] = field(default_factory=list)
-    """Names of other MVs this one depends on"""
+    """Names of other MVs this one depends on (resolved to strings)"""
     append: bool = False
     """Use APPEND mode instead of full refresh"""
 
 
 # ============================================================================
-# MaterializedView Options and Class
+# Incremental MaterializedView Configuration and Class
 # ============================================================================
 
 
 class MaterializedViewOptions(BaseModel):
-    """Configuration options for creating a Materialized View.
+    """Configuration options for creating an incremental Materialized View.
 
-    Two types of materialized views are supported:
-    - **Incremental**: Triggered on every insert to source tables (when refresh_config is NOT set)
-    - **Refreshable**: Runs on a schedule (when refresh_config IS set)
+    Incremental MVs are triggered on every insert to source tables.
 
     Attributes:
         select_statement: The SQL SELECT statement defining the view's data.
         select_tables: List of source tables/views the select statement reads from.
-                       Can be OlapTable, View, or any object with a `name` attribute.
         table_name: Optional name of the underlying target table storing the materialized data.
-                    Not needed if passing target_table directly to MaterializedView constructor.
         materialized_view_name: The name of the MATERIALIZED VIEW object itself.
-        engine: Optional ClickHouse engine for the target table (used when creating
-                a target table via table_name). Note: refreshable MVs only support MergeTree.
-        order_by_fields: Optional ordering key for the target table (required for
-                         engines like ReplacingMergeTree).
-        refresh_config: Configuration for refreshable MVs. If set, creates a refreshable MV.
-                        If not set, creates an incremental MV.
+        engine: Optional ClickHouse engine for the target table.
+        order_by_fields: Optional ordering key for the target table.
         metadata: Optional metadata dictionary.
         model_config: ConfigDict for Pydantic validation
         life_cycle: Optional lifecycle management policy. Controls how Moose handles
@@ -148,41 +159,32 @@ class MaterializedViewOptions(BaseModel):
 
     select_statement: str
     select_tables: List[Union[OlapTable, "View"]]
-    # For inline table creation (when not passing target_table to constructor)
     table_name: Optional[str] = None
     materialized_view_name: str
     engine: Optional[ClickHouseEngines] = None
     order_by_fields: Optional[List[str]] = None
-    # Refresh configuration for refreshable MVs
-    refresh_config: Optional[RefreshConfig] = None
     metadata: Optional[dict] = None
     life_cycle: Optional[LifeCycle] = None
-    # Ensure arbitrary types are allowed for Pydantic validation
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class MaterializedView(BaseTypedResource, Generic[T]):
-    """Represents a ClickHouse Materialized View.
+    """Represents an incremental Materialized View in ClickHouse.
 
-    Two types are supported:
-    - **Incremental**: Triggered on inserts to source tables (refresh_config not set)
-    - **Refreshable**: Runs on a schedule (refresh_config is set)
+    Incremental MVs are triggered on every insert to source tables.
+    For scheduled/refreshable MVs, use `RefreshableMaterializedView` instead.
 
     Args:
         options: Configuration defining the select statement, names, and dependencies.
-        target_table: Optional existing OlapTable to use as the target. If not provided,
-                      a new table will be created using options.table_name.
-        t: The Pydantic model defining the schema of the target table
-           (passed via `MaterializedView[MyModel](...)`).
+        target_table: Optional existing OlapTable to use as the target.
+        t: The Pydantic model defining the schema of the target table.
 
     Attributes:
         target_table (OlapTable[T]): The `OlapTable` instance storing the materialized data.
         config (MaterializedViewOptions): The configuration options used to create the view.
         name (str): The name of the MATERIALIZED VIEW object.
-        model_type (type[T]): The Pydantic model associated with the target table.
         select_sql (str): The SELECT SQL statement.
         source_tables (list[str]): Names of source tables the SELECT reads from.
-        refresh_config (Optional[RefreshConfig]): The refresh configuration if refreshable.
         life_cycle (LifeCycle | None): Lifecycle management policy. Controls how Moose
             handles this MV when code definitions change. Defaults to FULLY_MANAGED when
             not specified. See LifeCycle enum for available values.
@@ -195,7 +197,7 @@ class MaterializedView(BaseTypedResource, Generic[T]):
     select_sql: str
     source_tables: List[str]
     metadata: Optional[dict] = None
-    refresh_config: Optional[RefreshConfig] = None
+    refresh_config: None = None  # Always None for incremental MVs
     life_cycle: Optional[LifeCycle] = None
 
     def __init__(
@@ -206,26 +208,19 @@ class MaterializedView(BaseTypedResource, Generic[T]):
     ):
         self._set_type(options.materialized_view_name, self._get_type(kwargs))
 
-        # Determine if this is a refreshable MV
-        is_refreshable = options.refresh_config is not None
-
         # Resolve target table
         if target_table:
-            # Using existing OlapTable passed as parameter
             self.target_table = target_table
             if self._t != target_table._t:
                 raise ValueError(
                     "Target table must have the same type as the materialized view"
                 )
-            target_engine = getattr(target_table.config, "engine", None)
         else:
-            # Create table from options.table_name
             if not options.table_name:
                 raise ValueError(
                     "Name of target table is not specified. "
                     "Provide 'target_table' parameter or 'table_name' in options."
                 )
-            target_engine = options.engine
             target_table = OlapTable(
                 name=options.table_name,
                 config=OlapConfig(
@@ -236,18 +231,6 @@ class MaterializedView(BaseTypedResource, Generic[T]):
             )
             self.target_table = target_table
 
-        # Validate: refreshable MVs cannot use custom engines
-        if (
-            is_refreshable
-            and target_engine is not None
-            and target_engine != ClickHouseEngines.MergeTree
-        ):
-            raise ValueError(
-                f"Refreshable materialized views cannot use custom engines. "
-                f"Found engine '{target_engine}' but refreshable MVs only support MergeTree. "
-                f"Remove the 'engine' option or remove 'refresh_config' to create an incremental MV."
-            )
-
         if target_table.name == options.materialized_view_name:
             raise ValueError(
                 "Target table name cannot be the same as the materialized view name"
@@ -256,11 +239,11 @@ class MaterializedView(BaseTypedResource, Generic[T]):
         self.name = options.materialized_view_name
         self.config = options
         self.select_sql = options.select_statement
-        self.refresh_config = options.refresh_config
         self.source_tables = [_format_table_reference(t) for t in options.select_tables]
+        self.refresh_config = None
         self.life_cycle = options.life_cycle
 
-        # Initialize metadata, preserving user-provided metadata if any
+        # Initialize metadata
         if options.metadata:
             self.metadata = (
                 options.metadata.copy()
@@ -270,7 +253,7 @@ class MaterializedView(BaseTypedResource, Generic[T]):
         else:
             self.metadata = {}
 
-        # Capture source file from stack trace if not already provided
+        # Capture source file from stack trace
         if not isinstance(self.metadata, dict):
             self.metadata = {}
         if "source" not in self.metadata:
@@ -283,13 +266,146 @@ class MaterializedView(BaseTypedResource, Generic[T]):
         _materialized_views[self.name] = self
 
     def is_incremental(self) -> bool:
-        """Returns True if this is an incremental (trigger-based) materialized view."""
-        return self.refresh_config is None
+        """Returns True - incremental MVs are always incremental."""
+        return True
 
     def is_refreshable(self) -> bool:
-        """Returns True if this is a refreshable (scheduled) materialized view."""
-        return self.refresh_config is not None
+        """Returns False - incremental MVs are never refreshable."""
+        return False
 
-    def get_refresh_config(self) -> Optional[RefreshConfig]:
-        """Returns the refresh configuration if this is a refreshable MV."""
+
+# ============================================================================
+# Refreshable MaterializedView Configuration and Class
+# ============================================================================
+
+
+class RefreshableMaterializedViewOptions(BaseModel):
+    """Configuration options for creating a Refreshable Materialized View.
+
+    Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
+    being triggered by inserts to source tables.
+
+    Note: Refreshable MVs always use MergeTree engine (no custom engine option).
+
+    Attributes:
+        select_statement: The SQL SELECT statement defining the view's data.
+        select_tables: List of source tables/views the select statement reads from.
+        materialized_view_name: The name of the MATERIALIZED VIEW object itself.
+        target_table_name: Name of the underlying target table.
+        order_by_fields: Optional ordering key for the target table.
+        refresh_config: Configuration for the refresh schedule. Required.
+        metadata: Optional metadata dictionary.
+    """
+
+    select_statement: str
+    select_tables: List[Union[OlapTable, "View"]]
+    materialized_view_name: str
+    target_table_name: str
+    order_by_fields: Optional[List[str]] = None
+    refresh_config: RefreshConfig
+    metadata: Optional[dict] = None
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class RefreshableMaterializedView(BaseTypedResource, Generic[T]):
+    """Represents a Refreshable Materialized View in ClickHouse.
+
+    Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
+    being triggered by inserts to source tables.
+
+    For incremental/trigger-based MVs, use `MaterializedView` instead.
+
+    Args:
+        options: Configuration defining the select statement, names, and dependencies.
+        t: The Pydantic model defining the schema of the target table.
+
+    Attributes:
+        target_table (OlapTable[T]): The `OlapTable` instance storing the materialized data.
+        config (RefreshableMaterializedViewOptions): The configuration options.
+        name (str): The name of the MATERIALIZED VIEW object.
+        select_sql (str): The SELECT SQL statement.
+        source_tables (list[str]): Names of source tables the SELECT reads from.
+        refresh_config (ResolvedRefreshConfig): The refresh configuration with resolved dependencies.
+    """
+
+    kind: str = "MaterializedView"
+    target_table: OlapTable[T]
+    config: RefreshableMaterializedViewOptions
+    name: str
+    select_sql: str
+    source_tables: List[str]
+    metadata: Optional[dict] = None
+    refresh_config: ResolvedRefreshConfig  # Always set for refreshable MVs
+
+    def __init__(
+        self,
+        options: RefreshableMaterializedViewOptions,
+        **kwargs: Any,
+    ):
+        self._set_type(options.materialized_view_name, self._get_type(kwargs))
+
+        # Create target table (always MergeTree for refreshable MVs)
+        target_table = OlapTable(
+            name=options.target_table_name,
+            config=OlapConfig(
+                order_by_fields=options.order_by_fields or [],
+                engine=ClickHouseEngines.MergeTree,
+            ),
+            t=self._t,
+        )
+        self.target_table = target_table
+
+        if target_table.name == options.materialized_view_name:
+            raise ValueError(
+                "Target table name cannot be the same as the materialized view name"
+            )
+
+        self.name = options.materialized_view_name
+        self.config = options
+        self.select_sql = options.select_statement
+        self.source_tables = [_format_table_reference(t) for t in options.select_tables]
+
+        # Convert refresh_config.depends_on from RefreshableMaterializedView objects to string names
+        self.refresh_config = ResolvedRefreshConfig(
+            interval=options.refresh_config.interval,
+            offset=options.refresh_config.offset,
+            randomize=options.refresh_config.randomize,
+            depends_on=[dep.name for dep in options.refresh_config.depends_on],
+            append=options.refresh_config.append,
+        )
+
+        # Initialize metadata
+        if options.metadata:
+            self.metadata = (
+                options.metadata.copy()
+                if isinstance(options.metadata, dict)
+                else options.metadata
+            )
+        else:
+            self.metadata = {}
+
+        # Capture source file from stack trace
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
+        if "source" not in self.metadata:
+            source_file = get_source_file_from_stack()
+            if source_file:
+                self.metadata["source"] = {"file": source_file}
+
+        if self.name in _materialized_views:
+            raise ValueError(
+                f"RefreshableMaterializedView with name {self.name} already exists"
+            )
+        _materialized_views[self.name] = self
+
+    def is_incremental(self) -> bool:
+        """Returns False - refreshable MVs are never incremental."""
+        return False
+
+    def is_refreshable(self) -> bool:
+        """Returns True - refreshable MVs are always refreshable."""
+        return True
+
+    def get_refresh_config(self) -> ResolvedRefreshConfig:
+        """Returns the refresh configuration."""
         return self.refresh_config

--- a/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
@@ -14,7 +14,7 @@ from typing import Any, Literal, Optional, Union, Generic, List
 
 from pydantic import BaseModel, ConfigDict
 
-from ..blocks import ClickHouseEngines
+from ..blocks import ClickHouseEngines, MergeTreeEngine
 from .types import BaseTypedResource, T
 from .olap_table import OlapTable, OlapConfig
 from .life_cycle import LifeCycle
@@ -349,7 +349,7 @@ class RefreshableMaterializedView(BaseTypedResource, Generic[T]):
             name=options.target_table_name,
             config=OlapConfig(
                 order_by_fields=options.order_by_fields or [],
-                engine=ClickHouseEngines.MergeTree,
+                engine=MergeTreeEngine(),
             ),
             t=self._t,
         )

--- a/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
@@ -10,7 +10,7 @@ Two types of materialized views are supported:
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional, Union, Generic, List, TYPE_CHECKING
+from typing import Any, Literal, Optional, Union, Generic, List
 
 from pydantic import BaseModel, ConfigDict
 
@@ -102,7 +102,7 @@ class RefreshConfig:
     interval: RefreshInterval
     """The refresh interval (EVERY or AFTER)"""
     offset: Optional[Duration] = None
-    """Optional offset from interval start"""
+    """Optional offset from interval start. NOTE: Only valid with REFRESH EVERY, not REFRESH AFTER."""
     randomize: Optional[Duration] = None
     """Optional randomization window"""
     depends_on: List["RefreshableMaterializedView"] = field(default_factory=list)
@@ -358,6 +358,16 @@ class RefreshableMaterializedView(BaseTypedResource, Generic[T]):
         if target_table.name == options.materialized_view_name:
             raise ValueError(
                 "Target table name cannot be the same as the materialized view name"
+            )
+
+        # Validate OFFSET is not used with REFRESH AFTER (only valid with REFRESH EVERY)
+        if (
+            options.refresh_config.interval.type == "after"
+            and options.refresh_config.offset is not None
+        ):
+            raise ValueError(
+                "OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER. "
+                "Remove the 'offset' option or change the interval type to 'every'."
             )
 
         self.name = options.materialized_view_name

--- a/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
@@ -36,7 +36,7 @@ def _format_table_reference(table: Union[OlapTable, View]) -> str:
 # ============================================================================
 
 # Supported time units for refresh intervals
-TimeUnit = Literal["second", "minute", "hour", "day", "week"]
+TimeUnit = Literal["second", "minute", "hour", "day", "week", "month", "year"]
 
 
 @dataclass
@@ -52,6 +52,12 @@ class RefreshIntervalEvery:
     """The time unit for the interval"""
     type: Literal["every"] = "every"
 
+    def __post_init__(self):
+        if self.value <= 0:
+            raise ValueError(
+                f"Refresh interval value must be positive, got {self.value}"
+            )
+
 
 @dataclass
 class RefreshIntervalAfter:
@@ -65,6 +71,12 @@ class RefreshIntervalAfter:
     unit: TimeUnit
     """The time unit for the interval"""
     type: Literal["after"] = "after"
+
+    def __post_init__(self):
+        if self.value <= 0:
+            raise ValueError(
+                f"Refresh interval value must be positive, got {self.value}"
+            )
 
 
 RefreshInterval = Union[RefreshIntervalEvery, RefreshIntervalAfter]
@@ -81,6 +93,10 @@ class Duration:
     """The numeric value"""
     unit: TimeUnit
     """The time unit"""
+
+    def __post_init__(self):
+        if self.value <= 0:
+            raise ValueError(f"Duration value must be positive, got {self.value}")
 
 
 @dataclass
@@ -376,11 +392,17 @@ class RefreshableMaterializedView(BaseTypedResource, Generic[T]):
         self.source_tables = [_format_table_reference(t) for t in options.select_tables]
 
         # Convert refresh_config.depends_on from RefreshableMaterializedView objects to string names
+        dep_names = [dep.name for dep in options.refresh_config.depends_on]
+        if options.materialized_view_name in dep_names:
+            raise ValueError(
+                f"RefreshableMaterializedView '{options.materialized_view_name}' "
+                "cannot depend on itself"
+            )
         self.refresh_config = ResolvedRefreshConfig(
             interval=options.refresh_config.interval,
             offset=options.refresh_config.offset,
             randomize=options.refresh_config.randomize,
-            depends_on=[dep.name for dep in options.refresh_config.depends_on],
+            depends_on=dep_names,
             append=options.refresh_config.append,
         )
 

--- a/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/materialized_view.py
@@ -3,10 +3,16 @@ Materialized View definitions for Moose Data Model v2 (dmv2).
 
 This module provides classes for defining Materialized Views,
 including their SQL statements, target tables, and dependencies.
+
+Two types of materialized views are supported:
+- **Incremental**: Triggered on every insert to source tables (when refresh_config is NOT set)
+- **Refreshable**: Runs on a schedule (when refresh_config IS set)
 """
 
-from typing import Any, Optional, Union, Generic
-from pydantic import BaseModel, ConfigDict, model_validator
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional, Union, Generic, List
+
+from pydantic import BaseModel, ConfigDict
 
 from ..blocks import ClickHouseEngines
 from .types import BaseTypedResource, T
@@ -25,20 +31,85 @@ def _format_table_reference(table: Union[OlapTable, View]) -> str:
     return f"`{table.name}`"
 
 
+# ============================================================================
+# Refresh Configuration Types for Refreshable Materialized Views
+# ============================================================================
+
+
+@dataclass
+class RefreshIntervalEvery:
+    """
+    Refresh interval using EVERY mode - periodic refresh at fixed times.
+    Example: RefreshIntervalEvery("1 hour") => REFRESH EVERY 1 HOUR
+    """
+
+    interval: str
+    """Interval string like '1 hour', '30 minutes', '1 day'"""
+    type: Literal["every"] = "every"
+
+
+@dataclass
+class RefreshIntervalAfter:
+    """
+    Refresh interval using AFTER mode - refresh after interval since last refresh.
+    Example: RefreshIntervalAfter("30 minutes") => REFRESH AFTER 30 MINUTES
+    """
+
+    interval: str
+    """Interval string like '1 hour', '30 minutes', '1 day'"""
+    type: Literal["after"] = "after"
+
+
+RefreshInterval = Union[RefreshIntervalEvery, RefreshIntervalAfter]
+
+
+@dataclass
+class RefreshConfig:
+    """
+    Configuration for refreshable (scheduled) materialized views.
+
+    Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
+    being triggered by inserts to source tables.
+    """
+
+    interval: RefreshInterval
+    """The refresh interval (EVERY or AFTER)"""
+    offset: Optional[str] = None
+    """Optional offset from interval start, e.g., '5 minutes'"""
+    randomize: Optional[str] = None
+    """Optional randomization window, e.g., '10 seconds'"""
+    depends_on: List[str] = field(default_factory=list)
+    """Names of other MVs this one depends on"""
+    append: bool = False
+    """Use APPEND mode instead of full refresh"""
+
+
+# ============================================================================
+# MaterializedView Options and Class
+# ============================================================================
+
+
 class MaterializedViewOptions(BaseModel):
     """Configuration options for creating a Materialized View.
+
+    Two types of materialized views are supported:
+    - **Incremental**: Triggered on every insert to source tables (when refresh_config is NOT set)
+    - **Refreshable**: Runs on a schedule (when refresh_config IS set)
 
     Attributes:
         select_statement: The SQL SELECT statement defining the view's data.
         select_tables: List of source tables/views the select statement reads from.
                        Can be OlapTable, View, or any object with a `name` attribute.
-        table_name: (Deprecated in favor of target_table) Optional name of the underlying
-                    target table storing the materialized data.
+        table_name: Optional name of the underlying target table storing the materialized data.
+                    Not needed if passing target_table directly to MaterializedView constructor.
         materialized_view_name: The name of the MATERIALIZED VIEW object itself.
         engine: Optional ClickHouse engine for the target table (used when creating
-                a target table via table_name or inline config).
+                a target table via table_name). Note: refreshable MVs only support MergeTree.
         order_by_fields: Optional ordering key for the target table (required for
                          engines like ReplacingMergeTree).
+        refresh_config: Configuration for refreshable MVs. If set, creates a refreshable MV.
+                        If not set, creates an incremental MV.
+        metadata: Optional metadata dictionary.
         model_config: ConfigDict for Pydantic validation
         life_cycle: Optional lifecycle management policy. Controls how Moose handles
                     this materialized view when code definitions change. Valid values:
@@ -50,12 +121,14 @@ class MaterializedViewOptions(BaseModel):
     """
 
     select_statement: str
-    select_tables: list[Union[OlapTable, "View"]]
-    # Backward-compatibility: allow specifying just the table_name and engine
+    select_tables: List[Union[OlapTable, "View"]]
+    # For inline table creation (when not passing target_table to constructor)
     table_name: Optional[str] = None
     materialized_view_name: str
     engine: Optional[ClickHouseEngines] = None
-    order_by_fields: Optional[list[str]] = None
+    order_by_fields: Optional[List[str]] = None
+    # Refresh configuration for refreshable MVs
+    refresh_config: Optional[RefreshConfig] = None
     metadata: Optional[dict] = None
     life_cycle: Optional[LifeCycle] = None
     # Ensure arbitrary types are allowed for Pydantic validation
@@ -65,11 +138,14 @@ class MaterializedViewOptions(BaseModel):
 class MaterializedView(BaseTypedResource, Generic[T]):
     """Represents a ClickHouse Materialized View.
 
-    Encapsulates the MATERIALIZED VIEW definition and the underlying target `OlapTable`
-    that stores the data. Emits structured data for the Moose infrastructure system.
+    Two types are supported:
+    - **Incremental**: Triggered on inserts to source tables (refresh_config not set)
+    - **Refreshable**: Runs on a schedule (refresh_config is set)
 
     Args:
         options: Configuration defining the select statement, names, and dependencies.
+        target_table: Optional existing OlapTable to use as the target. If not provided,
+                      a new table will be created using options.table_name.
         t: The Pydantic model defining the schema of the target table
            (passed via `MaterializedView[MyModel](...)`).
 
@@ -80,6 +156,7 @@ class MaterializedView(BaseTypedResource, Generic[T]):
         model_type (type[T]): The Pydantic model associated with the target table.
         select_sql (str): The SELECT SQL statement.
         source_tables (list[str]): Names of source tables the SELECT reads from.
+        refresh_config (Optional[RefreshConfig]): The refresh configuration if refreshable.
         life_cycle (LifeCycle | None): Lifecycle management policy. Controls how Moose
             handles this MV when code definitions change. Defaults to FULLY_MANAGED when
             not specified. See LifeCycle enum for available values.
@@ -90,37 +167,59 @@ class MaterializedView(BaseTypedResource, Generic[T]):
     config: MaterializedViewOptions
     name: str
     select_sql: str
-    source_tables: list[str]
+    source_tables: List[str]
     metadata: Optional[dict] = None
+    refresh_config: Optional[RefreshConfig] = None
     life_cycle: Optional[LifeCycle] = None
 
     def __init__(
         self,
         options: MaterializedViewOptions,
         target_table: Optional[OlapTable[T]] = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         self._set_type(options.materialized_view_name, self._get_type(kwargs))
 
-        # Resolve target table from options
+        # Determine if this is a refreshable MV
+        is_refreshable = options.refresh_config is not None
+
+        # Resolve target table
         if target_table:
+            # Using existing OlapTable passed as parameter
             self.target_table = target_table
             if self._t != target_table._t:
                 raise ValueError(
                     "Target table must have the same type as the materialized view"
                 )
+            target_engine = getattr(target_table.config, "engine", None)
         else:
-            # Backward-compatibility path using table_name/engine/order_by_fields
+            # Create table from options.table_name
             if not options.table_name:
                 raise ValueError(
-                    "Name of target table is not specified. Provide 'target_table' or 'table_name'."
+                    "Name of target table is not specified. "
+                    "Provide 'target_table' parameter or 'table_name' in options."
                 )
+            target_engine = options.engine
             target_table = OlapTable(
                 name=options.table_name,
                 config=OlapConfig(
-                    order_by_fields=options.order_by_fields or [], engine=options.engine
+                    order_by_fields=options.order_by_fields or [],
+                    engine=options.engine,
                 ),
                 t=self._t,
+            )
+            self.target_table = target_table
+
+        # Validate: refreshable MVs cannot use custom engines
+        if (
+            is_refreshable
+            and target_engine is not None
+            and target_engine != ClickHouseEngines.MergeTree
+        ):
+            raise ValueError(
+                f"Refreshable materialized views cannot use custom engines. "
+                f"Found engine '{target_engine}' but refreshable MVs only support MergeTree. "
+                f"Remove the 'engine' option or remove 'refresh_config' to create an incremental MV."
             )
 
         if target_table.name == options.materialized_view_name:
@@ -129,9 +228,9 @@ class MaterializedView(BaseTypedResource, Generic[T]):
             )
 
         self.name = options.materialized_view_name
-        self.target_table = target_table
         self.config = options
         self.select_sql = options.select_statement
+        self.refresh_config = options.refresh_config
         self.source_tables = [_format_table_reference(t) for t in options.select_tables]
         self.life_cycle = options.life_cycle
 
@@ -156,3 +255,15 @@ class MaterializedView(BaseTypedResource, Generic[T]):
         if self.name in _materialized_views:
             raise ValueError(f"MaterializedView with name {self.name} already exists")
         _materialized_views[self.name] = self
+
+    def is_incremental(self) -> bool:
+        """Returns True if this is an incremental (trigger-based) materialized view."""
+        return self.refresh_config is None
+
+    def is_refreshable(self) -> bool:
+        """Returns True if this is a refreshable (scheduled) materialized view."""
+        return self.refresh_config is not None
+
+    def get_refresh_config(self) -> Optional[RefreshConfig]:
+        """Returns the refresh configuration if this is a refreshable MV."""
+        return self.refresh_config

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -8,7 +8,7 @@ JSON format expected by the Moose infrastructure management system.
 """
 
 from importlib import import_module
-from typing import Literal, Optional, List, Any, Dict, Union, TYPE_CHECKING
+from typing import Literal, Optional, List, Any, Dict, Union
 from pydantic import BaseModel, ConfigDict, AliasGenerator, Field
 import json
 import os
@@ -1246,7 +1246,7 @@ def to_infra_map() -> dict:
                 ),
                 depends_on=(
                     mv.refresh_config.depends_on
-                    if mv.refresh_config.depends_on
+                    if mv.refresh_config.depends_on is not None
                     else None
                 ),
                 append=mv.refresh_config.append,

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -499,6 +499,34 @@ class SqlResourceConfig(BaseModel):
     metadata: Optional[dict] = None
 
 
+class RefreshIntervalJson(BaseModel):
+    """Internal representation of a refresh interval for serialization.
+
+    Matches Rust's RefreshInterval enum with serde(tag = "type").
+    """
+
+    model_config = model_config
+
+    type: Literal["every", "after"]
+    interval: int  # Interval in seconds
+
+
+class RefreshConfigJson(BaseModel):
+    """Internal representation of refresh config for serialization.
+
+    Only present for refreshable MVs. Incremental MVs have refresh_config = None.
+    Matches Rust's RefreshableConfig struct.
+    """
+
+    model_config = model_config
+
+    interval: RefreshIntervalJson
+    offset: Optional[int] = None  # Offset in seconds
+    randomize: Optional[int] = None  # Randomize window in seconds
+    depends_on: Optional[List[str]] = None
+    append: Optional[bool] = None
+
+
 class MaterializedViewJson(BaseModel):
     """Internal representation of a structured Materialized View for serialization.
 
@@ -510,6 +538,7 @@ class MaterializedViewJson(BaseModel):
         target_table: Name of the target table where data is written.
         target_database: Optional database for the target table.
         metadata: Optional metadata for the materialized view (e.g., description, source file).
+        refresh_config: Refresh config for refreshable MVs. None = incremental MV.
         life_cycle: Optional lifecycle management policy.
     """
 
@@ -522,6 +551,7 @@ class MaterializedViewJson(BaseModel):
     target_table: str
     target_database: Optional[str] = None
     metadata: Optional[dict] = None
+    refresh_config: Optional[RefreshConfigJson] = None
     life_cycle: Optional[str] = None
 
 
@@ -575,6 +605,47 @@ class InfrastructureMap(BaseModel):
     materialized_views: dict[str, MaterializedViewJson]
     views: dict[str, ViewJson]
     unloaded_files: list[str] = []
+
+
+import re
+
+
+def _parse_interval_to_seconds(interval: str) -> int:
+    """Parse an interval string like '1 hour', '30 minutes', '2 days' to seconds.
+
+    Supports: seconds, second, minutes, minute, hours, hour, days, day
+
+    Args:
+        interval: Interval string like '1 hour', '30 minutes', etc.
+
+    Returns:
+        The interval in seconds.
+
+    Raises:
+        ValueError: If the interval format is invalid.
+    """
+    match = re.match(
+        r"^(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days)$",
+        interval.strip(),
+        re.IGNORECASE,
+    )
+    if not match:
+        raise ValueError(
+            f'Invalid interval format: "{interval}". '
+            'Expected format like "1 hour", "30 minutes", etc.'
+        )
+    value = int(match.group(1))
+    unit = match.group(2).lower()
+    if unit in ("second", "seconds"):
+        return value
+    elif unit in ("minute", "minutes"):
+        return value * 60
+    elif unit in ("hour", "hours"):
+        return value * 3600
+    elif unit in ("day", "days"):
+        return value * 86400
+    else:
+        raise ValueError(f"Unknown interval unit: {unit}")
 
 
 def _map_sql_resource_ref(r: Any) -> InfrastructureSignatureJson:
@@ -1152,6 +1223,35 @@ def to_infra_map() -> dict:
 
     # Serialize materialized views with structured data
     for name, mv in get_materialized_views().items():
+        # Convert refresh_config to JSON format (only for refreshable MVs)
+        refresh_config_json: Optional[RefreshConfigJson] = None
+
+        if mv.refresh_config is not None:
+            refresh_config_json = RefreshConfigJson(
+                interval=RefreshIntervalJson(
+                    type=mv.refresh_config.interval.type,
+                    interval=_parse_interval_to_seconds(
+                        mv.refresh_config.interval.interval
+                    ),
+                ),
+                offset=(
+                    _parse_interval_to_seconds(mv.refresh_config.offset)
+                    if mv.refresh_config.offset
+                    else None
+                ),
+                randomize=(
+                    _parse_interval_to_seconds(mv.refresh_config.randomize)
+                    if mv.refresh_config.randomize
+                    else None
+                ),
+                depends_on=(
+                    mv.refresh_config.depends_on
+                    if mv.refresh_config.depends_on
+                    else None
+                ),
+                append=mv.refresh_config.append if mv.refresh_config.append else None,
+            )
+
         materialized_views[name] = MaterializedViewJson(
             name=mv.name,
             select_sql=mv.select_sql,
@@ -1159,6 +1259,7 @@ def to_infra_map() -> dict:
             target_table=mv.target_table.name,
             target_database=getattr(mv.target_table.config, "database", None),
             metadata=getattr(mv, "metadata", None),
+            refresh_config=refresh_config_json,
             life_cycle=(mv.life_cycle.value if mv.life_cycle else "FULLY_MANAGED"),
         )
 

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -1249,7 +1249,7 @@ def to_infra_map() -> dict:
                     if mv.refresh_config.depends_on
                     else None
                 ),
-                append=mv.refresh_config.append if mv.refresh_config.append else None,
+                append=mv.refresh_config.append,
             )
 
         materialized_views[name] = MaterializedViewJson(

--- a/packages/ts-moose-lib/src/browserCompatible.ts
+++ b/packages/ts-moose-lib/src/browserCompatible.ts
@@ -24,6 +24,7 @@ export {
   SqlResource,
   View,
   MaterializedView,
+  RefreshableMaterializedView,
   Task,
   Workflow,
   ETLPipeline,

--- a/packages/ts-moose-lib/src/dmv2/dataModelMetadata.ts
+++ b/packages/ts-moose-lib/src/dmv2/dataModelMetadata.ts
@@ -16,6 +16,7 @@ const typesToArgsLength = new Map([
   ["IngestApi", 2],
   ["Api", 2],
   ["MaterializedView", 1],
+  ["RefreshableMaterializedView", 1],
   ["Task", 2],
 ]);
 

--- a/packages/ts-moose-lib/src/dmv2/index.ts
+++ b/packages/ts-moose-lib/src/dmv2/index.ts
@@ -73,6 +73,14 @@ export { ETLPipeline, ETLPipelineConfig } from "./sdk/etlPipeline";
 export {
   MaterializedView,
   MaterializedViewConfig,
+  RefreshableMaterializedView,
+  RefreshableMaterializedViewConfig,
+  RefreshConfig,
+  RefreshInterval,
+  RefreshIntervalEvery,
+  RefreshIntervalAfter,
+  Duration,
+  TimeUnit,
 } from "./sdk/materializedView";
 export { SqlResource } from "./sdk/sqlResource";
 export { View } from "./sdk/view";

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -39,7 +39,10 @@ import {
 } from "./sdk/stream";
 import { compilerLog } from "../commons";
 import { WebApp } from "./sdk/webApp";
-import { MaterializedView } from "./sdk/materializedView";
+import {
+  MaterializedView,
+  RefreshableMaterializedView,
+} from "./sdk/materializedView";
 import { View } from "./sdk/view";
 import {
   getSourceDir,
@@ -170,7 +173,10 @@ const moose_internal = {
   sqlResources: new Map<string, SqlResource>(),
   workflows: new Map<string, Workflow>(),
   webApps: new Map<string, WebApp>(),
-  materializedViews: new Map<string, MaterializedView<any>>(),
+  materializedViews: new Map<
+    string,
+    MaterializedView<any> | RefreshableMaterializedView<any>
+  >(),
   views: new Map<string, View>(),
 };
 /**

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -604,36 +604,29 @@ interface ViewJson {
 }
 
 /**
- * Parse an interval string like "1 hour", "30 minutes", "2 days" to seconds.
- * Supports: seconds, second, minutes, minute, hours, hour, days, day
+ * Seconds per time unit lookup table.
+ * Used to convert structured Duration/RefreshInterval to seconds.
  */
-function parseIntervalToSeconds(interval: string): number {
-  const match = interval
-    .trim()
-    .match(/^(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days)$/i);
-  if (!match) {
+const UNIT_TO_SECONDS: Record<string, number> = {
+  second: 1,
+  minute: 60,
+  hour: 3600,
+  day: 86400,
+  week: 604800,
+};
+
+/**
+ * Convert a Duration (value + unit) to seconds.
+ * This is a simple lookup - no string parsing needed.
+ */
+function durationToSeconds(duration: { value: number; unit: string }): number {
+  const multiplier = UNIT_TO_SECONDS[duration.unit];
+  if (multiplier === undefined) {
     throw new Error(
-      `Invalid interval format: "${interval}". Expected format like "1 hour", "30 minutes", etc.`,
+      `Unknown time unit: "${duration.unit}". Supported units: ${Object.keys(UNIT_TO_SECONDS).join(", ")}`,
     );
   }
-  const value = parseInt(match[1], 10);
-  const unit = match[2].toLowerCase();
-  switch (unit) {
-    case "second":
-    case "seconds":
-      return value;
-    case "minute":
-    case "minutes":
-      return value * 60;
-    case "hour":
-    case "hours":
-      return value * 3600;
-    case "day":
-    case "days":
-      return value * 86400;
-    default:
-      throw new Error(`Unknown interval unit: ${unit}`);
-  }
+  return duration.value * multiplier;
 }
 
 /**
@@ -1319,15 +1312,15 @@ export const toInfraMap = (registry: typeof moose_internal) => {
       refreshConfigJson = {
         interval: {
           type: mv.refreshConfig.interval.type,
-          interval: parseIntervalToSeconds(mv.refreshConfig.interval.interval),
+          interval: durationToSeconds(mv.refreshConfig.interval),
         },
         offset:
           mv.refreshConfig.offset ?
-            parseIntervalToSeconds(mv.refreshConfig.offset)
+            durationToSeconds(mv.refreshConfig.offset)
           : undefined,
         randomize:
           mv.refreshConfig.randomize ?
-            parseIntervalToSeconds(mv.refreshConfig.randomize)
+            durationToSeconds(mv.refreshConfig.randomize)
           : undefined,
         dependsOn: mv.refreshConfig.dependsOn,
         append: mv.refreshConfig.append,

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -542,6 +542,28 @@ interface SqlResourceJson {
 }
 
 /**
+ * JSON representation of a refresh interval.
+ */
+interface RefreshIntervalJson {
+  type: "every" | "after";
+  /** Interval as seconds for proto compatibility */
+  interval: number;
+}
+
+/**
+ * JSON representation of refreshable MV configuration.
+ */
+interface RefreshConfigJson {
+  interval: RefreshIntervalJson;
+  /** Offset in seconds */
+  offset?: number;
+  /** Randomize window in seconds */
+  randomize?: number;
+  dependsOn?: string[];
+  append?: boolean;
+}
+
+/**
  * JSON representation of a structured Materialized View.
  */
 interface MaterializedViewJson {
@@ -561,6 +583,8 @@ interface MaterializedViewJson {
   metadata?: { [key: string]: any };
   /** Optional lifecycle management policy */
   lifeCycle?: string;
+  /** Refresh config for refreshable MVs. If undefined, this is an incremental MV. */
+  refreshConfig?: RefreshConfigJson;
 }
 
 /**
@@ -577,6 +601,39 @@ interface ViewJson {
   sourceTables: string[];
   /** Optional metadata for the view (e.g., description, source file) */
   metadata?: { [key: string]: any };
+}
+
+/**
+ * Parse an interval string like "1 hour", "30 minutes", "2 days" to seconds.
+ * Supports: seconds, second, minutes, minute, hours, hour, days, day
+ */
+function parseIntervalToSeconds(interval: string): number {
+  const match = interval
+    .trim()
+    .match(/^(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days)$/i);
+  if (!match) {
+    throw new Error(
+      `Invalid interval format: "${interval}". Expected format like "1 hour", "30 minutes", etc.`,
+    );
+  }
+  const value = parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+  switch (unit) {
+    case "second":
+    case "seconds":
+      return value;
+    case "minute":
+    case "minutes":
+      return value * 60;
+    case "hour":
+    case "hours":
+      return value * 3600;
+    case "day":
+    case "days":
+      return value * 86400;
+    default:
+      throw new Error(`Unknown interval unit: ${unit}`);
+  }
 }
 
 /**
@@ -1256,6 +1313,27 @@ export const toInfraMap = (registry: typeof moose_internal) => {
 
   // Serialize materialized views with structured data
   registry.materializedViews.forEach((mv) => {
+    // Convert refresh config to JSON format (if refreshable MV)
+    let refreshConfigJson: RefreshConfigJson | undefined;
+    if (mv.refreshConfig) {
+      refreshConfigJson = {
+        interval: {
+          type: mv.refreshConfig.interval.type,
+          interval: parseIntervalToSeconds(mv.refreshConfig.interval.interval),
+        },
+        offset:
+          mv.refreshConfig.offset ?
+            parseIntervalToSeconds(mv.refreshConfig.offset)
+          : undefined,
+        randomize:
+          mv.refreshConfig.randomize ?
+            parseIntervalToSeconds(mv.refreshConfig.randomize)
+          : undefined,
+        dependsOn: mv.refreshConfig.dependsOn,
+        append: mv.refreshConfig.append,
+      };
+    }
+
     materializedViews[mv.name] = {
       name: mv.name,
       selectSql: mv.selectSql,
@@ -1264,6 +1342,7 @@ export const toInfraMap = (registry: typeof moose_internal) => {
       targetDatabase: mv.targetTable.config.database,
       metadata: mv.metadata,
       lifeCycle: mv.lifeCycle,
+      refreshConfig: refreshConfigJson,
     };
   });
 

--- a/packages/ts-moose-lib/src/dmv2/registry.ts
+++ b/packages/ts-moose-lib/src/dmv2/registry.ts
@@ -14,7 +14,10 @@ import { Api } from "./sdk/consumptionApi";
 import { SqlResource } from "./sdk/sqlResource";
 import { Workflow } from "./sdk/workflow";
 import { WebApp } from "./sdk/webApp";
-import { MaterializedView } from "./sdk/materializedView";
+import {
+  MaterializedView,
+  RefreshableMaterializedView,
+} from "./sdk/materializedView";
 import { View } from "./sdk/view";
 import { getMooseInternal } from "./internal";
 
@@ -177,21 +180,24 @@ export function getWebApp(name: string): WebApp | undefined {
 }
 
 /**
- * Get all registered materialized views.
- * @returns A Map of MV name to MaterializedView instance
+ * Get all registered materialized views (both incremental and refreshable).
+ * @returns A Map of MV name to MaterializedView or RefreshableMaterializedView instance
  */
-export function getMaterializedViews(): Map<string, MaterializedView<any>> {
+export function getMaterializedViews(): Map<
+  string,
+  MaterializedView<any> | RefreshableMaterializedView<any>
+> {
   return getMooseInternal().materializedViews;
 }
 
 /**
  * Get a registered materialized view by name.
  * @param name - The name of the materialized view
- * @returns The MaterializedView instance or undefined if not found
+ * @returns The MaterializedView or RefreshableMaterializedView instance, or undefined if not found
  */
 export function getMaterializedView(
   name: string,
-): MaterializedView<any> | undefined {
+): MaterializedView<any> | RefreshableMaterializedView<any> | undefined {
   return getMooseInternal().materializedViews.get(name);
 }
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
@@ -90,7 +90,10 @@ export interface Duration {
 export interface RefreshConfig {
   /** The refresh interval (EVERY or AFTER) */
   interval: RefreshInterval;
-  /** Optional offset from interval start */
+  /**
+   * Optional offset from interval start.
+   * NOTE: Only valid with REFRESH EVERY, not REFRESH AFTER.
+   */
   offset?: Duration;
   /** Optional randomization window */
   randomize?: Duration;
@@ -506,6 +509,17 @@ export class RefreshableMaterializedView<TargetTable> {
     if (targetTable.name === options.materializedViewName) {
       throw new Error(
         "Materialized view name cannot be the same as the target table name.",
+      );
+    }
+
+    // Validate OFFSET is not used with REFRESH AFTER (only valid with REFRESH EVERY)
+    if (
+      options.refreshConfig.interval.type === "after" &&
+      options.refreshConfig.offset
+    ) {
+      throw new Error(
+        "OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER. " +
+          "Remove the 'offset' option or change the interval type to 'every'.",
       );
     }
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
@@ -20,41 +20,133 @@ function formatTableReference(table: OlapTable<any> | View): string {
   return `\`${table.name}\``;
 }
 
+// ============================================================================
+// Refresh Configuration Types for Refreshable Materialized Views
+// ============================================================================
+
+/**
+ * Refresh interval using EVERY mode - periodic refresh at fixed times.
+ * Example: { type: "every", interval: "1 hour" } => REFRESH EVERY 1 HOUR
+ */
+export interface RefreshIntervalEvery {
+  type: "every";
+  /** Interval string like "1 hour", "30 minutes", "1 day" */
+  interval: string;
+}
+
+/**
+ * Refresh interval using AFTER mode - refresh after interval since last refresh.
+ * Example: { type: "after", interval: "30 minutes" } => REFRESH AFTER 30 MINUTES
+ */
+export interface RefreshIntervalAfter {
+  type: "after";
+  /** Interval string like "1 hour", "30 minutes", "1 day" */
+  interval: string;
+}
+
+/**
+ * Refresh interval specification - either EVERY or AFTER mode.
+ */
+export type RefreshInterval = RefreshIntervalEvery | RefreshIntervalAfter;
+
+/**
+ * Configuration for refreshable (scheduled) materialized views.
+ *
+ * Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
+ * being triggered by inserts to source tables.
+ */
+export interface RefreshConfig {
+  /** The refresh interval (EVERY or AFTER) */
+  interval: RefreshInterval;
+  /** Optional offset from interval start, e.g., "5 minutes" */
+  offset?: string;
+  /** Optional randomization window, e.g., "10 seconds" */
+  randomize?: string;
+  /** Names of other MVs this one depends on */
+  dependsOn?: string[];
+  /** Use APPEND mode instead of full refresh */
+  append?: boolean;
+}
+
+// ============================================================================
+// MaterializedView Configuration
+// ============================================================================
+
 /**
  * Configuration options for creating a Materialized View.
+ *
+ * Two types of materialized views are supported:
+ * - **Incremental**: Triggered on every insert to source tables (when refreshConfig is NOT set)
+ * - **Refreshable**: Runs on a schedule (when refreshConfig IS set)
+ *
  * @template T The data type of the records stored in the target table of the materialized view.
  */
 export interface MaterializedViewConfig<T> {
   /** The SQL SELECT statement or `Sql` object defining the data to be materialized. Dynamic SQL (with parameters) is not allowed here. */
   selectStatement: string | Sql;
-  /** An array of OlapTable or View objects that the `selectStatement` reads from. */
-  selectTables: (OlapTable<any> | View)[];
 
-  /** @deprecated See {@link targetTable}
-   *  The name for the underlying target OlapTable that stores the materialized data. */
-  tableName?: string;
+  /**
+   * The source tables/views that the SELECT statement reads from.
+   * Required for ALL materialized views.
+   *
+   * - For incremental MVs: these tables trigger the MV on insert
+   * - For refreshable MVs: these tables are read during scheduled refresh (data lineage)
+   */
+  selectTables: (OlapTable<any> | View)[];
 
   /** The name for the ClickHouse MATERIALIZED VIEW object itself. */
   materializedViewName: string;
 
-  /** @deprecated See {@link targetTable}
-   *  Optional ClickHouse engine for the target table (e.g., ReplacingMergeTree). Defaults to MergeTree. */
-  engine?: ClickHouseEngines;
-
+  /**
+   * The target table where transformed data is written.
+   * Can be an existing OlapTable or inline configuration to create one.
+   *
+   * Preferred over the deprecated tableName/engine/orderByFields fields.
+   */
   targetTable?:
-    | OlapTable<T> /**  Target table if the OlapTable object is already constructed. */
+    | OlapTable<T>
     | {
         /** The name for the underlying target OlapTable that stores the materialized data. */
         name: string;
-        /** Optional ClickHouse engine for the target table (e.g., ReplacingMergeTree). Defaults to MergeTree. */
+        /**
+         * ClickHouse engine for the target table (e.g., ReplacingMergeTree).
+         * Defaults to MergeTree.
+         *
+         * Note: Custom engines are only supported for incremental MVs.
+         * Refreshable MVs must use the default MergeTree engine.
+         */
         engine?: ClickHouseEngines;
         /** Optional ordering fields for the target table. Crucial if using ReplacingMergeTree. */
         orderByFields?: (keyof T & string)[];
       };
 
-  /** @deprecated See {@link targetTable}
-   *  Optional ordering fields for the target table. Crucial if using ReplacingMergeTree. */
+  /**
+   * @deprecated Use targetTable instead.
+   * The name for the underlying target OlapTable that stores the materialized data.
+   */
+  tableName?: string;
+
+  /**
+   * @deprecated Use targetTable instead.
+   * Optional ClickHouse engine for the target table (e.g., ReplacingMergeTree). Defaults to MergeTree.
+   */
+  engine?: ClickHouseEngines;
+
+  /**
+   * @deprecated Use targetTable instead.
+   * Optional ordering fields for the target table. Crucial if using ReplacingMergeTree.
+   */
   orderByFields?: (keyof T & string)[];
+
+  /**
+   * Configuration for refreshable (scheduled) materialized views.
+   *
+   * - If set: The MV runs on a schedule (REFRESH EVERY/AFTER)
+   * - If not set: The MV is incremental (triggered by inserts to selectTables)
+   *
+   * Note: Refreshable MVs cannot use custom engines on the target table.
+   */
+  refreshConfig?: RefreshConfig;
 
   /** Optional metadata for the materialized view (e.g., description, source file). */
   metadata?: { [key: string]: any };
@@ -65,20 +157,14 @@ export interface MaterializedViewConfig<T> {
   lifeCycle?: LifeCycle;
 }
 
-const requireTargetTableName = (tableName: string | undefined): string => {
-  if (typeof tableName === "string") {
-    return tableName;
-  } else {
-    throw new Error("Name of targetTable is not specified.");
-  }
-};
-
 /**
  * Represents a Materialized View in ClickHouse.
- * This encapsulates both the target OlapTable that stores the data and the MATERIALIZED VIEW definition
- * that populates the table based on inserts into the source tables.
  *
- * @template TargetTable The data type of the records stored in the underlying target OlapTable. The structure of T defines the target table schema.
+ * Two types are supported:
+ * - **Incremental**: Triggered on inserts to source tables (refreshConfig not set)
+ * - **Refreshable**: Runs on a schedule (refreshConfig is set)
+ *
+ * @template TargetTable The data type of the records stored in the underlying target OlapTable.
  */
 export class MaterializedView<TargetTable> {
   /** @internal */
@@ -103,9 +189,14 @@ export class MaterializedView<TargetTable> {
   lifeCycle?: LifeCycle;
 
   /**
+   * The refresh configuration if this is a refreshable MV.
+   * If undefined, this is an incremental MV.
+   * @internal
+   */
+  refreshConfig?: RefreshConfig;
+
+  /**
    * Creates a new MaterializedView instance.
-   * Requires the `TargetTable` type parameter to be explicitly provided or inferred,
-   * as it's needed to define the schema of the underlying target table.
    *
    * @param options Configuration options for the materialized view.
    */
@@ -122,6 +213,7 @@ export class MaterializedView<TargetTable> {
     targetSchema?: IJsonSchemaCollection.IV3_1,
     targetColumns?: Column[],
   ) {
+    // Validate selectStatement
     let selectStatement = options.selectStatement;
     if (typeof selectStatement !== "string") {
       selectStatement = toStaticQuery(selectStatement);
@@ -133,24 +225,77 @@ export class MaterializedView<TargetTable> {
       );
     }
 
-    const targetTable =
-      options.targetTable instanceof OlapTable ?
-        options.targetTable
-      : new OlapTable(
-          requireTargetTableName(
-            options.targetTable?.name ?? options.tableName,
-          ),
-          {
-            orderByFields:
-              options.targetTable?.orderByFields ?? options.orderByFields,
-            engine:
-              options.targetTable?.engine ??
-              options.engine ??
-              ClickHouseEngines.MergeTree,
-          } as OlapConfig<TargetTable>,
-          targetSchema,
-          targetColumns,
-        );
+    // Validate selectTables is provided and not empty
+    if (!options.selectTables || options.selectTables.length === 0) {
+      throw new Error(
+        "MaterializedView requires 'selectTables' to be specified with at least one table. " +
+          "These are the tables that your SELECT statement reads from.",
+      );
+    }
+
+    // Resolve target table configuration
+    // Support both new (targetTable) and deprecated (tableName/engine/orderByFields) approaches
+    const isRefreshable = options.refreshConfig !== undefined;
+    let targetTableEngine: ClickHouseEngines | undefined;
+    let targetTable: OlapTable<TargetTable>;
+
+    if (options.targetTable !== undefined && options.tableName !== undefined) {
+      throw new Error(
+        "Cannot specify both 'targetTable' and 'tableName'. " +
+          "Use 'targetTable' (preferred) or 'tableName' (deprecated).",
+      );
+    }
+
+    if (options.targetTable instanceof OlapTable) {
+      // Using existing OlapTable directly
+      targetTable = options.targetTable;
+      const config = targetTable.config as { engine?: ClickHouseEngines };
+      targetTableEngine = config.engine;
+    } else if (options.targetTable) {
+      // Using inline targetTable config (preferred)
+      targetTableEngine = options.targetTable.engine;
+      targetTable = new OlapTable(
+        options.targetTable.name,
+        {
+          orderByFields: options.targetTable.orderByFields,
+          engine: options.targetTable.engine ?? ClickHouseEngines.MergeTree,
+        } as OlapConfig<TargetTable>,
+        targetSchema,
+        targetColumns,
+      );
+    } else if (options.tableName) {
+      // Using deprecated tableName/engine/orderByFields
+      targetTableEngine = options.engine;
+      targetTable = new OlapTable(
+        options.tableName,
+        {
+          orderByFields: options.orderByFields,
+          engine: options.engine ?? ClickHouseEngines.MergeTree,
+        } as OlapConfig<TargetTable>,
+        targetSchema,
+        targetColumns,
+      );
+    } else {
+      throw new Error(
+        "Target table must be specified. Use one of:\n" +
+          "  targetTable: myOlapTable              // existing OlapTable\n" +
+          "  targetTable: { name: 'my_table' }     // inline config\n" +
+          "  tableName: 'my_table'                 // deprecated",
+      );
+    }
+
+    // Validate: refreshable MVs cannot use custom engines
+    if (
+      isRefreshable &&
+      targetTableEngine !== undefined &&
+      targetTableEngine !== ClickHouseEngines.MergeTree
+    ) {
+      throw new Error(
+        "Refreshable materialized views cannot use custom engines. " +
+          `Found engine '${targetTableEngine}' but refreshable MVs only support MergeTree. ` +
+          "Remove the 'engine' option or remove 'refreshConfig' to create an incremental MV.",
+      );
+    }
 
     if (targetTable.name === options.materializedViewName) {
       throw new Error(
@@ -161,6 +306,9 @@ export class MaterializedView<TargetTable> {
     this.name = options.materializedViewName;
     this.targetTable = targetTable;
     this.selectSql = selectStatement;
+    this.refreshConfig = options.refreshConfig;
+
+    // Set sourceTables from the selectTables configuration
     this.sourceTables = options.selectTables.map((t) =>
       formatTableReference(t),
     );
@@ -184,5 +332,26 @@ export class MaterializedView<TargetTable> {
       throw new Error(`MaterializedView with name ${this.name} already exists`);
     }
     materializedViews.set(this.name, this);
+  }
+
+  /**
+   * Returns true if this is an incremental (trigger-based) materialized view.
+   */
+  isIncremental(): boolean {
+    return this.refreshConfig === undefined;
+  }
+
+  /**
+   * Returns true if this is a refreshable (scheduled) materialized view.
+   */
+  isRefreshable(): boolean {
+    return this.refreshConfig !== undefined;
+  }
+
+  /**
+   * Returns the refresh configuration if this is a refreshable MV.
+   */
+  getRefreshConfig(): RefreshConfig | undefined {
+    return this.refreshConfig;
   }
 }

--- a/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
@@ -28,7 +28,14 @@ function formatTableReference(table: OlapTable<any> | View): string {
  * Supported time units for refresh intervals.
  * Maps directly to ClickHouse interval units.
  */
-export type TimeUnit = "second" | "minute" | "hour" | "day" | "week";
+export type TimeUnit =
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
 
 /**
  * Refresh interval using EVERY mode - periodic refresh at fixed times.
@@ -512,6 +519,24 @@ export class RefreshableMaterializedView<TargetTable> {
       );
     }
 
+    // Validate interval value is a positive integer
+    const intervalVal = options.refreshConfig.interval.value;
+    if (!Number.isInteger(intervalVal) || intervalVal <= 0) {
+      throw new Error(
+        `Refresh interval value must be a positive integer, got: ${intervalVal}`,
+      );
+    }
+
+    // Validate offset/randomize values if present
+    for (const key of ["offset", "randomize"] as const) {
+      const dur = options.refreshConfig[key];
+      if (dur && (!Number.isInteger(dur.value) || dur.value <= 0)) {
+        throw new Error(
+          `Refresh ${key} value must be a positive integer, got: ${dur.value}`,
+        );
+      }
+    }
+
     // Validate OFFSET is not used with REFRESH AFTER (only valid with REFRESH EVERY)
     if (
       options.refreshConfig.interval.type === "after" &&
@@ -554,7 +579,7 @@ export class RefreshableMaterializedView<TargetTable> {
     const materializedViews = getMooseInternal().materializedViews;
     if (!isClientOnlyMode() && materializedViews.has(this.name)) {
       throw new Error(
-        `RefreshableMaterializedView with name ${this.name} already exists`,
+        `A MaterializedView with name '${this.name}' is already registered.`,
       );
     }
     materializedViews.set(this.name, this);

--- a/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
@@ -25,23 +25,33 @@ function formatTableReference(table: OlapTable<any> | View): string {
 // ============================================================================
 
 /**
+ * Supported time units for refresh intervals.
+ * Maps directly to ClickHouse interval units.
+ */
+export type TimeUnit = "second" | "minute" | "hour" | "day" | "week";
+
+/**
  * Refresh interval using EVERY mode - periodic refresh at fixed times.
- * Example: { type: "every", interval: "1 hour" } => REFRESH EVERY 1 HOUR
+ * Example: { type: "every", value: 1, unit: "hour" } => REFRESH EVERY 1 HOUR
  */
 export interface RefreshIntervalEvery {
   type: "every";
-  /** Interval string like "1 hour", "30 minutes", "1 day" */
-  interval: string;
+  /** The numeric value of the interval */
+  value: number;
+  /** The time unit for the interval */
+  unit: TimeUnit;
 }
 
 /**
  * Refresh interval using AFTER mode - refresh after interval since last refresh.
- * Example: { type: "after", interval: "30 minutes" } => REFRESH AFTER 30 MINUTES
+ * Example: { type: "after", value: 30, unit: "minute" } => REFRESH AFTER 30 MINUTE
  */
 export interface RefreshIntervalAfter {
   type: "after";
-  /** Interval string like "1 hour", "30 minutes", "1 day" */
-  interval: string;
+  /** The numeric value of the interval */
+  value: number;
+  /** The time unit for the interval */
+  unit: TimeUnit;
 }
 
 /**
@@ -50,18 +60,43 @@ export interface RefreshIntervalAfter {
 export type RefreshInterval = RefreshIntervalEvery | RefreshIntervalAfter;
 
 /**
+ * A duration specified as value + unit.
+ * Used for offset and randomize configurations.
+ */
+export interface Duration {
+  /** The numeric value */
+  value: number;
+  /** The time unit */
+  unit: TimeUnit;
+}
+
+/**
  * Configuration for refreshable (scheduled) materialized views.
  *
  * Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
  * being triggered by inserts to source tables.
+ *
+ * @example
+ * ```typescript
+ * const mv = new MaterializedView<Stats>({
+ *   materializedViewName: "hourly_stats_mv",
+ *   selectStatement: "SELECT count(*) as cnt FROM events",
+ *   selectTables: [eventsTable],
+ *   targetTable: { name: "hourly_stats" },
+ *   refreshConfig: {
+ *     interval: { type: "every", value: 1, unit: "hour" },
+ *     offset: { value: 5, unit: "minute" },
+ *   },
+ * });
+ * ```
  */
 export interface RefreshConfig {
   /** The refresh interval (EVERY or AFTER) */
   interval: RefreshInterval;
-  /** Optional offset from interval start, e.g., "5 minutes" */
-  offset?: string;
-  /** Optional randomization window, e.g., "10 seconds" */
-  randomize?: string;
+  /** Optional offset from interval start */
+  offset?: Duration;
+  /** Optional randomization window */
+  randomize?: Duration;
   /** Names of other MVs this one depends on */
   dependsOn?: string[];
   /** Use APPEND mode instead of full refresh */

--- a/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
@@ -73,12 +73,9 @@ export interface Duration {
 /**
  * Configuration for refreshable (scheduled) materialized views.
  *
- * Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
- * being triggered by inserts to source tables.
- *
  * @example
  * ```typescript
- * const mv = new MaterializedView<Stats>({
+ * const mv = new RefreshableMaterializedView<Stats>({
  *   materializedViewName: "hourly_stats_mv",
  *   selectStatement: "SELECT count(*) as cnt FROM events",
  *   selectTables: [eventsTable],
@@ -97,35 +94,46 @@ export interface RefreshConfig {
   offset?: Duration;
   /** Optional randomization window */
   randomize?: Duration;
-  /** Names of other MVs this one depends on */
-  dependsOn?: string[];
+  /**
+   * Other refreshable MVs this one depends on (will wait for them to refresh first).
+   * Only accepts RefreshableMaterializedView objects - ensures type safety.
+   */
+  dependsOn?: RefreshableMaterializedView<any>[];
   /** Use APPEND mode instead of full refresh */
   append?: boolean;
 }
 
+/**
+ * Internal representation of RefreshConfig with dependsOn converted to string names.
+ * @internal
+ */
+export interface ResolvedRefreshConfig {
+  interval: RefreshInterval;
+  offset?: Duration;
+  randomize?: Duration;
+  /** Names of other MVs this one depends on (already resolved to strings) */
+  dependsOn?: string[];
+  append?: boolean;
+}
+
 // ============================================================================
-// MaterializedView Configuration
+// Incremental MaterializedView Configuration and Class
 // ============================================================================
 
 /**
- * Configuration options for creating a Materialized View.
+ * Configuration options for creating an incremental Materialized View.
  *
- * Two types of materialized views are supported:
- * - **Incremental**: Triggered on every insert to source tables (when refreshConfig is NOT set)
- * - **Refreshable**: Runs on a schedule (when refreshConfig IS set)
+ * Incremental MVs are triggered on every insert to source tables.
  *
- * @template T The data type of the records stored in the target table of the materialized view.
+ * @template T The data type of the records stored in the target table.
  */
 export interface MaterializedViewConfig<T> {
-  /** The SQL SELECT statement or `Sql` object defining the data to be materialized. Dynamic SQL (with parameters) is not allowed here. */
+  /** The SQL SELECT statement or `Sql` object defining the data to be materialized. */
   selectStatement: string | Sql;
 
   /**
    * The source tables/views that the SELECT statement reads from.
-   * Required for ALL materialized views.
-   *
-   * - For incremental MVs: these tables trigger the MV on insert
-   * - For refreshable MVs: these tables are read during scheduled refresh (data lineage)
+   * These tables trigger the MV on insert.
    */
   selectTables: (OlapTable<any> | View)[];
 
@@ -135,55 +143,37 @@ export interface MaterializedViewConfig<T> {
   /**
    * The target table where transformed data is written.
    * Can be an existing OlapTable or inline configuration to create one.
-   *
-   * Preferred over the deprecated tableName/engine/orderByFields fields.
    */
   targetTable?:
     | OlapTable<T>
     | {
-        /** The name for the underlying target OlapTable that stores the materialized data. */
+        /** The name for the underlying target OlapTable. */
         name: string;
         /**
          * ClickHouse engine for the target table (e.g., ReplacingMergeTree).
          * Defaults to MergeTree.
-         *
-         * Note: Custom engines are only supported for incremental MVs.
-         * Refreshable MVs must use the default MergeTree engine.
          */
         engine?: ClickHouseEngines;
-        /** Optional ordering fields for the target table. Crucial if using ReplacingMergeTree. */
+        /** Optional ordering fields for the target table. */
         orderByFields?: (keyof T & string)[];
       };
 
   /**
    * @deprecated Use targetTable instead.
-   * The name for the underlying target OlapTable that stores the materialized data.
    */
   tableName?: string;
 
   /**
    * @deprecated Use targetTable instead.
-   * Optional ClickHouse engine for the target table (e.g., ReplacingMergeTree). Defaults to MergeTree.
    */
   engine?: ClickHouseEngines;
 
   /**
    * @deprecated Use targetTable instead.
-   * Optional ordering fields for the target table. Crucial if using ReplacingMergeTree.
    */
   orderByFields?: (keyof T & string)[];
 
-  /**
-   * Configuration for refreshable (scheduled) materialized views.
-   *
-   * - If set: The MV runs on a schedule (REFRESH EVERY/AFTER)
-   * - If not set: The MV is incremental (triggered by inserts to selectTables)
-   *
-   * Note: Refreshable MVs cannot use custom engines on the target table.
-   */
-  refreshConfig?: RefreshConfig;
-
-  /** Optional metadata for the materialized view (e.g., description, source file). */
+  /** Optional metadata for the materialized view. */
   metadata?: { [key: string]: any };
 
   /** Optional lifecycle management policy for the materialized view.
@@ -193,13 +183,12 @@ export interface MaterializedViewConfig<T> {
 }
 
 /**
- * Represents a Materialized View in ClickHouse.
+ * Represents an incremental Materialized View in ClickHouse.
  *
- * Two types are supported:
- * - **Incremental**: Triggered on inserts to source tables (refreshConfig not set)
- * - **Refreshable**: Runs on a schedule (refreshConfig is set)
+ * Incremental MVs are triggered on every insert to source tables.
+ * For scheduled/refreshable MVs, use `RefreshableMaterializedView` instead.
  *
- * @template TargetTable The data type of the records stored in the underlying target OlapTable.
+ * @template TargetTable The data type of the records stored in the target table.
  */
 export class MaterializedView<TargetTable> {
   /** @internal */
@@ -224,14 +213,13 @@ export class MaterializedView<TargetTable> {
   lifeCycle?: LifeCycle;
 
   /**
-   * The refresh configuration if this is a refreshable MV.
-   * If undefined, this is an incremental MV.
+   * Always undefined for incremental MVs.
    * @internal
    */
-  refreshConfig?: RefreshConfig;
+  refreshConfig?: undefined;
 
   /**
-   * Creates a new MaterializedView instance.
+   * Creates a new incremental MaterializedView instance.
    *
    * @param options Configuration options for the materialized view.
    */
@@ -269,9 +257,6 @@ export class MaterializedView<TargetTable> {
     }
 
     // Resolve target table configuration
-    // Support both new (targetTable) and deprecated (tableName/engine/orderByFields) approaches
-    const isRefreshable = options.refreshConfig !== undefined;
-    let targetTableEngine: ClickHouseEngines | undefined;
     let targetTable: OlapTable<TargetTable>;
 
     if (options.targetTable !== undefined && options.tableName !== undefined) {
@@ -282,13 +267,8 @@ export class MaterializedView<TargetTable> {
     }
 
     if (options.targetTable instanceof OlapTable) {
-      // Using existing OlapTable directly
       targetTable = options.targetTable;
-      const config = targetTable.config as { engine?: ClickHouseEngines };
-      targetTableEngine = config.engine;
     } else if (options.targetTable) {
-      // Using inline targetTable config (preferred)
-      targetTableEngine = options.targetTable.engine;
       targetTable = new OlapTable(
         options.targetTable.name,
         {
@@ -299,8 +279,6 @@ export class MaterializedView<TargetTable> {
         targetColumns,
       );
     } else if (options.tableName) {
-      // Using deprecated tableName/engine/orderByFields
-      targetTableEngine = options.engine;
       targetTable = new OlapTable(
         options.tableName,
         {
@@ -319,19 +297,6 @@ export class MaterializedView<TargetTable> {
       );
     }
 
-    // Validate: refreshable MVs cannot use custom engines
-    if (
-      isRefreshable &&
-      targetTableEngine !== undefined &&
-      targetTableEngine !== ClickHouseEngines.MergeTree
-    ) {
-      throw new Error(
-        "Refreshable materialized views cannot use custom engines. " +
-          `Found engine '${targetTableEngine}' but refreshable MVs only support MergeTree. ` +
-          "Remove the 'engine' option or remove 'refreshConfig' to create an incremental MV.",
-      );
-    }
-
     if (targetTable.name === options.materializedViewName) {
       throw new Error(
         "Materialized view name cannot be the same as the target table name.",
@@ -341,7 +306,7 @@ export class MaterializedView<TargetTable> {
     this.name = options.materializedViewName;
     this.targetTable = targetTable;
     this.selectSql = selectStatement;
-    this.refreshConfig = options.refreshConfig;
+    this.refreshConfig = undefined;
 
     // Set sourceTables from the selectTables configuration
     this.sourceTables = options.selectTables.map((t) =>
@@ -349,7 +314,7 @@ export class MaterializedView<TargetTable> {
     );
     this.lifeCycle = options.lifeCycle;
 
-    // Initialize metadata, preserving user-provided metadata if any
+    // Initialize metadata
     this.metadata = options.metadata ? { ...options.metadata } : {};
 
     // Capture source file from stack trace if not already provided
@@ -370,23 +335,235 @@ export class MaterializedView<TargetTable> {
   }
 
   /**
-   * Returns true if this is an incremental (trigger-based) materialized view.
+   * Returns true - incremental MVs are always incremental.
    */
   isIncremental(): boolean {
-    return this.refreshConfig === undefined;
+    return true;
   }
 
   /**
-   * Returns true if this is a refreshable (scheduled) materialized view.
+   * Returns false - incremental MVs are never refreshable.
    */
   isRefreshable(): boolean {
-    return this.refreshConfig !== undefined;
+    return false;
+  }
+}
+
+// ============================================================================
+// Refreshable MaterializedView Configuration and Class
+// ============================================================================
+
+/**
+ * Configuration options for creating a Refreshable Materialized View.
+ *
+ * Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
+ * being triggered by inserts to source tables.
+ *
+ * Note: Refreshable MVs always use MergeTree engine (no custom engine option).
+ *
+ * @template T The data type of the records stored in the target table.
+ */
+export interface RefreshableMaterializedViewConfig<T> {
+  /** The SQL SELECT statement or `Sql` object defining the data to be materialized. */
+  selectStatement: string | Sql;
+
+  /**
+   * The source tables/views that the SELECT statement reads from.
+   * These define the data lineage for the refresh operation.
+   */
+  selectTables: (OlapTable<any> | View)[];
+
+  /** The name for the ClickHouse MATERIALIZED VIEW object itself. */
+  materializedViewName: string;
+
+  /**
+   * The target table where transformed data is written.
+   * Can be an existing OlapTable or inline configuration to create one.
+   *
+   * Note: Custom engines are not supported for refreshable MVs (MergeTree only).
+   */
+  targetTable:
+    | OlapTable<T>
+    | {
+        /** The name for the underlying target OlapTable. */
+        name: string;
+        /** Optional ordering fields for the target table. */
+        orderByFields?: (keyof T & string)[];
+      };
+
+  /**
+   * Configuration for the refresh schedule.
+   * Required for refreshable MVs.
+   */
+  refreshConfig: RefreshConfig;
+
+  /** Optional metadata for the materialized view. */
+  metadata?: { [key: string]: any };
+}
+
+/**
+ * Represents a Refreshable Materialized View in ClickHouse.
+ *
+ * Refreshable MVs run on a schedule (REFRESH EVERY/AFTER) rather than
+ * being triggered by inserts to source tables.
+ *
+ * For incremental/trigger-based MVs, use `MaterializedView` instead.
+ *
+ * @template TargetTable The data type of the records stored in the target table.
+ */
+export class RefreshableMaterializedView<TargetTable> {
+  /** @internal */
+  public readonly kind = "MaterializedView";
+
+  /** The name of the materialized view */
+  name: string;
+
+  /** The target OlapTable instance where the materialized data is stored. */
+  targetTable: OlapTable<TargetTable>;
+
+  /** The SELECT SQL statement */
+  selectSql: string;
+
+  /** Names of source tables that the SELECT reads from */
+  sourceTables: string[];
+
+  /** Optional metadata for the materialized view */
+  metadata: { [key: string]: any };
+
+  /**
+   * The refresh configuration for this refreshable MV.
+   * dependsOn is resolved to string names.
+   * @internal
+   */
+  refreshConfig: ResolvedRefreshConfig;
+
+  /**
+   * Creates a new RefreshableMaterializedView instance.
+   *
+   * @param options Configuration options for the materialized view.
+   */
+  constructor(options: RefreshableMaterializedViewConfig<TargetTable>);
+
+  /** @internal **/
+  constructor(
+    options: RefreshableMaterializedViewConfig<TargetTable>,
+    targetSchema: IJsonSchemaCollection.IV3_1,
+    targetColumns: Column[],
+  );
+  constructor(
+    options: RefreshableMaterializedViewConfig<TargetTable>,
+    targetSchema?: IJsonSchemaCollection.IV3_1,
+    targetColumns?: Column[],
+  ) {
+    // Validate selectStatement
+    let selectStatement = options.selectStatement;
+    if (typeof selectStatement !== "string") {
+      selectStatement = toStaticQuery(selectStatement);
+    }
+
+    if (targetSchema === undefined || targetColumns === undefined) {
+      throw new Error(
+        "Supply the type param T so that the schema is inserted by the compiler plugin.",
+      );
+    }
+
+    // Validate selectTables is provided and not empty
+    if (!options.selectTables || options.selectTables.length === 0) {
+      throw new Error(
+        "RefreshableMaterializedView requires 'selectTables' to be specified with at least one table. " +
+          "These are the tables that your SELECT statement reads from.",
+      );
+    }
+
+    // Resolve target table configuration
+    let targetTable: OlapTable<TargetTable>;
+
+    if (options.targetTable instanceof OlapTable) {
+      targetTable = options.targetTable;
+      // Validate no custom engine on existing OlapTable
+      const config = targetTable.config as { engine?: ClickHouseEngines };
+      if (
+        config.engine !== undefined &&
+        config.engine !== ClickHouseEngines.MergeTree
+      ) {
+        throw new Error(
+          "RefreshableMaterializedView cannot use custom engines. " +
+            `Found engine '${config.engine}' but refreshable MVs only support MergeTree.`,
+        );
+      }
+    } else {
+      targetTable = new OlapTable(
+        options.targetTable.name,
+        {
+          orderByFields: options.targetTable.orderByFields,
+          engine: ClickHouseEngines.MergeTree, // Always MergeTree
+        } as OlapConfig<TargetTable>,
+        targetSchema,
+        targetColumns,
+      );
+    }
+
+    if (targetTable.name === options.materializedViewName) {
+      throw new Error(
+        "Materialized view name cannot be the same as the target table name.",
+      );
+    }
+
+    this.name = options.materializedViewName;
+    this.targetTable = targetTable;
+    this.selectSql = selectStatement;
+
+    // Convert refreshConfig.dependsOn from RefreshableMaterializedView objects to string names
+    this.refreshConfig = {
+      ...options.refreshConfig,
+      dependsOn: options.refreshConfig.dependsOn?.map((dep) => dep.name),
+    };
+
+    // Set sourceTables from the selectTables configuration
+    this.sourceTables = options.selectTables.map((t) =>
+      formatTableReference(t),
+    );
+
+    // Initialize metadata
+    this.metadata = options.metadata ? { ...options.metadata } : {};
+
+    // Capture source file from stack trace if not already provided
+    if (!this.metadata.source) {
+      const stack = new Error().stack;
+      const sourceInfo = getSourceFileFromStack(stack);
+      if (sourceInfo) {
+        this.metadata.source = { file: sourceInfo };
+      }
+    }
+
+    // Register in the materializedViews registry
+    const materializedViews = getMooseInternal().materializedViews;
+    if (!isClientOnlyMode() && materializedViews.has(this.name)) {
+      throw new Error(
+        `RefreshableMaterializedView with name ${this.name} already exists`,
+      );
+    }
+    materializedViews.set(this.name, this);
   }
 
   /**
-   * Returns the refresh configuration if this is a refreshable MV.
+   * Returns false - refreshable MVs are never incremental.
    */
-  getRefreshConfig(): RefreshConfig | undefined {
+  isIncremental(): boolean {
+    return false;
+  }
+
+  /**
+   * Returns true - refreshable MVs are always refreshable.
+   */
+  isRefreshable(): boolean {
+    return true;
+  }
+
+  /**
+   * Returns the refresh configuration.
+   */
+  getRefreshConfig(): ResolvedRefreshConfig {
     return this.refreshConfig;
   }
 }

--- a/templates/python-tests/src/views/__init__.py
+++ b/templates/python-tests/src/views/__init__.py
@@ -1,0 +1,8 @@
+from .bar_aggregated import barAggregatedMV
+from .refreshable_mv import (
+    hourly_stats_mv,
+    daily_stats_mv,
+    weekly_rollup_mv,
+    randomized_stats_mv,
+    incremental_stats_mv,
+)

--- a/templates/python-tests/src/views/refreshable_mv.py
+++ b/templates/python-tests/src/views/refreshable_mv.py
@@ -5,7 +5,6 @@
 # new refresh configuration API works correctly end-to-end.
 
 from datetime import datetime, date
-from typing import Optional
 from pydantic import BaseModel
 
 from moose_lib.dmv2 import MaterializedView, MaterializedViewOptions

--- a/templates/python-tests/src/views/refreshable_mv.py
+++ b/templates/python-tests/src/views/refreshable_mv.py
@@ -1,0 +1,187 @@
+# ============================================================================
+# Refreshable Materialized View E2E Tests
+# ============================================================================
+# Tests both incremental and refreshable materialized views to ensure the
+# new refresh configuration API works correctly end-to-end.
+
+from datetime import datetime, date
+from typing import Optional
+from pydantic import BaseModel
+
+from moose_lib.dmv2 import MaterializedView, MaterializedViewOptions
+from moose_lib.dmv2.materialized_view import (
+    RefreshConfig,
+    RefreshIntervalEvery,
+    RefreshIntervalAfter,
+    Duration,
+)
+from src.ingest.models import barModel
+
+
+# ============================================================================
+# Target Schemas
+# ============================================================================
+
+
+class HourlyStats(BaseModel):
+    """Target schema for hourly aggregated stats."""
+
+    hour: datetime
+    total_rows: int
+    avg_text_length: float
+
+
+class DailyStats(BaseModel):
+    """Target schema for daily stats with refresh."""
+
+    day: date
+    row_count: int
+    max_text_length: int
+
+
+class WeeklyRollup(BaseModel):
+    """Target schema for weekly rollup."""
+
+    week_start: date
+    total_records: int
+
+
+class RandomizedStats(BaseModel):
+    """Target schema for randomized stats."""
+
+    minute: datetime
+    event_count: int
+
+
+class IncrementalStats(BaseModel):
+    """Target schema for incremental MV (control)."""
+
+    primary_key: str
+    processed_at: datetime
+    text_length_squared: int
+
+
+# ============================================================================
+# Test 1: Refreshable MV with EVERY interval
+# ============================================================================
+# This MV refreshes every hour, aggregating data from the Bar table
+
+hourly_stats_mv = MaterializedView[HourlyStats](
+    MaterializedViewOptions(
+        materialized_view_name="hourly_stats_mv",
+        table_name="hourly_stats",
+        select_statement="""
+            SELECT
+                toStartOfHour(utc_timestamp) as hour,
+                count(*) as total_rows,
+                avg(text_length) as avg_text_length
+            FROM Bar
+            GROUP BY hour
+        """,
+        select_tables=[barModel.table],
+        refresh_config=RefreshConfig(
+            interval=RefreshIntervalEvery(value=1, unit="hour"),
+        ),
+    )
+)
+
+
+# ============================================================================
+# Test 2: Refreshable MV with AFTER interval and offset
+# ============================================================================
+# This MV refreshes 30 minutes after the last refresh completed,
+# with a 5-minute offset from the start of the interval
+
+daily_stats_mv = MaterializedView[DailyStats](
+    MaterializedViewOptions(
+        materialized_view_name="daily_stats_mv",
+        table_name="daily_stats",
+        select_statement="""
+            SELECT
+                toDate(utc_timestamp) as day,
+                count(*) as row_count,
+                max(text_length) as max_text_length
+            FROM Bar
+            GROUP BY day
+        """,
+        select_tables=[barModel.table],
+        refresh_config=RefreshConfig(
+            interval=RefreshIntervalAfter(value=30, unit="minute"),
+            offset=Duration(value=5, unit="minute"),
+        ),
+    )
+)
+
+
+# ============================================================================
+# Test 3: Refreshable MV with DEPENDS ON and APPEND
+# ============================================================================
+# This MV depends on daily_stats_mv and uses APPEND mode for incremental updates
+
+weekly_rollup_mv = MaterializedView[WeeklyRollup](
+    MaterializedViewOptions(
+        materialized_view_name="weekly_rollup_mv",
+        table_name="weekly_rollup",
+        select_statement="""
+            SELECT
+                toMonday(day) as week_start,
+                sum(row_count) as total_records
+            FROM daily_stats
+            GROUP BY week_start
+        """,
+        select_tables=[],  # Note: source is another MV's target table
+        refresh_config=RefreshConfig(
+            interval=RefreshIntervalEvery(value=1, unit="day"),
+            depends_on=["daily_stats_mv"],
+            append=True,
+        ),
+    )
+)
+
+
+# ============================================================================
+# Test 4: Refreshable MV with randomize window
+# ============================================================================
+# This MV uses randomization to prevent thundering herd on refresh
+
+randomized_stats_mv = MaterializedView[RandomizedStats](
+    MaterializedViewOptions(
+        materialized_view_name="randomized_stats_mv",
+        table_name="randomized_stats",
+        select_statement="""
+            SELECT
+                toStartOfMinute(utc_timestamp) as minute,
+                count(*) as event_count
+            FROM Bar
+            GROUP BY minute
+        """,
+        select_tables=[barModel.table],
+        refresh_config=RefreshConfig(
+            interval=RefreshIntervalEvery(value=5, unit="minute"),
+            randomize=Duration(value=30, unit="second"),
+        ),
+    )
+)
+
+
+# ============================================================================
+# Test 5: Incremental MV (control - no refresh_config)
+# ============================================================================
+# This is a traditional incremental MV for comparison - no refresh_config means
+# it triggers on every insert to the source table
+
+incremental_stats_mv = MaterializedView[IncrementalStats](
+    MaterializedViewOptions(
+        materialized_view_name="incremental_stats_mv",
+        table_name="incremental_stats",
+        select_statement="""
+            SELECT
+                primary_key,
+                now() as processed_at,
+                text_length * text_length as text_length_squared
+            FROM Bar
+        """,
+        select_tables=[barModel.table],
+        # No refresh_config = incremental MV
+    )
+)

--- a/templates/typescript-tests/src/index.ts
+++ b/templates/typescript-tests/src/index.ts
@@ -15,4 +15,5 @@ export * from "./apis/barKoa";
 export * from "./apis/barRaw";
 export * from "./apis/sqlHelpersTest";
 export * from "./views/barAggregated";
+export * from "./views/refreshableMv";
 export * from "./workflows/generator";

--- a/templates/typescript-tests/src/views/refreshableMv.ts
+++ b/templates/typescript-tests/src/views/refreshableMv.ts
@@ -17,9 +17,10 @@ const barTable = BarPipeline.table!;
 const barColumns = barTable.columns;
 
 // ============================================================================
-// Test 1: Refreshable MV with EVERY interval
+// Test 1: Refreshable MV with EVERY interval and OFFSET
 // ============================================================================
-// This MV refreshes every hour, aggregating data from the Bar table
+// This MV refreshes every hour with a 5-minute offset, aggregating data from the Bar table.
+// OFFSET is only valid with REFRESH EVERY (not REFRESH AFTER).
 
 interface HourlyStats {
   hour: DateTime;
@@ -42,14 +43,15 @@ export const HourlyStatsMV = new RefreshableMaterializedView<HourlyStats>({
   selectTables: [barTable],
   refreshConfig: {
     interval: { type: "every", value: 1, unit: "hour" },
+    offset: { value: 5, unit: "minute" }, // OFFSET is valid with EVERY
   },
 });
 
 // ============================================================================
-// Test 2: Refreshable MV with AFTER interval and offset
+// Test 2: Refreshable MV with AFTER interval (no offset - OFFSET only valid with EVERY)
 // ============================================================================
-// This MV refreshes 30 minutes after the last refresh completed,
-// with a 5-minute offset from the start of the interval
+// This MV refreshes 30 minutes after the last refresh completed.
+// Note: OFFSET is NOT valid with REFRESH AFTER in ClickHouse, only with REFRESH EVERY.
 
 interface DailyStats {
   day: string & typia.tags.Format<"date">;
@@ -72,7 +74,7 @@ export const DailyStatsMV = new RefreshableMaterializedView<DailyStats>({
   selectTables: [barTable],
   refreshConfig: {
     interval: { type: "after", value: 30, unit: "minute" },
-    offset: { value: 5, unit: "minute" },
+    // Note: No offset here - OFFSET is only valid with REFRESH EVERY, not REFRESH AFTER
   },
 });
 

--- a/templates/typescript-tests/src/views/refreshableMv.ts
+++ b/templates/typescript-tests/src/views/refreshableMv.ts
@@ -1,0 +1,143 @@
+import typia from "typia";
+import { MaterializedView, OlapTable, sql, DateTime } from "@514labs/moose-lib";
+import { BarPipeline } from "../ingest/models";
+
+// ============================================================================
+// Refreshable Materialized View E2E Tests
+// ============================================================================
+// Tests both incremental and refreshable materialized views to ensure the
+// new refresh configuration API works correctly end-to-end.
+
+// Target schema for hourly aggregated stats
+interface HourlyStats {
+  hour: DateTime;
+  totalRows: number & typia.tags.Type<"int64">;
+  avgTextLength: number;
+}
+
+// Target schema for daily stats with refresh
+interface DailyStats {
+  day: string & typia.tags.Format<"date">;
+  rowCount: number & typia.tags.Type<"int64">;
+  maxTextLength: number & typia.tags.Type<"int64">;
+}
+
+// Target schema for weekly rollup
+interface WeeklyRollup {
+  weekStart: string & typia.tags.Format<"date">;
+  totalRecords: number & typia.tags.Type<"int64">;
+}
+
+const barTable = BarPipeline.table!;
+
+// ============================================================================
+// Test 1: Refreshable MV with EVERY interval
+// ============================================================================
+// This MV refreshes every hour, aggregating data from the Bar table
+
+export const HourlyStatsMV = new MaterializedView<HourlyStats>({
+  materializedViewName: "HourlyStats_MV",
+  targetTable: { name: "HourlyStats" },
+  selectStatement: sql`SELECT
+    toStartOfHour(${barTable.columns.utcTimestamp}) as hour,
+    count(*) as totalRows,
+    avg(${barTable.columns.textLength}) as avgTextLength
+  FROM ${barTable}
+  GROUP BY hour`,
+  selectTables: [barTable],
+  refreshConfig: {
+    interval: { type: "every", value: 1, unit: "hour" },
+  },
+});
+
+// ============================================================================
+// Test 2: Refreshable MV with AFTER interval and offset
+// ============================================================================
+// This MV refreshes 30 minutes after the last refresh completed,
+// with a 5-minute offset from the start of the interval
+
+export const DailyStatsMV = new MaterializedView<DailyStats>({
+  materializedViewName: "DailyStats_MV",
+  targetTable: { name: "DailyStats" },
+  selectStatement: sql`SELECT
+    toDate(${barTable.columns.utcTimestamp}) as day,
+    count(*) as rowCount,
+    max(${barTable.columns.textLength}) as maxTextLength
+  FROM ${barTable}
+  GROUP BY day`,
+  selectTables: [barTable],
+  refreshConfig: {
+    interval: { type: "after", value: 30, unit: "minute" },
+    offset: { value: 5, unit: "minute" },
+  },
+});
+
+// ============================================================================
+// Test 3: Refreshable MV with DEPENDS ON and APPEND
+// ============================================================================
+// This MV depends on DailyStats_MV and uses APPEND mode for incremental updates
+
+export const WeeklyRollupMV = new MaterializedView<WeeklyRollup>({
+  materializedViewName: "WeeklyRollup_MV",
+  targetTable: { name: "WeeklyRollup" },
+  selectStatement: `SELECT
+    toMonday(day) as weekStart,
+    sum(rowCount) as totalRecords
+  FROM DailyStats
+  GROUP BY weekStart`,
+  selectTables: [], // Note: source is another MV's target table
+  refreshConfig: {
+    interval: { type: "every", value: 1, unit: "day" },
+    dependsOn: ["DailyStats_MV"],
+    append: true,
+  },
+});
+
+// ============================================================================
+// Test 4: Refreshable MV with randomize window
+// ============================================================================
+// This MV uses randomization to prevent thundering herd on refresh
+
+interface RandomizedStats {
+  minute: DateTime;
+  eventCount: number & typia.tags.Type<"int64">;
+}
+
+export const RandomizedStatsMV = new MaterializedView<RandomizedStats>({
+  materializedViewName: "RandomizedStats_MV",
+  targetTable: { name: "RandomizedStats" },
+  selectStatement: sql`SELECT
+    toStartOfMinute(${barTable.columns.utcTimestamp}) as minute,
+    count(*) as eventCount
+  FROM ${barTable}
+  GROUP BY minute`,
+  selectTables: [barTable],
+  refreshConfig: {
+    interval: { type: "every", value: 5, unit: "minute" },
+    randomize: { value: 30, unit: "second" },
+  },
+});
+
+// ============================================================================
+// Test 5: Incremental MV (control - no refreshConfig)
+// ============================================================================
+// This is a traditional incremental MV for comparison - no refreshConfig means
+// it triggers on every insert to the source table
+
+interface IncrementalStats {
+  primaryKey: string;
+  processedAt: DateTime;
+  textLengthSquared: number & typia.tags.Type<"int64">;
+}
+
+export const IncrementalStatsMV = new MaterializedView<IncrementalStats>({
+  materializedViewName: "IncrementalStats_MV",
+  targetTable: { name: "IncrementalStats" },
+  selectStatement: sql`SELECT
+    ${barTable.columns.primaryKey} as primaryKey,
+    now() as processedAt,
+    ${barTable.columns.textLength} * ${barTable.columns.textLength} as textLengthSquared
+  FROM ${barTable}`,
+  selectTables: [barTable],
+  // No refreshConfig = incremental MV
+});

--- a/templates/typescript-tests/tsconfig.moose-build.json
+++ b/templates/typescript-tests/tsconfig.moose-build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "transform": "./node_modules/@514labs/moose-lib/dist/compilerPlugin.js",
+        "transformProgram": true
+      },
+      {
+        "transform": "typia/lib/transform"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core ClickHouse DDL parsing/execution and MV update planning, so mistakes could cause incorrect schema changes or unexpected DROP/CREATE behavior. Coverage is improved with new unit tests and e2e validation of generated REFRESH clauses.
> 
> **Overview**
> Adds **refreshable materialized views** as a first-class concept end-to-end: new MV refresh config model (interval, offset, randomize, dependencies, append), proto/schema updates, and TS/Python SDK APIs to define and serialize refreshable MVs alongside existing incremental MVs.
> 
> Updates the CLI/engine to **preserve and parse REFRESH clauses** from ClickHouse DDL, include REFRESH when creating MVs, and introduce `AlterMaterializedViewRefresh` so refresh-only changes can be applied via `ALTER TABLE ... MODIFY REFRESH` instead of DROP/CREATE (with new diff logic and tests).
> 
> Extends e2e templates/tests to create both TS and Python refreshable MVs and validates their ClickHouse DDL refresh settings; also reduces false negatives when loading DMV2 by filtering structured logs/warnings from stderr.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81f8ebe747e9f49a98b463c0bf62365671df7333. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->