### PR TITLE
ENG-2072: add SAP migration cross-references to data warehouses guide

### DIFF
--- a/apps/framework-docs-v2/content/guides/data-warehouses.mdx
+++ b/apps/framework-docs-v2/content/guides/data-warehouses.mdx
@@ -2416,6 +2416,13 @@ Follow the prompts to create your Boreal account and provision production infras
 - Real-time streaming analytics
 - Machine learning feature stores
 
+### SAP Data Migration
+
+Looking to migrate data from SAP systems to ClickHouse?
+
+- **[SAP HANA CDC to ClickHouse](/guides/sap-hana-cdc-to-clickhouse)** - Set up Change Data Capture from SAP HANA
+- **[QVD to ClickHouse](/guides/qvd-to-clickhouse)** - Import QlikView Data files
+
 ---
 
 ## Appendix: Common Issues


### PR DESCRIPTION
## Summary

Add cross-references to dedicated SAP migration guides in the Data Warehouses guide's "Next Steps" section.

This keeps the Data Warehouses guide focused on general concepts while directing users interested in SAP-specific migrations to the appropriate dedicated guides:
- SAP HANA CDC to ClickHouse guide
- QVD to ClickHouse guide

## Changes

- Added "SAP Data Migration" subsection in the "Next Steps" section of `data-warehouses.mdx`
- Added links to `/guides/sap-hana-cdc-to-clickhouse` and `/guides/qvd-to-clickhouse`
- Verified no SAP HANA CDC-specific content exists in the guide

## Test Plan

- [ ] Preview the updated guide in the docs site
- [ ] Verify the new "SAP Data Migration" section appears in the correct location
- [ ] Confirm links will work once the dedicated SAP guides are published (ENG-2100, ENG-2099)

## Related Issues

- Closes ENG-2072
- Depends on: ENG-2099 (QVD to ClickHouse guide)
- Depends on: ENG-2100 (SAP HANA CDC to ClickHouse guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds cross-links; main risk is broken/changed routes for the new guide URLs.
> 
> **Overview**
> Adds a new **SAP Data Migration** subsection to the `Data Warehouses` guide’s *Next Steps* section.
> 
> The subsection links readers to the dedicated guides for `SAP HANA CDC to ClickHouse` (`/guides/sap-hana-cdc-to-clickhouse`) and `QVD to ClickHouse` (`/guides/qvd-to-clickhouse`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ffeca9464df8adf5586f62b728e4c08cfa91108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->