### PR TITLE
fix: update the matching algorithm for the ci env

### DIFF
--- a/apps/framework-cli/src/utilities/ci_detection.rs
+++ b/apps/framework-cli/src/utilities/ci_detection.rs
@@ -1,7 +1,7 @@
 //! CI/CD and Container Environment Detection
 //!
 //! Detects whether the CLI is running in a CI/CD environment or Docker container
-//! by checking for common environment variable prefixes set by various CI providers.
+//! by checking for specific CI indicator environment variables set by various CI providers.
 
 use std::env;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the CI detection algorithm from prefix-based matching to exact indicator variables, which can alter whether the CLI treats an environment as CI for some providers. Risk is limited in scope but could affect telemetry/behavior gating in less-common CI setups if their expected indicator vars differ.
> 
> **Overview**
> **Refines CI environment detection in `framework-cli`.** Detection now matches against a curated list of exact CI *indicator* environment variables (e.g., `GITHUB_ACTIONS`, `GITLAB_CI`) instead of any `*_` prefixed variables, reducing false positives.
> 
> Updates and expands unit tests to reflect exact-match behavior, adds coverage for additional providers (e.g., `drone`, `semaphore`, `appveyor`, `harness`), and clarifies that generic `CI` is handled only via the existing truthy-value fallback in `detect_ci_environment`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19cf400abeb31ad20f334c169599d877863ae122. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->