### PR TITLE
Remove unreleased features from release notes

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/release-notes/2026-01-23.mdx
+++ b/apps/framework-docs-v2/content/moosestack/release-notes/2026-01-23.mdx
@@ -333,6 +333,3 @@ import { Callout } from "@/components/mdx";
 
 ### Bug Fixes
 - Fix branch deployment issues with long names: Fixed an issue where branches with long organization, project, or branch names could fail to deploy properly. Branch deployments now work reliably regardless of name length by ensuring generated identifiers stay within system limits. ([@LucioFranco](https://github.com/LucioFranco))
-
-
-- Fix branch deployment issues with long names: Fixed an issue where branches with long organization, project, or branch names could fail to deploy properly. Branch deployments now work reliably regardless of name length by ensuring generated identifiers stay within system limits. ([@LucioFranco](https://github.com/LucioFranco))


### PR DESCRIPTION
## Summary
- Remove entries for features not ready for release (Vercel deployment, MCP template fix, template gallery)
- Update Node.js requirement description to specify 20-24 range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release notes cleanup for 2026-01-23**
> 
> - Removed unreleased items: `Vercel deployment` for TypeScript MCP template, MCP template Anthropic API key fix, and Boreal `template gallery with deployment wizard`
> - Clarified wording to "Officially Supported Node.js 20–24" and updated requirement text
> - Minor text/format fixes in highlights and bug fixes sections; no functional code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd82c1318976ba18e7ba1661395e5e267f98a95a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->