### PR TITLE
Carlos/report guide pdfmake update

### DIFF
--- a/apps/framework-docs-v2/content/guides/static-report-generation.mdx
+++ b/apps/framework-docs-v2/content/guides/static-report-generation.mdx
@@ -486,7 +486,7 @@ curl -s "http://localhost:18123/?user=panda&password=pandapass" \
   -d "SELECT count() FROM local.sales"
 ```
 
-> **Note:** Running the file loader multiple times creates duplicate records—ClickHouse doesn't enforce unique constraints. To start fresh, stop `moose dev` and run `docker volume prune`.
+> **Note:** Running the file loader multiple times creates duplicate records—ClickHouse doesn't enforce unique constraints. To start fresh, stop `moose dev` and remove the project's Docker volumes. **Caution:** `docker volume prune` deletes *all* unused volumes on your machine. Instead, use `docker volume ls` to list volumes, identify the ones for your project (typically containing `clickhouse` or `redpanda`), and remove them selectively with `docker volume rm <volume_name>`.
 
 ### Step 5: Add validation (recommended)
 
@@ -851,7 +851,7 @@ pnpm add pdfmake
 pnpm add -D @types/pdfmake
 ```
 
-> **Note:** This guide uses pdfmake 0.3.x which requires Node.js 20 LTS (Long Term Support) or higher. The API changed significantly from version 0.2.x—see the [pdfmake 0.3 documentation](https://pdfmake.github.io/docs/0.3/) for details.
+> **Note:** This guide uses pdfmake 0.3.x which requires Node.js 20 LTS (Long-Term Support) or higher. The API changed significantly from version 0.2.x—see the [pdfmake 0.3 documentation](https://pdfmake.github.io/docs/0.3/) for details.
 
 ### Step 2: Create PDF generator
 
@@ -1537,7 +1537,7 @@ If this returns empty `[]`, verify data was ingested and the date range is corre
 
 **Starting over completely:** Stop `moose dev`, delete the project directory, and run `moose init` again.
 
-**Reset data but keep code:** Stop `moose dev`, then run `docker volume prune` to clear all data.
+**Reset data but keep code:** Stop `moose dev`, then remove the project's Docker volumes. **Caution:** `docker volume prune` deletes *all* unused volumes on your machine—not just this project's. Use `docker volume ls` to list volumes, identify yours (typically containing `clickhouse` or `redpanda`), and remove them with `docker volume rm <volume_name>`.
 
 **Data persists across restarts:** If you stop and restart `moose dev`, your ingested data is still there—it's stored in Docker volumes.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes the guide and code samples to current tooling and APIs.
> 
> - Require `Node.js 20+` and note pdfmake 0.3 compatibility
> - Migrate PDF generator to `pdfmake` 0.3: replace `PdfPrinter` with `pdfmake.createPdf(...)` and `pdf.write(...)`, add built-in fonts registration
> - Update commands to `pnpm exec ts-node` and add `ts-node` dev dependency; replace `npx` usages
> - Expand setup tips, service readiness checks, and verification steps; add API sample response and ClickHouse UI tip
> - Clarify MV usage and performance notes; add cleanup guidance and more detailed troubleshooting (ports, Docker, TypeScript errors)
> - Small content edits for accuracy/consistency and improved step-by-step flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98e0cefa802949a98388544e2701a6e1a978dc11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->