### PR TITLE
ENG-2098: disable temporal connect if workflows false

### DIFF
--- a/apps/framework-cli/src/framework/python/consumption.rs
+++ b/apps/framework-cli/src/framework/python/consumption.rs
@@ -62,7 +62,7 @@ pub fn run(
         .map(|jwt| jwt.enforce_on_all_consumptions_apis.to_string())
         .unwrap_or("false".to_string());
 
-    let args = vec![
+    let mut args = vec![
         clickhouse_config.db_name.clone(),
         clickhouse_config.host.clone(),
         clickhouse_config.host_port.to_string(),
@@ -73,13 +73,23 @@ pub fn run(
         jwt_issuer,
         jwt_audience,
         enforce_on_all_consumptions_apis,
-        project.temporal_config.temporal_url(),
-        project.temporal_config.get_temporal_namespace(),
-        project.temporal_config.client_cert.clone(),
-        project.temporal_config.client_key.clone(),
-        project.temporal_config.api_key.clone(),
-        proxy_port.unwrap_or(4001).to_string(),
     ];
+
+    if project.features.workflows {
+        args.push("--temporal-url".to_string());
+        args.push(project.temporal_config.temporal_url());
+        args.push("--temporal-namespace".to_string());
+        args.push(project.temporal_config.get_temporal_namespace());
+        args.push("--client-cert".to_string());
+        args.push(project.temporal_config.client_cert.clone());
+        args.push("--client-key".to_string());
+        args.push(project.temporal_config.client_key.clone());
+        args.push("--api-key".to_string());
+        args.push(project.temporal_config.api_key.clone());
+    }
+
+    args.push("--proxy-port".to_string());
+    args.push(proxy_port.unwrap_or(4001).to_string());
 
     let mut consumption_process = executor::run_python_program(
         project,

--- a/packages/ts-moose-lib/src/moose-runner.ts
+++ b/packages/ts-moose-lib/src/moose-runner.ts
@@ -129,13 +129,16 @@ program
           issuer: options.jwtIssuer,
           audience: options.jwtAudience,
         },
-        temporalConfig: {
-          url: options.temporalUrl,
-          namespace: options.temporalNamespace,
-          clientCert: options.clientCert,
-          clientKey: options.clientKey,
-          apiKey: options.apiKey,
-        },
+        temporalConfig:
+          options.temporalUrl ?
+            {
+              url: options.temporalUrl,
+              namespace: options.temporalNamespace,
+              clientCert: options.clientCert,
+              clientKey: options.clientKey,
+              apiKey: options.apiKey,
+            }
+          : undefined,
         enforceAuth: options.enforceAuth,
         proxyPort: options.proxyPort,
         workerCount: options.workerCount,
@@ -196,13 +199,16 @@ program
   .option("--api-key <key>", "API key for authentication")
   .action((options) => {
     runScripts({
-      temporalConfig: {
-        url: options.temporalUrl,
-        namespace: options.temporalNamespace,
-        clientCert: options.clientCert,
-        clientKey: options.clientKey,
-        apiKey: options.apiKey,
-      },
+      temporalConfig:
+        options.temporalUrl ?
+          {
+            url: options.temporalUrl,
+            namespace: options.temporalNamespace,
+            clientCert: options.clientCert,
+            clientKey: options.clientKey,
+            apiKey: options.apiKey,
+          }
+        : undefined,
     });
   });
 

--- a/packages/ts-moose-lib/src/scripts/runner.ts
+++ b/packages/ts-moose-lib/src/scripts/runner.ts
@@ -22,7 +22,7 @@ interface TemporalConfig {
 }
 
 interface ScriptsConfig {
-  temporalConfig: TemporalConfig;
+  temporalConfig?: TemporalConfig;
 }
 
 // Maintain a global set of activity names we've already registered
@@ -115,6 +115,12 @@ async function registerWorkflows(
   config: ScriptsConfig,
 ): Promise<Worker | null> {
   logger.info(`Registering workflows`);
+
+  // If temporalConfig is not provided, workflows are disabled
+  if (!config.temporalConfig) {
+    logger.info(`Temporal config not provided, skipping workflow registration`);
+    return null;
+  }
 
   // Collect all TypeScript activities from registered workflows
   const allScriptPaths: string[] = [];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CLI argument shapes and when Temporal connections/workflow registration occur, which could break existing invocations or unintentionally disable workflow functionality if flags/config are mis-set.
> 
> **Overview**
> Makes Temporal integration conditional on workflows being enabled, rather than always attempting to configure/connect.
> 
> The Rust CLI now only passes Temporal parameters to the Python `consumption_runner` when `project.features.workflows` is true, and always passes `--proxy-port`. The Python runner switches Temporal/port args from required positionals to optional flags and only connects to Temporal when `--temporal-url` is provided.
> 
> In the TS runner, `temporalConfig` is now optional (for `consumption-apis` and `scripts`), and the scripts worker skips workflow registration entirely when Temporal config isn’t provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d3529e4bd5967b3bbc866d1028aab46f59dd4fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->