### PR TITLE
fix: naive engine parsing picked up properties with engine keyword in it

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/sql_parser.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/sql_parser.rs
@@ -322,7 +322,7 @@ fn find_matching_paren(
 }
 
 /// Returns the SQL substring corresponding to the given span.
-fn slice_for_span<'a>(sql: &'a str, span: Span) -> Option<&'a str> {
+fn slice_for_span(sql: &str, span: Span) -> Option<&str> {
     let start = location_to_index(sql, span.start)?;
     let end = location_to_index(sql, span.end)?;
     if end < start {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core SQL engine extraction logic used for ClickHouse table introspection; while scoped and test-covered, it may alter behavior on unusual CREATE TABLE formatting or comments.
> 
> **Overview**
> Fixes `extract_engine_from_create_table` to avoid naive substring matching of `ENGINE` (e.g., when an identifier contains `engine`).
> 
> The function now uses `sqlparser` parsing to confirm the statement is a `CREATE TABLE` with an engine option, then extracts the engine definition via dialect-aware tokenization and span slicing (handling whitespace/`=` and nested parentheses). Adds a regression test for a column name containing `engine`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c1e501ba217f9e3dbfd3ab790fd4fb734305cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->