### PR TITLE
ENG-2030: clean up sparse eprintlns

### DIFF
--- a/apps/framework-cli/src/infrastructure/orchestration/temporal_client.rs
+++ b/apps/framework-cli/src/infrastructure/orchestration/temporal_client.rs
@@ -11,7 +11,7 @@ use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Uri};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::infrastructure::orchestration::temporal::{InvalidTemporalSchemeError, TemporalConfig};
 use crate::project::Project;
@@ -103,7 +103,7 @@ impl TemporalClientManager {
     async fn get_temporal_client(&self) -> Result<WorkflowServiceClient<Channel>> {
         let endpoint: Uri = self.temporal_url.parse().unwrap();
         WorkflowServiceClient::connect(endpoint).await.map_err(|e| {
-            eprintln!("{e}");
+            warn!("Failed to connect to Temporal: {}", e);
             Error::msg(format!(
                 r#"Could not connect to Temporal: {e}
 

--- a/apps/framework-cli/src/metrics_inserter.rs
+++ b/apps/framework-cli/src/metrics_inserter.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::time;
+use tracing::error;
 
 const MAX_FLUSH_INTERVAL_SECONDS: u64 = 10;
 const MAX_BATCH_SIZE: usize = 1000;
@@ -156,7 +157,7 @@ async fn flush(
             {
                 Some(route) => route,
                 None => {
-                    eprintln!("Error: No endpoint found for event type: {event_type}");
+                    error!("No endpoint found for event type: {event_type}");
                     continue;
                 }
             };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes how a couple of error conditions are logged (switching from `eprintln!` to `tracing`), without altering control flow or external behavior beyond log output.
> 
> **Overview**
> Replaces a few ad-hoc `eprintln!` calls with structured `tracing` logs in the CLI.
> 
> Temporal connection failures now emit a `warn!` log in `TemporalClientManager::get_temporal_client`, and missing metric endpoint mappings in `MetricsInserter` are logged via `error!` instead of printing to stderr.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 564dd17e652723fd952a774b6894fcda2b654e17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->