### PR TITLE
Plan CDC-as-code UX changes

### DIFF
--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -212,6 +212,9 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
             // Add test credentials for S3Queue tests
             TEST_AWS_ACCESS_KEY_ID: "test-access-key-id",
             TEST_AWS_SECRET_ACCESS_KEY: "test-secret-access-key",
+            // Dummy CDC connection string for template CDC sources
+            TEST_CDC_CONNECTION:
+              "postgres://test_user:test_pass@localhost:5432/test_db",
             MOOSE_DEV__SUPPRESS_DEV_SETUP_PROMPT: "true",
             MOOSE_AUTHENTICATION__ADMIN_API_KEY: TEST_ADMIN_API_KEY_HASH,
           }
@@ -220,6 +223,9 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
             // Add test credentials for S3Queue tests
             TEST_AWS_ACCESS_KEY_ID: "test-access-key-id",
             TEST_AWS_SECRET_ACCESS_KEY: "test-secret-access-key",
+            // Dummy CDC connection string for template CDC sources
+            TEST_CDC_CONNECTION:
+              "postgres://test_user:test_pass@localhost:5432/test_db",
             MOOSE_DEV__SUPPRESS_DEV_SETUP_PROMPT: "true",
             MOOSE_AUTHENTICATION__ADMIN_API_KEY: TEST_ADMIN_API_KEY_HASH,
           };

--- a/apps/framework-cli-e2e/test/utils/plan-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/plan-utils.ts
@@ -7,6 +7,7 @@ export interface PlanOutput {
   target_infra_map: {
     default_database: string;
     tables: any;
+    cdc_sources?: Record<string, any>;
   };
   changes: {
     olap_changes: Array<Record<string, any>>;

--- a/apps/framework-cli/src/cli/display/infrastructure.rs
+++ b/apps/framework-cli/src/cli/display/infrastructure.rs
@@ -757,6 +757,9 @@ pub fn show_process_changes(process_changes: &[ProcessChange]) {
         }) => {
             infra_updated("Reloading Orchestration worker...");
         }
+        ProcessChange::CdcSource(cdc_change) => {
+            handle_standard_change!(cdc_change);
+        }
     });
 }
 

--- a/apps/framework-cli/src/cli/routines/peek.rs
+++ b/apps/framework-cli/src/cli/routines/peek.rs
@@ -418,6 +418,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         }
     }
 

--- a/apps/framework-cli/src/cli/routines/seed_data.rs
+++ b/apps/framework-cli/src/cli/routines/seed_data.rs
@@ -688,6 +688,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         }
     }
 

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -975,6 +975,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         // Create reality checker
@@ -1047,6 +1048,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map
@@ -1125,6 +1127,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map
@@ -1194,6 +1197,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map
@@ -1265,6 +1269,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map
@@ -1352,6 +1357,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map
@@ -1556,6 +1562,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map
@@ -1622,6 +1629,7 @@ mod tests {
             web_apps: HashMap::new(),
             materialized_views: HashMap::new(),
             views: HashMap::new(),
+            cdc_sources: HashMap::new(),
         };
 
         infra_map

