### PR TITLE
Fix precompilation for workflows

### DIFF
--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -1277,11 +1277,10 @@ const loadIndex = async () => {
   // providing automatic fallback to ts-node if compilation wasn't run.
   const useCompiled = shouldUseCompiled();
 
-  const registry = getMooseInternal();
-
   // In dev mode, clear registry and require.cache to support hot reloading.
   // In production (compiled mode), skip clearing - code doesn't change.
   if (!useCompiled) {
+    const registry = getMooseInternal();
     registry.tables.clear();
     registry.streams.clear();
     registry.ingestApis.clear();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix precompilation behavior**
> 
> - Updates `loadIndex` to clear `moose_internal` registries and `require.cache` only when not using compiled artifacts, preserving state in compiled (production) mode
> - Maintains hot-reload behavior in development while allowing precompiled workflows to load without cache invalidation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf2cb7384cb3a27e92f34abea4d14a291145cbbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->