### PR TITLE
Rename workflow from 'myworkflow' to 'example'

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/workflows/define-workflow.mdx
+++ b/apps/framework-docs-v2/content/moosestack/workflows/define-workflow.mdx
@@ -38,7 +38,7 @@ export const task1 = new Task<Foo, void>("task1", {
   },
 });
 
-export const myworkflow = new Workflow("myworkflow", {
+export const example_workflow = new Workflow("example", {
   startingTask: task1,
 });
 ```
@@ -62,8 +62,8 @@ task1 = Task[Foo, None](
   config=TaskConfig(run=run_task1)
 )
 
-myworkflow = Workflow(
-  name="myworkflow",
+example_workflow = Workflow(
+  name="example",
   config=WorkflowConfig(starting_task=task1)
 )
 ```
@@ -114,7 +114,7 @@ export const task1 = new Task<Foo, Bar>("task1", {
   onComplete: [task2],
 });
 
-export const myworkflow = new Workflow("myworkflow", {
+export const examploe_workflow = new Workflow("example", {
   startingTask: task1,
 });
 ```
@@ -159,7 +159,7 @@ task1 = Task[Foo, Bar](
   )
 )
 
-myworkflow = Workflow(
+example_workflow = Workflow(
   name="example",
   config=WorkflowConfig(starting_task=task1)
 )


### PR DESCRIPTION
This pull request makes a minor update to the workflow definition example by renaming the workflow from "myworkflow" to "example". This change helps clarify the example's intent and improves readability.It's to align with the rest of the doc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes workflow naming in docs examples.
> 
> - Renames `myworkflow` to `example_workflow` (TS) and `example_workflow`/`Workflow(name="example")` (Python) in `define-workflow.mdx`
> - Updates workflow ID strings from `"myworkflow"` to `"example"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f19609399dec1f31eb74547ba1f6f34038f6b24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->