--- a/apps/framework-cli/src/framework/core/infrastructure/cdc_source.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/cdc_source.rs
@@ -1,0 +1,148 @@
+use crate::framework::core::infrastructure::table::Metadata;
+use crate::framework::core::partial_infrastructure_map::LifeCycle;
+use crate::proto::infrastructure_map::{
+    CdcSource as ProtoCdcSource, CdcTable as ProtoCdcTable, LifeCycle as ProtoLifeCycle,
+};
+use protobuf::MessageField;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CdcTable {
+    pub name: String,
+    #[serde(rename = "sourceTable")]
+    pub source_table: String,
+    #[serde(rename = "primaryKey")]
+    pub primary_key: Vec<String>,
+    pub stream: Option<String>,
+    pub table: Option<String>,
+    pub snapshot: Option<String>,
+    pub version: Option<String>,
+    pub metadata: Option<Metadata>,
+}
+
+impl CdcTable {
+    pub fn to_proto(&self) -> ProtoCdcTable {
+        ProtoCdcTable {
+            name: self.name.clone(),
+            source_table: self.source_table.clone(),
+            primary_key: self.primary_key.clone(),
+            stream: self.stream.clone(),
+            table: self.table.clone(),
+            snapshot: self.snapshot.clone(),
+            version: self.version.clone(),
+            metadata: MessageField::from_option(self.metadata.as_ref().map(|m| {
+                crate::proto::infrastructure_map::Metadata {
+                    description: m.description.clone().unwrap_or_default(),
+                    source: MessageField::from_option(m.source.as_ref().map(|s| {
+                        crate::proto::infrastructure_map::SourceLocation {
+                            file: s.file.clone(),
+                            special_fields: Default::default(),
+                        }
+                    })),
+                    special_fields: Default::default(),
+                }
+            })),
+            special_fields: Default::default(),
+        }
+    }
+
+    pub fn from_proto(proto: ProtoCdcTable) -> Self {
+        CdcTable {
+            name: proto.name,
+            source_table: proto.source_table,
+            primary_key: proto.primary_key,
+            stream: proto.stream,
+            table: proto.table,
+            snapshot: proto.snapshot,
+            version: proto.version,
+            metadata: proto.metadata.into_option().map(|m| Metadata {
+                description: if m.description.is_empty() {
+                    None
+                } else {
+                    Some(m.description)
+                },
+                source: m
+                    .source
+                    .into_option()
+                    .map(|s| super::table::SourceLocation { file: s.file }),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CdcSource {
+    pub name: String,
+    pub kind: String,
+    pub connection: String,
+    pub tables: Vec<CdcTable>,
+    pub metadata: Option<Metadata>,
+    pub life_cycle: LifeCycle,
+}
+
+impl CdcSource {
+    pub fn expanded_display(&self) -> String {
+        format!(
+            "CDC Source: {} ({}) - {} tables",
+            self.name,
+            self.kind,
+            self.tables.len()
+        )
+    }
+
+    pub fn short_display(&self) -> String {
+        self.expanded_display()
+    }
+
+    pub fn to_proto(&self) -> ProtoCdcSource {
+        ProtoCdcSource {
+            name: self.name.clone(),
+            kind: self.kind.clone(),
+            connection: self.connection.clone(),
+            tables: self.tables.iter().map(|t| t.to_proto()).collect(),
+            metadata: MessageField::from_option(self.metadata.as_ref().map(|m| {
+                crate::proto::infrastructure_map::Metadata {
+                    description: m.description.clone().unwrap_or_default(),
+                    source: MessageField::from_option(m.source.as_ref().map(|s| {
+                        crate::proto::infrastructure_map::SourceLocation {
+                            file: s.file.clone(),
+                            special_fields: Default::default(),
+                        }
+                    })),
+                    special_fields: Default::default(),
+                }
+            })),
+            life_cycle: match self.life_cycle {
+                LifeCycle::FullyManaged => ProtoLifeCycle::FULLY_MANAGED.into(),
+                LifeCycle::DeletionProtected => ProtoLifeCycle::DELETION_PROTECTED.into(),
+                LifeCycle::ExternallyManaged => ProtoLifeCycle::EXTERNALLY_MANAGED.into(),
+            },
+            special_fields: Default::default(),
+        }
+    }
+
+    pub fn from_proto(proto: ProtoCdcSource) -> Self {
+        CdcSource {
+            name: proto.name,
+            kind: proto.kind,
+            connection: proto.connection,
+            tables: proto.tables.into_iter().map(CdcTable::from_proto).collect(),
+            metadata: proto.metadata.into_option().map(|m| Metadata {
+                description: if m.description.is_empty() {
+                    None
+                } else {
+                    Some(m.description)
+                },
+                source: m
+                    .source
+                    .into_option()
+                    .map(|s| super::table::SourceLocation { file: s.file }),
+            }),
+            life_cycle: match proto.life_cycle.enum_value_or_default() {
+                ProtoLifeCycle::FULLY_MANAGED => LifeCycle::FullyManaged,
+                ProtoLifeCycle::DELETION_PROTECTED => LifeCycle::DeletionProtected,
+                ProtoLifeCycle::EXTERNALLY_MANAGED => LifeCycle::ExternallyManaged,
+            },
+        }
+    }
+}

--- a/apps/framework-cli/src/framework/core/infrastructure/mod.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/mod.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
 pub mod api_endpoint;
+pub mod cdc_source;
 pub mod consumption_webserver;
 pub mod function_process;
 pub mod materialized_view;

--- a/apps/framework-cli/src/infrastructure/processes/mod.rs
+++ b/apps/framework-cli/src/infrastructure/processes/mod.rs
@@ -203,6 +203,23 @@ pub async fn execute_changes(
                 process_registry.orchestration_workers.stop(before).await?;
                 process_registry.orchestration_workers.start(after).await?;
             }
+            ProcessChange::CdcSource(change) => match change {
+                Change::Added(source) => {
+                    tracing::info!(
+                        "CDC source '{}' reviewed (no apply step in v1)",
+                        source.name
+                    );
+                }
+                Change::Removed(source) => {
+                    tracing::info!(
+                        "CDC source '{}' removal reviewed (no apply step in v1)",
+                        source.name
+                    );
+                }
+                Change::Updated { before: _, after } => {
+                    tracing::info!("CDC source '{}' updated (no apply step in v1)", after.name);
+                }
+            },
         }
     }
 

--- a/apps/framework-docs-v2/content/moosestack/configuration.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration.mdx
@@ -114,6 +114,28 @@ MOOSE_<SECTION>__<KEY>=value
 | `features.workflows` | `MOOSE_FEATURES__WORKFLOWS` |
 | `redis_config.url` | `MOOSE_REDIS_CONFIG__URL` |
 
+### CDC Connection Strings
+
+For CDC sources, keep database URLs in `.env` files or your platform’s environment variables, then reference them in code:
+
+```bash
+ORDERS_DB_URL=postgres://user:pass@host:5432/orders
+```
+
+TypeScript:
+
+```ts
+connection: mooseRuntimeEnv.get("ORDERS_DB_URL")
+```
+
+Python:
+
+```python
+connection=moose_runtime_env.get("ORDERS_DB_URL")
+```
+
+Moose resolves these at runtime and masks them in plan output.
+
 ### Complete Example
 
 **File structure:**

--- a/apps/framework-docs-v2/content/moosestack/deploying/configuring-moose-for-cloud.mdx
+++ b/apps/framework-docs-v2/content/moosestack/deploying/configuring-moose-for-cloud.mdx
@@ -120,6 +120,29 @@ MOOSE_TEMPORAL_CONFIG__API_KEY=<your_temporal_api_key>
 MOOSE_TEMPORAL_CONFIG__TEMPORAL_HOST=<your_temporal_namespace>.tmprl.cloud
 ```
 
+#### CDC Connections (Optional)
+
+If you define CDC sources in code, keep credentials in environment variables and load them using runtime env helpers:
+
+```
+# Example CDC connection string
+ORDERS_DB_URL=postgres://user:pass@host:5432/orders
+```
+
+TypeScript:
+
+```ts
+connection: mooseRuntimeEnv.get("ORDERS_DB_URL")
+```
+
+Python:
+
+```python
+connection=moose_runtime_env.get("ORDERS_DB_URL")
+```
+
+Moose loads `.env` files using the same precedence rules described in the configuration docs. In cloud environments, set the variables in your platform’s secret manager or runtime env settings. `moose plan` surfaces CDC resources for sign‑off and masks secrets in output.
+
 ## Securing Sensitive Information
 
 When deploying to cloud environments, it's important to handle sensitive information like passwords and API keys securely. Each cloud provider offers mechanisms for this:

--- a/apps/framework-docs-v2/content/moosestack/streaming/connect-cdc.mdx
+++ b/apps/framework-docs-v2/content/moosestack/streaming/connect-cdc.mdx
@@ -7,4 +7,158 @@ category: streaming
 
 # Connect to CDC Services
 
-Coming Soon!
+Moose supports CDC-as-code so you can configure change data capture directly in TypeScript or Python with full types and autocomplete.
+
+## TypeScript
+
+```ts
+import {
+  CdcSource,
+  CdcTable,
+  DateTime,
+  Stream,
+  mooseRuntimeEnv,
+} from "@514labs/moose-lib";
+
+export interface OrderRow {
+  id: string;
+  customerId: string;
+  totalCents: number;
+  status: string;
+  createdAt: DateTime;
+}
+
+const ordersDb = new CdcSource("orders_cdc", {
+  kind: "postgresql",
+  connection: mooseRuntimeEnv.get("ORDERS_DB_URL"),
+});
+
+export const orders = new CdcTable<OrderRow>("orders", ordersDb, {
+  sourceTable: "public.orders",
+  primaryKey: ["id"],
+  stream: true,
+  table: true,
+  snapshot: "initial",
+});
+
+export interface OrdersIngestRow {
+  orderId: string;
+  totalUsd: number;
+  status: string;
+  updatedAt: DateTime;
+  op: string;
+}
+
+export const ordersIngest = new Stream<OrdersIngestRow>("orders_ingest");
+
+orders.changes?.addTransform(ordersIngest, (event) => {
+  const row = event.after ?? event.before;
+  if (!row) return null;
+  return {
+    orderId: row.id,
+    totalUsd: row.totalCents / 100,
+    status: row.status,
+    updatedAt: row.createdAt,
+    op: event.op,
+  };
+});
+```
+
+## Python
+
+```python
+from datetime import datetime
+from pydantic import BaseModel
+
+from moose_lib import (
+    CdcSource,
+    CdcSourceConfig,
+    CdcTable,
+    CdcTableConfig,
+    Stream,
+    moose_runtime_env,
+)
+
+
+class OrderRow(BaseModel):
+    id: str
+    customer_id: str
+    total_cents: int
+    status: str
+    created_at: datetime
+
+
+orders_db = CdcSource(
+    "orders_cdc",
+    CdcSourceConfig(
+        kind="postgresql",
+        connection=moose_runtime_env.get("ORDERS_DB_URL"),
+    ),
+)
+
+orders = CdcTable[OrderRow](
+    "orders",
+    orders_db,
+    CdcTableConfig(
+        source_table="public.orders",
+        primary_key=["id"],
+        stream=True,
+        table=True,
+        snapshot="initial",
+    ),
+)
+
+
+class OrdersIngestRow(BaseModel):
+    order_id: str
+    total_usd: float
+    status: str
+    updated_at: datetime
+    op: str
+
+
+orders_ingest = Stream[OrdersIngestRow]("orders_ingest")
+
+
+def to_orders_ingest(event):
+    row = event.after or event.before
+    if row is None:
+        return None
+    return OrdersIngestRow(
+        order_id=row.id,
+        total_usd=row.total_cents / 100,
+        status=row.status,
+        updated_at=row.created_at,
+        op=event.op,
+    )
+
+
+if orders.changes is not None:
+    orders.changes.add_transform(orders_ingest, to_orders_ingest)
+```
+
+## CDC Event Shape
+
+`orders.changes` is a `Stream<CdcEvent<T>>` that includes:
+
+- `op`: `"insert" | "update" | "delete"`
+- `before`: the previous row (nullable)
+- `after`: the new row (nullable)
+- `ts`: event timestamp
+- `lsn`: log sequence / version marker
+- `source`: source identifier
+
+## Destination Tables
+
+If you enable `table: true`, Moose creates a CDC destination table that defaults to:
+
+- ClickHouse `ReplacingMergeTree`
+- Version column `__cdc_lsn`
+- Delete marker `__cdc_is_deleted`
+- Metadata columns: `__cdc_op`, `__cdc_lsn`, `__cdc_ts`, `__cdc_is_deleted`
+
+You can override the table config via `table: { ... }` if you need custom engines or settings.
+
+## Runtime Env and Sign-Off
+
+Use `mooseRuntimeEnv.get("ORDERS_DB_URL")` or `moose_runtime_env.get("ORDERS_DB_URL")` so credentials come from `.env` files or your deployment environment. Run `moose plan` to review CDC sources and tables before applying changes. Plan output masks secrets by default.

--- a/examples/cdp-analytics/packages/moosestack-service/app/workflows/cdc-placeholder.ts
+++ b/examples/cdp-analytics/packages/moosestack-service/app/workflows/cdc-placeholder.ts
@@ -7,7 +7,7 @@
  * This is a placeholder file demonstrating where CDC configuration would go.
  *
  * MOOSE CDC DOCUMENTATION:
- * @see https://docs.fiveonefour.com/moosestack/capture-data-changes
+ * @see https://docs.fiveonefour.com/moosestack/streaming/connect-cdc
  *
  * CDC Use Cases:
  * - Real-time sync from production PostgreSQL to ClickHouse
@@ -21,39 +21,36 @@
  * 3. Moose captures INSERT, UPDATE, DELETE operations
  * 4. Changes are streamed to ClickHouse in near real-time
  *
- * Example Configuration (moose.config.toml):
- *
- * ```toml
- * [[cdc_sources]]
- * name = "postgres_orders"
- * type = "postgresql"
- * connection_string = "postgres://user:pass@host:5432/db"
- * tables = ["orders", "order_items", "customers"]
- *
- * [[cdc_destinations]]
- * source = "postgres_orders"
- * table = "orders"
- * destination = "Transaction"
- * ```
- *
- * Example Transform (app/cdc/orders.ts):
+ * Example CDC-as-code configuration:
  *
  * ```typescript
- * import { CDCTransform } from "@514labs/moose-lib";
+ * import { CdcSource, CdcTable, Stream, mooseRuntimeEnv } from "@514labs/moose-lib";
  *
- * export const ordersTransform = new CDCTransform<PostgresOrder, Transaction>(
- *   "orders",
- *   {
- *     transform: (change) => ({
- *       transactionId: change.after.id,
- *       customerId: change.after.customer_id,
- *       totalAmount: change.after.total / 100, // cents to dollars
- *       status: mapStatus(change.after.status),
- *       timestamp: change.after.created_at,
- *       // ... map other fields
- *     }),
- *   }
- * );
+ * const ordersDb = new CdcSource("orders_cdc", {
+ *   kind: "postgresql",
+ *   connection: mooseRuntimeEnv.get("ORDERS_DB_URL"),
+ * });
+ *
+ * const orders = new CdcTable<OrderRow>("orders", ordersDb, {
+ *   sourceTable: "public.orders",
+ *   primaryKey: ["id"],
+ *   stream: true,
+ *   table: true,
+ * });
+ *
+ * const ordersIngest = new Stream<OrderIngest>("orders_ingest");
+ *
+ * orders.changes?.addTransform(ordersIngest, (event) => {
+ *   const row = event.after ?? event.before;
+ *   if (!row) return null;
+ *   return {
+ *     orderId: row.id,
+ *     totalUsd: row.totalCents / 100,
+ *     status: row.status,
+ *     updatedAt: row.createdAt,
+ *     op: event.op,
+ *   };
+ * });
  * ```
  *
  * For full implementation details, see the Moose CDC documentation.
@@ -63,4 +60,4 @@
 // Actual CDC implementation requires database infrastructure setup.
 
 export const CDC_DOCS_URL =
-  "https://docs.fiveonefour.com/moosestack/capture-data-changes";
+  "https://docs.fiveonefour.com/moosestack/streaming/connect-cdc";

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -31,6 +31,8 @@ message InfrastructureMap {
   map<string, View> views = 17;
   // Workflow definitions
   map<string, Workflow> workflows = 18;
+  // CDC source definitions
+  map<string, CdcSource> cdc_sources = 19;
 }
 
 message SourceLocation {
@@ -516,4 +518,24 @@ message Workflow {
   string timeout = 4;
   // Programming language of the workflow
   string language = 5;
+}
+
+message CdcSource {
+  string name = 1;
+  string kind = 2;
+  string connection = 3;
+  repeated CdcTable tables = 4;
+  optional Metadata metadata = 5;
+  LifeCycle life_cycle = 6;
+}
+
+message CdcTable {
+  string name = 1;
+  string source_table = 2;
+  repeated string primary_key = 3;
+  optional string stream = 4;
+  optional string table = 5;
+  optional string snapshot = 6;
+  optional string version = 7;
+  optional Metadata metadata = 8;
 }

--- a/packages/py-moose-lib/moose_lib/dmv2/__init__.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/__init__.py
@@ -49,6 +49,16 @@ from .ingest_pipeline import (
     IngestPipeline,
 )
 
+from .cdc_source import (
+    CdcSourceConfig,
+    CdcTableConfig,
+    CdcSource,
+    CdcTable,
+    CdcEvent,
+    CdcRow,
+    CdcOperation,
+)
+
 from .consumption import (
     ApiConfig,
     Api,
@@ -115,6 +125,8 @@ from .registry import (
     get_materialized_view,
     get_views,
     get_view,
+    get_cdc_sources,
+    get_cdc_source,
     # Backward compatibility aliases
     get_consumption_apis,
     get_consumption_api,
@@ -152,6 +164,14 @@ __all__ = [
     "IngestPipelineConfig",
     "IngestApi",
     "IngestPipeline",
+    # CDC
+    "CdcSourceConfig",
+    "CdcTableConfig",
+    "CdcSource",
+    "CdcTable",
+    "CdcEvent",
+    "CdcRow",
+    "CdcOperation",
     # Consumption
     "ApiConfig",
     "Api",
@@ -199,6 +219,8 @@ __all__ = [
     "get_materialized_view",
     "get_views",
     "get_view",
+    "get_cdc_sources",
+    "get_cdc_source",
     # Backward compatibility aliases (deprecated)
     "get_consumption_apis",
     "get_consumption_api",

--- a/packages/py-moose-lib/moose_lib/dmv2/_registry.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/_registry.py
@@ -22,3 +22,4 @@ _web_apps: Dict[str, Any] = {}
 # Structured registries for views and materialized views
 _materialized_views: Dict[str, Any] = {}
 _views: Dict[str, Any] = {}
+_cdc_sources: Dict[str, Any] = {}

--- a/packages/py-moose-lib/moose_lib/dmv2/cdc_source.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/cdc_source.py
@@ -1,0 +1,176 @@
+"""
+CDC source definitions for Moose Data Model v2 (dmv2).
+
+This module provides classes for defining CDC sources and CDC tables,
+including typed CDC event streams and optional CDC destination tables.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Generic, Literal, TypeVar, Union, Any
+
+from pydantic import BaseModel, create_model
+
+from .types import TypedMooseResource, T
+from .stream import Stream, StreamConfig
+from .olap_table import OlapTable, OlapConfig
+from .life_cycle import LifeCycle
+from ._source_capture import get_source_file_from_stack
+from ._registry import _cdc_sources
+from ..blocks import ReplacingMergeTreeEngine
+
+CdcOperation = Literal["insert", "update", "delete"]
+
+
+class CdcEvent(BaseModel, Generic[T]):
+    op: CdcOperation
+    before: Optional[T] = None
+    after: Optional[T] = None
+    ts: datetime
+    lsn: str
+    source: str
+
+
+class CdcRow(BaseModel, Generic[T]):
+    __cdc_op: CdcOperation
+    __cdc_lsn: str
+    __cdc_ts: datetime
+    __cdc_is_deleted: bool
+
+
+class CdcSourceConfig(BaseModel):
+    kind: str
+    connection: str
+    metadata: Optional[dict] = None
+    life_cycle: Optional[LifeCycle] = None
+
+
+class CdcTableConfig(BaseModel):
+    source_table: str
+    primary_key: list[str]
+    stream: bool | StreamConfig = True
+    table: bool | OlapConfig = True
+    snapshot: Optional[Literal["initial", "never"]] = None
+    version: Optional[str] = None
+    metadata: Optional[dict] = None
+    life_cycle: Optional[LifeCycle] = None
+
+
+class CdcSource:
+    def __init__(self, name: str, config: CdcSourceConfig):
+        self.name = name
+        self.config = config
+        if config.metadata:
+            self.metadata = (
+                config.metadata.copy()
+                if isinstance(config.metadata, dict)
+                else config.metadata
+            )
+        else:
+            self.metadata = {}
+
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
+
+        if "source" not in self.metadata:
+            source_file = get_source_file_from_stack()
+            if source_file:
+                self.metadata["source"] = {"file": source_file}
+        self.tables: dict[str, CdcTable[Any]] = {}
+
+        _cdc_sources[name] = self
+
+    def register_table(self, table: "CdcTable[Any]"):
+        self.tables[table.name] = table
+
+
+class CdcTable(TypedMooseResource, Generic[T]):
+    stream: Optional[Stream] = None
+    changes: Optional[Stream] = None
+    table: Optional[OlapTable] = None
+
+    def __init__(self, name: str, source: CdcSource, config: CdcTableConfig, **kwargs):
+        super().__init__()
+        self._set_type(name, self._get_type(kwargs))
+
+        if not config.primary_key:
+            raise ValueError("CdcTable requires a non-empty primary_key list")
+
+        self.name = name
+        self.source = source
+        self.config = config
+        self.source_table = config.source_table
+        if config.metadata:
+            self.metadata = (
+                config.metadata.copy()
+                if isinstance(config.metadata, dict)
+                else config.metadata
+            )
+        else:
+            self.metadata = {}
+
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
+
+        if "source" not in self.metadata:
+            source_file = get_source_file_from_stack()
+            if source_file:
+                self.metadata["source"] = {"file": source_file}
+
+        source.register_table(self)
+
+        event_model = _create_cdc_event_model(self._t)
+        row_model = _create_cdc_row_model(self._t)
+
+        if config.stream is not False:
+            stream_config = (
+                config.stream
+                if isinstance(config.stream, StreamConfig)
+                else StreamConfig(life_cycle=config.life_cycle)
+            )
+            if config.version:
+                stream_config.version = config.version
+            if config.metadata:
+                stream_config.metadata = config.metadata
+            self.stream = Stream[event_model](name, stream_config, t=event_model)
+            self.changes = self.stream
+
+        if config.table:
+            table_config = (
+                config.table
+                if isinstance(config.table, OlapConfig)
+                else OlapConfig(life_cycle=config.life_cycle)
+            )
+            if table_config.engine is None:
+                table_config.engine = ReplacingMergeTreeEngine(
+                    ver="__cdc_lsn", is_deleted="__cdc_is_deleted"
+                )
+            if config.version:
+                table_config.version = config.version
+            if not table_config.order_by_fields:
+                table_config.order_by_fields = config.primary_key
+            self.table = OlapTable[row_model](name, table_config, t=row_model)
+
+
+def _create_cdc_event_model(model: type[BaseModel]) -> type[BaseModel]:
+    return create_model(
+        f"{model.__name__}CdcEvent",
+        op=(CdcOperation, ...),
+        before=(Optional[model], None),
+        after=(Optional[model], None),
+        ts=(datetime, ...),
+        lsn=(str, ...),
+        source=(str, ...),
+    )
+
+
+def _create_cdc_row_model(model: type[BaseModel]) -> type[BaseModel]:
+    return create_model(
+        f"{model.__name__}CdcRow",
+        __base__=model,
+        __cdc_op=(CdcOperation, ...),
+        __cdc_lsn=(str, ...),
+        __cdc_ts=(datetime, ...),
+        __cdc_is_deleted=(bool, ...),
+    )

--- a/packages/py-moose-lib/moose_lib/dmv2/registry.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/registry.py
@@ -25,6 +25,7 @@ from ._registry import (
     _web_apps,
     _materialized_views,
     _views,
+    _cdc_sources,
 )
 from .materialized_view import MaterializedView
 from .view import View
@@ -135,6 +136,16 @@ def get_views() -> Dict[str, "View"]:
 def get_view(name: str) -> Optional["View"]:
     """Get a registered view by name."""
     return _views.get(name)
+
+
+def get_cdc_sources() -> Dict[str, "CdcSource"]:
+    """Get all registered CDC sources."""
+    return _cdc_sources
+
+
+def get_cdc_source(name: str) -> Optional["CdcSource"]:
+    """Get a registered CDC source by name."""
+    return _cdc_sources.get(name)
 
 
 # Backward compatibility aliases (deprecated)

--- a/packages/ts-moose-lib/src/browserCompatible.ts
+++ b/packages/ts-moose-lib/src/browserCompatible.ts
@@ -24,6 +24,13 @@ export {
   SqlResource,
   View,
   MaterializedView,
+  CdcSource,
+  CdcSourceConfig,
+  CdcTable,
+  CdcTableConfig,
+  CdcEvent,
+  CdcOperation,
+  CdcRow,
   Task,
   Workflow,
   ETLPipeline,
@@ -52,6 +59,8 @@ export {
   getViews,
   getMaterializedView,
   getMaterializedViews,
+  getCdcSources,
+  getCdcSource,
 } from "./dmv2";
 
 export {

--- a/packages/ts-moose-lib/src/dmv2/dataModelMetadata.ts
+++ b/packages/ts-moose-lib/src/dmv2/dataModelMetadata.ts
@@ -16,6 +16,7 @@ const typesToArgsLength = new Map([
   ["IngestApi", 2],
   ["Api", 2],
   ["MaterializedView", 1],
+  ["CdcTable", 3],
   ["Task", 2],
 ]);
 

--- a/packages/ts-moose-lib/src/dmv2/index.ts
+++ b/packages/ts-moose-lib/src/dmv2/index.ts
@@ -71,6 +71,15 @@ export {
 export { IngestPipeline, IngestPipelineConfig } from "./sdk/ingestPipeline";
 export { ETLPipeline, ETLPipelineConfig } from "./sdk/etlPipeline";
 export {
+  CdcSource,
+  CdcSourceConfig,
+  CdcTable,
+  CdcTableConfig,
+  CdcEvent,
+  CdcOperation,
+  CdcRow,
+} from "./sdk/cdcSource";
+export {
   MaterializedView,
   MaterializedViewConfig,
 } from "./sdk/materializedView";
@@ -103,4 +112,6 @@ export {
   getMaterializedView,
   getViews,
   getView,
+  getCdcSources,
+  getCdcSource,
 } from "./registry";

--- a/packages/ts-moose-lib/src/dmv2/registry.ts
+++ b/packages/ts-moose-lib/src/dmv2/registry.ts
@@ -16,6 +16,7 @@ import { Workflow } from "./sdk/workflow";
 import { WebApp } from "./sdk/webApp";
 import { MaterializedView } from "./sdk/materializedView";
 import { View } from "./sdk/view";
+import { CdcSource } from "./sdk/cdcSource";
 import { getMooseInternal } from "./internal";
 
 /**
@@ -210,4 +211,21 @@ export function getViews(): Map<string, View> {
  */
 export function getView(name: string): View | undefined {
   return getMooseInternal().views.get(name);
+}
+
+/**
+ * Get all registered CDC sources.
+ * @returns A Map of CDC source name to CdcSource instance
+ */
+export function getCdcSources(): Map<string, CdcSource> {
+  return getMooseInternal().cdcSources;
+}
+
+/**
+ * Get a registered CDC source by name.
+ * @param name - The name of the CDC source
+ * @returns The CdcSource instance or undefined if not found
+ */
+export function getCdcSource(name: string): CdcSource | undefined {
+  return getMooseInternal().cdcSources.get(name);
 }

--- a/packages/ts-moose-lib/src/dmv2/sdk/cdcSource.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/cdcSource.ts
@@ -1,0 +1,407 @@
+import { IJsonSchemaCollection } from "typia";
+import { ClickHouseEngines } from "../../dataModels/types";
+import { Column, DataType } from "../../dataModels/dataModelTypes";
+import { OlapConfig, OlapTable } from "./olapTable";
+import { Stream, StreamConfig } from "./stream";
+import { LifeCycle } from "./lifeCycle";
+import { TypedBase, TypiaValidators } from "../typedBase";
+import { getMooseInternal } from "../internal";
+import { getSourceLocationFromStack } from "../utils/stackTrace";
+
+export type CdcOperation = "insert" | "update" | "delete";
+
+export interface CdcEvent<T> {
+  op: CdcOperation;
+  before?: T | null;
+  after?: T | null;
+  ts: Date;
+  lsn: string;
+  source: string;
+}
+
+export type CdcRow<T> = T & {
+  __cdc_op: CdcOperation;
+  __cdc_lsn: string;
+  __cdc_ts: Date;
+  __cdc_is_deleted: boolean;
+};
+
+export type CdcSourceConfig = {
+  kind: string;
+  connection: string;
+  metadata?: { description?: string };
+  lifeCycle?: LifeCycle;
+};
+
+export type CdcTableConfig<T> = {
+  sourceTable: string;
+  primaryKey: Array<keyof T & string>;
+  stream?: boolean | Omit<StreamConfig<CdcEvent<T>>, "destination">;
+  table?: boolean | OlapConfig<CdcRow<T>>;
+  snapshot?: "initial" | "never";
+  version?: string;
+  metadata?: { description?: string };
+  lifeCycle?: LifeCycle;
+};
+
+export class CdcSource {
+  readonly name: string;
+  readonly config: CdcSourceConfig;
+  readonly tables: Map<string, CdcTable<any>> = new Map();
+  metadata?: {
+    description?: string;
+    source?: { file?: string; line?: string };
+  };
+
+  constructor(name: string, config: CdcSourceConfig) {
+    this.name = name;
+    this.config = config;
+
+    this.metadata = config.metadata ? { ...config.metadata } : {};
+    if (!this.metadata.source) {
+      const stack = new Error().stack;
+      const info = getSourceLocationFromStack(stack);
+      if (info) {
+        this.metadata.source = { file: info.file, line: info.line.toString() };
+      }
+    }
+
+    getMooseInternal().cdcSources.set(name, this);
+  }
+
+  registerTable(table: CdcTable<any>) {
+    this.tables.set(table.name, table);
+  }
+}
+
+export class CdcTable<T> extends TypedBase<T, CdcTableConfig<T>> {
+  readonly source: CdcSource;
+  readonly sourceTable: string;
+  stream?: Stream<CdcEvent<T>>;
+  changes?: Stream<CdcEvent<T>>;
+  table?: OlapTable<CdcRow<T>>;
+
+  constructor(name: string, source: CdcSource, config: CdcTableConfig<T>);
+
+  constructor(
+    name: string,
+    source: CdcSource,
+    config: CdcTableConfig<T>,
+    schema?: IJsonSchemaCollection.IV3_1,
+    columns?: Column[],
+    validators?: TypiaValidators<T>,
+    allowExtraFields?: boolean,
+  );
+
+  constructor(
+    name: string,
+    source: CdcSource,
+    config: CdcTableConfig<T>,
+    schema?: IJsonSchemaCollection.IV3_1,
+    columns?: Column[],
+    validators?: TypiaValidators<T>,
+    allowExtraFields?: boolean,
+  ) {
+    super(name, config, schema, columns, validators, allowExtraFields);
+
+    this.source = source;
+    this.sourceTable = config.sourceTable;
+    source.registerTable(this);
+
+    if (!config.primaryKey || config.primaryKey.length === 0) {
+      throw new Error(
+        `CdcTable '${name}' requires a non-empty primaryKey array.`,
+      );
+    }
+
+    const metaColumnNames = new Set([
+      "__cdc_op",
+      "__cdc_lsn",
+      "__cdc_ts",
+      "__cdc_is_deleted",
+    ]);
+    for (const col of this.columnArray) {
+      if (metaColumnNames.has(col.name)) {
+        throw new Error(
+          `CdcTable '${name}' uses reserved CDC metadata column name '${col.name}'.`,
+        );
+      }
+    }
+
+    if (config.stream !== false) {
+      const eventSchema = buildCdcEventSchema(this.schema);
+      const eventColumns = buildCdcEventColumns(this.columnArray);
+      const streamConfig: StreamConfig<CdcEvent<T>> = {
+        ...(typeof config.stream === "object" ? config.stream : {}),
+        lifeCycle: config.lifeCycle,
+        ...(config.version && { version: config.version }),
+        metadata: config.metadata,
+      };
+
+      this.stream = new Stream(
+        name,
+        streamConfig,
+        eventSchema,
+        eventColumns,
+        undefined,
+        false,
+      );
+      this.changes = this.stream;
+    }
+
+    if (config.table) {
+      const rowSchema = buildCdcRowSchema(this.schema);
+      const rowColumns = buildCdcRowColumns(this.columnArray);
+      const baseTableConfig = (
+        typeof config.table === "object" ?
+          {
+            ...config.table,
+            lifeCycle: config.table.lifeCycle ?? config.lifeCycle,
+            ...(config.version && { version: config.version }),
+          }
+        : {
+            engine: ClickHouseEngines.ReplacingMergeTree,
+            orderByFields: config.primaryKey as Array<keyof CdcRow<T> & string>,
+            ver: "__cdc_lsn",
+            isDeleted: "__cdc_is_deleted",
+            lifeCycle: config.lifeCycle,
+            ...(config.version && { version: config.version }),
+          }) as OlapConfig<CdcRow<T>>;
+
+      if (
+        "engine" in baseTableConfig &&
+        baseTableConfig.engine === ClickHouseEngines.ReplacingMergeTree
+      ) {
+        const replacingConfig = baseTableConfig as {
+          engine: ClickHouseEngines.ReplacingMergeTree;
+          ver?: string;
+          isDeleted?: string;
+        };
+        replacingConfig.ver = replacingConfig.ver ?? "__cdc_lsn";
+        replacingConfig.isDeleted =
+          replacingConfig.isDeleted ?? "__cdc_is_deleted";
+      }
+
+      if (
+        "orderByFields" in baseTableConfig &&
+        (!baseTableConfig.orderByFields ||
+          baseTableConfig.orderByFields.length === 0)
+      ) {
+        baseTableConfig.orderByFields = config.primaryKey as Array<
+          keyof CdcRow<T> & string
+        >;
+      }
+
+      this.table = new OlapTable(
+        name,
+        baseTableConfig,
+        rowSchema,
+        rowColumns,
+        undefined,
+      );
+    }
+  }
+}
+
+const buildCdcEventSchema = (
+  base: IJsonSchemaCollection.IV3_1,
+): IJsonSchemaCollection.IV3_1 => {
+  const baseSchema = base.schemas[0] as any;
+  const nullableBase = {
+    anyOf: [baseSchema, { type: "null" }],
+  } as any;
+
+  return {
+    ...base,
+    schemas: [
+      {
+        type: "object",
+        properties: {
+          op: { type: "string" },
+          before: nullableBase,
+          after: nullableBase,
+          ts: { type: "string", format: "date-time" },
+          lsn: { type: "string" },
+          source: { type: "string" },
+        },
+        required: ["op", "ts", "lsn", "source"],
+      } as any,
+    ],
+  } as IJsonSchemaCollection.IV3_1;
+};
+
+const buildCdcRowSchema = (
+  base: IJsonSchemaCollection.IV3_1,
+): IJsonSchemaCollection.IV3_1 => {
+  const baseSchema = base.schemas[0] as any;
+  return {
+    ...base,
+    schemas: [
+      {
+        allOf: [
+          baseSchema,
+          {
+            type: "object",
+            properties: {
+              __cdc_op: { type: "string" },
+              __cdc_lsn: { type: "string" },
+              __cdc_ts: { type: "string", format: "date-time" },
+              __cdc_is_deleted: { type: "boolean" },
+            },
+            required: ["__cdc_op", "__cdc_lsn", "__cdc_ts", "__cdc_is_deleted"],
+          },
+        ],
+      } as any,
+    ],
+  } as IJsonSchemaCollection.IV3_1;
+};
+
+const buildCdcEventColumns = (columns: Column[]): Column[] => {
+  const nestedBefore: DataType = {
+    name: "before",
+    columns,
+    jwt: false,
+  };
+  const nestedAfter: DataType = {
+    name: "after",
+    columns,
+    jwt: false,
+  };
+
+  return [
+    {
+      name: "op",
+      data_type: "String",
+      primary_key: false,
+      required: true,
+      unique: false,
+      default: null,
+      annotations: [],
+      ttl: null,
+      codec: null,
+      materialized: null,
+      comment: null,
+    },
+    {
+      name: "before",
+      data_type: { nullable: nestedBefore },
+      primary_key: false,
+      required: false,
+      unique: false,
+      default: null,
+      annotations: [],
+      ttl: null,
+      codec: null,
+      materialized: null,
+      comment: null,
+    },
+    {
+      name: "after",
+      data_type: { nullable: nestedAfter },
+      primary_key: false,
+      required: false,
+      unique: false,
+      default: null,
+      annotations: [],
+      ttl: null,
+      codec: null,
+      materialized: null,
+      comment: null,
+    },
+    {
+      name: "ts",
+      data_type: "DateTime",
+      primary_key: false,
+      required: true,
+      unique: false,
+      default: null,
+      annotations: [],
+      ttl: null,
+      codec: null,
+      materialized: null,
+      comment: null,
+    },
+    {
+      name: "lsn",
+      data_type: "String",
+      primary_key: false,
+      required: true,
+      unique: false,
+      default: null,
+      annotations: [],
+      ttl: null,
+      codec: null,
+      materialized: null,
+      comment: null,
+    },
+    {
+      name: "source",
+      data_type: "String",
+      primary_key: false,
+      required: true,
+      unique: false,
+      default: null,
+      annotations: [],
+      ttl: null,
+      codec: null,
+      materialized: null,
+      comment: null,
+    },
+  ];
+};
+
+const buildCdcRowColumns = (columns: Column[]): Column[] => [
+  ...columns,
+  {
+    name: "__cdc_op",
+    data_type: "String",
+    primary_key: false,
+    required: true,
+    unique: false,
+    default: null,
+    annotations: [],
+    ttl: null,
+    codec: null,
+    materialized: null,
+    comment: null,
+  },
+  {
+    name: "__cdc_lsn",
+    data_type: "String",
+    primary_key: false,
+    required: true,
+    unique: false,
+    default: null,
+    annotations: [],
+    ttl: null,
+    codec: null,
+    materialized: null,
+    comment: null,
+  },
+  {
+    name: "__cdc_ts",
+    data_type: "DateTime",
+    primary_key: false,
+    required: true,
+    unique: false,
+    default: null,
+    annotations: [],
+    ttl: null,
+    codec: null,
+    materialized: null,
+    comment: null,
+  },
+  {
+    name: "__cdc_is_deleted",
+    data_type: "UInt8",
+    primary_key: false,
+    required: true,
+    unique: false,
+    default: null,
+    annotations: [],
+    ttl: null,
+    codec: null,
+    materialized: null,
+    comment: null,
+  },
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12943,7 +12943,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12994,7 +12994,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/templates/python-tests/.env
+++ b/templates/python-tests/.env
@@ -1,0 +1,1 @@
+TEST_CDC_CONNECTION=postgres://test_user:test_pass@localhost:5432/test_db

--- a/templates/python-tests/src/ingest/cdc.py
+++ b/templates/python-tests/src/ingest/cdc.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from moose_lib import (
+    CdcSource,
+    CdcSourceConfig,
+    CdcTable,
+    CdcTableConfig,
+    Stream,
+    moose_runtime_env,
+)
+
+
+class OrderRow(BaseModel):
+    id: str
+    customer_id: str
+    total_cents: int
+    status: str
+    created_at: datetime
+
+
+orders_cdc_source = CdcSource(
+    "orders_cdc",
+    CdcSourceConfig(
+        kind="postgresql",
+        connection=moose_runtime_env.get("TEST_CDC_CONNECTION"),
+        metadata={"description": "CDC source for orders (template test)"},
+    ),
+)
+
+orders_cdc_table = CdcTable[OrderRow](
+    "orders",
+    orders_cdc_source,
+    CdcTableConfig(
+        source_table="public.orders",
+        primary_key=["id"],
+        snapshot="initial",
+        stream=True,
+        table=True,
+    ),
+)
+
+
+class OrdersIngestRow(BaseModel):
+    order_id: str
+    customer_id: str
+    total_usd: float
+    status: str
+    updated_at: datetime
+    op: str
+
+
+orders_ingest_stream = Stream[OrdersIngestRow]("orders_ingest")
+
+
+def to_orders_ingest(event):
+    row = event.after or event.before
+    if row is None:
+        return None
+    return OrdersIngestRow(
+        order_id=row.id,
+        customer_id=row.customer_id,
+        total_usd=row.total_cents / 100,
+        status=row.status,
+        updated_at=row.created_at,
+        op=event.op,
+    )
+
+
+if orders_cdc_table.changes is not None:
+    orders_cdc_table.changes.add_transform(orders_ingest_stream, to_orders_ingest)

--- a/templates/python-tests/src/main.py
+++ b/templates/python-tests/src/main.py
@@ -6,6 +6,7 @@ from src.ingest import (
 from src.ingest import s3_queue_tests  # Import S3Queue tests for runtime env resolution
 from src.ingest import s3_tests  # Import S3 engine tests for runtime env resolution
 from src.ingest import kafka_tests  # Import Kafka engine tests
+from src.ingest import cdc  # Import CDC test resources
 import src.apis.bar as bar_api
 from src.apis.webapp_bar import bar_fastapi_app
 import src.views.bar_aggregated as bar_view

--- a/templates/typescript-tests/.env
+++ b/templates/typescript-tests/.env
@@ -1,0 +1,1 @@
+TEST_CDC_CONNECTION=postgres://test_user:test_pass@localhost:5432/test_db

--- a/templates/typescript-tests/src/index.ts
+++ b/templates/typescript-tests/src/index.ts
@@ -6,6 +6,7 @@ export * from "./ingest/s3Tests"; // Import S3 engine tests for runtime env reso
 export * from "./ingest/kafkaTests"; // Import Kafka engine tests
 export * from "./ingest/drizzleInfer";
 export * from "./ingest/dateAggregationModels";
+export * from "./ingest/cdc";
 
 export * from "./apis/bar";
 export * from "./apis/barExpress";

--- a/templates/typescript-tests/src/ingest/cdc.ts
+++ b/templates/typescript-tests/src/ingest/cdc.ts
@@ -1,0 +1,65 @@
+import {
+  CdcSource,
+  CdcTable,
+  DateTime,
+  Stream,
+  mooseRuntimeEnv,
+} from "@514labs/moose-lib";
+
+export interface OrderRow {
+  id: string;
+  customerId: string;
+  totalCents: number;
+  status: string;
+  createdAt: DateTime;
+}
+
+export const ordersCdcSource = new CdcSource("orders_cdc", {
+  kind: "postgresql",
+  connection: mooseRuntimeEnv.get("TEST_CDC_CONNECTION"),
+  metadata: {
+    description: "CDC source for orders (template test)",
+  },
+});
+
+export const ordersCdcTable = new CdcTable<OrderRow>(
+  "orders",
+  ordersCdcSource,
+  {
+    sourceTable: "public.orders",
+    primaryKey: ["id"],
+    snapshot: "initial",
+    stream: true,
+    table: true,
+  },
+);
+
+export interface OrdersIngestRow {
+  orderId: string;
+  customerId: string;
+  totalUsd: number;
+  status: string;
+  updatedAt: DateTime;
+  op: string;
+}
+
+export const ordersIngestStream = new Stream<OrdersIngestRow>("orders_ingest");
+
+ordersCdcTable.changes?.addTransform(
+  ordersIngestStream,
+  (event) => {
+    const row = event.after ?? event.before;
+    if (!row) {
+      return null;
+    }
+    return {
+      orderId: row.id,
+      customerId: row.customerId,
+      totalUsd: row.totalCents / 100,
+      status: row.status,
+      updatedAt: row.createdAt,
+      op: event.op,
+    };
+  },
+  { version: "v1" },
+);


### PR DESCRIPTION
**Summary**
- Document the CDC-as-code UX plan covering TS/Python SDKs, Rust infra map exposure, CLI sign-off, docs, templates, and E2E coverage.
- Ensure CDC experience centers on typed, autocomplete-friendly APIs, env/config conventions, transform hooks, and ReplacingMergeTree destinations so the plan captures every touchpoint.

**Testing**
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CDC resource type that flows through planning/diffing/serialization across Rust, TS, and Python; mistakes could affect plan correctness and secret handling (connection strings), though apply behavior is currently no-op.
> 
> **Overview**
> Adds first-class **CDC-as-code** support end-to-end: TS and Python SDKs introduce `CdcSource`/`CdcTable` typed APIs (including CDC event/row shapes) and register them into the dmv2 infra JSON.
> 
> Updates the Rust CLI/planner to ingest `cdc_sources` into `InfrastructureMap`, serialize via protobuf, diff CDC sources as `ProcessChange::CdcSource` with lifecycle-aware add/update/remove behavior, validate required CDC fields, and **mask CDC connection strings** in `moose plan` JSON export.
> 
> Expands templates, E2E tests, and docs to cover runtime-env based CDC connections and to assert CDC sources appear in `moose plan` output (with dummy `TEST_CDC_CONNECTION`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcce032ac21782e2d04eccd4c6a0c03d7c3050a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->