### PR TITLE
ENG-2071: add structured logging to python

### DIFF
--- a/apps/framework-cli/src/framework/python/consumption.rs
+++ b/apps/framework-cli/src/framework/python/consumption.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::Path;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Child;
-use tracing::{error, info};
+use tracing::info;
 
 use super::executor;
 
@@ -98,7 +98,6 @@ pub fn run(
         .expect("Analytics api process did not have a handle to stderr");
 
     let mut stdout_reader = BufReader::new(stdout).lines();
-    let mut stderr_reader = BufReader::new(stderr).lines();
 
     tokio::spawn(async move {
         while let Ok(Some(line)) = stdout_reader.next_line().await {
@@ -119,11 +118,12 @@ pub fn run(
         }
     });
 
-    tokio::spawn(async move {
-        while let Ok(Some(line)) = stderr_reader.next_line().await {
-            error!("{}", line);
-        }
-    });
+    crate::cli::logger::spawn_stderr_structured_logger_with_ui(
+        stderr,
+        "api_name",
+        crate::cli::logger::resource_type::CONSUMPTION_API,
+        Some("API"),
+    );
 
     Ok(consumption_process)
 }

--- a/apps/framework-cli/src/framework/python/streaming.rs
+++ b/apps/framework-cli/src/framework/python/streaming.rs
@@ -70,7 +70,6 @@ pub fn run(
         .expect("Streaming process did not have a handle to stderr");
 
     let mut stdout_reader = tokio::io::BufReader::new(stdout).lines();
-    let mut stderr_reader = tokio::io::BufReader::new(stderr).lines();
 
     tokio::spawn(async move {
         while let Ok(Some(line)) = stdout_reader.next_line().await {
@@ -78,11 +77,12 @@ pub fn run(
         }
     });
 
-    tokio::spawn(async move {
-        while let Ok(Some(line)) = stderr_reader.next_line().await {
-            tracing::error!("{}", line);
-        }
-    });
+    crate::cli::logger::spawn_stderr_structured_logger_with_ui(
+        stderr,
+        "function_name",
+        crate::cli::logger::resource_type::TRANSFORM,
+        Some("Streaming"),
+    );
 
     Ok(streaming_function_process)
 }

--- a/packages/py-moose-lib/moose_lib/utilities/__init__.py
+++ b/packages/py-moose-lib/moose_lib/utilities/__init__.py
@@ -1,0 +1,6 @@
+from moose_lib.utilities.structured_logging import (
+    StructuredLogContext,
+    setup_structured_logging,
+)
+
+__all__ = ["StructuredLogContext", "setup_structured_logging"]

--- a/packages/py-moose-lib/moose_lib/utilities/structured_logging.py
+++ b/packages/py-moose-lib/moose_lib/utilities/structured_logging.py
@@ -1,0 +1,97 @@
+"""
+Structured logging utilities for Python Moose applications.
+
+Provides context-aware logging that outputs JSON to stderr with a marker for the CLI to parse.
+"""
+
+import json
+import sys
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+T = TypeVar("T")
+
+# Context variable to store the current logging context
+_logging_context: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "_logging_context", default=None
+)
+
+
+class StructuredLogContext:
+    """
+    Context manager for structured logging with propagated context.
+    """
+
+    def __init__(
+        self,
+        get_context_field: Callable[[Dict[str, Any]], Any],
+        context_field_name: str,
+    ):
+        """
+        Initialize the structured logging context.
+
+        Args:
+            get_context_field: Function to extract the context field value from context dict
+            context_field_name: Name of the field to include in log output
+        """
+        self.get_context_field = get_context_field
+        self.context_field_name = context_field_name
+
+    def run(self, context: Dict[str, Any], func: Callable[[], T]) -> T:
+        """
+        Run a function with the given logging context.
+
+        Args:
+            context: Dictionary containing context values
+            func: Function to execute with context
+
+        Returns:
+            The return value of func
+        """
+        token = _logging_context.set(context)
+        try:
+            return func()
+        finally:
+            _logging_context.reset(token)
+
+    def log(self, level: str, message: str) -> None:
+        """
+        Emit a structured log message to stderr.
+
+        Args:
+            level: Log level (e.g., "info", "error", "debug")
+            message: Log message
+        """
+        context = _logging_context.get()
+        log_entry: Dict[str, Any] = {
+            "__moose_structured_log__": True,
+            "level": level,
+            "message": message,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        if context is not None:
+            field_value = self.get_context_field(context)
+            log_entry[self.context_field_name] = field_value
+
+        json.dump(log_entry, sys.stderr)
+        sys.stderr.write("\n")
+        sys.stderr.flush()
+
+
+def setup_structured_logging(
+    get_context_field: Callable[[Dict[str, Any]], Any],
+    context_field_name: str,
+) -> StructuredLogContext:
+    """
+    Set up structured logging with a context field.
+
+    Args:
+        get_context_field: Function to extract the context field value from context dict
+        context_field_name: Name of the field to include in log output
+
+    Returns:
+        A StructuredLogContext instance for managing logging context
+    """
+    return StructuredLogContext(get_context_field, context_field_name)

--- a/packages/py-moose-lib/tests/test_structured_logging.py
+++ b/packages/py-moose-lib/tests/test_structured_logging.py
@@ -1,0 +1,105 @@
+"""Tests for structured logging utilities."""
+
+import json
+import sys
+from io import StringIO
+
+from moose_lib.utilities import setup_structured_logging
+
+
+def test_structured_log_output_format():
+    """Test that structured logging outputs correct JSON format to stderr."""
+    # Capture stderr
+    old_stderr = sys.stderr
+    sys.stderr = StringIO()
+
+    try:
+        # Setup structured logging with function_name context
+        context = setup_structured_logging(
+            lambda ctx: ctx["function_name"], "function_name"
+        )
+
+        # Log a message with context
+        context.run(
+            {"function_name": "test_function"},
+            lambda: context.log("info", "test message"),
+        )
+
+        # Get the output
+        output = sys.stderr.getvalue()
+
+        # Parse the JSON
+        log_entry = json.loads(output.strip())
+
+        # Verify the structure
+        assert log_entry["__moose_structured_log__"] is True
+        assert log_entry["level"] == "info"
+        assert log_entry["message"] == "test message"
+        assert log_entry["function_name"] == "test_function"
+        assert "timestamp" in log_entry
+
+    finally:
+        sys.stderr = old_stderr
+
+
+def test_structured_log_without_context():
+    """Test that structured logging works without context set."""
+    old_stderr = sys.stderr
+    sys.stderr = StringIO()
+
+    try:
+        context = setup_structured_logging(
+            lambda ctx: ctx["function_name"], "function_name"
+        )
+
+        # Log without setting context
+        context.log("error", "error message")
+
+        output = sys.stderr.getvalue()
+        log_entry = json.loads(output.strip())
+
+        # Should have log data but no function_name field
+        assert log_entry["__moose_structured_log__"] is True
+        assert log_entry["level"] == "error"
+        assert log_entry["message"] == "error message"
+        assert "function_name" not in log_entry
+
+    finally:
+        sys.stderr = old_stderr
+
+
+def test_context_isolation():
+    """Test that context is properly isolated between runs."""
+    old_stderr = sys.stderr
+    sys.stderr = StringIO()
+
+    try:
+        context = setup_structured_logging(
+            lambda ctx: ctx["function_name"], "function_name"
+        )
+
+        # First context
+        context.run(
+            {"function_name": "function1"},
+            lambda: context.log("info", "message1"),
+        )
+
+        # Second context
+        context.run(
+            {"function_name": "function2"},
+            lambda: context.log("info", "message2"),
+        )
+
+        output = sys.stderr.getvalue()
+        lines = output.strip().split("\n")
+
+        log1 = json.loads(lines[0])
+        log2 = json.loads(lines[1])
+
+        assert log1["function_name"] == "function1"
+        assert log1["message"] == "message1"
+        assert log2["function_name"] == "function2"
+        assert log2["message"] == "message2"
+
+    finally:
+        sys.stderr = old_stderr


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how Python child-process stderr is emitted and parsed by the CLI, which could affect error visibility and log formatting across streaming/consumption runs.
> 
> **Overview**
> Adds a Python `StructuredLogContext` utility that emits JSON structured logs to stderr (with a `__moose_structured_log__` marker) and includes a propagated context field such as `function_name`.
> 
> Updates the Python streaming function runner to use structured logging for its `log()` output and to wrap user transform execution in a per-function context.
> 
> Switches the Rust CLI Python `consumption` and `streaming` runners from raw stderr line logging to `spawn_stderr_structured_logger_with_ui`, enabling the CLI to parse/annotate structured stderr logs and surface errors in the UI. Includes new unit tests for the Python structured logging output and context isolation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bed186c62e026f81c374dfbb7df3d075e753ee5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->