### PR TITLE
Add claude settings & update flake.nix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm build:*)",
+      "Bash(pnpm dev:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm format:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm clean:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm typecheck:*)",
+      "Bash(cargo build:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo check:*)",
+      "Bash(pytest:*)",
+      "Bash(black:*)",
+      "Bash(turbo:*)",
+      "Bash(node scripts/*:*)",
+      "Bash(cargo-test:*)",
+      "Bash(ts-test:*)",
+      "Bash(py-test:*)",
+      "Bash(e2e-test:*)",
+      "Bash(test-all:*)",
+      "Bash(rustfmt:*)",
+      "Bash(mocha:*)",
+      "Bash(tsup:*)"
+    ]
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,12 @@
 
               # Set Python path for development
               export PYTHONPATH="$PWD/packages/py-moose-lib:$PYTHONPATH"
+
+              # Initialize husky git hooks if not already set up
+              if [ -d ".git" ] && [ ! -d ".husky/_" ]; then
+                echo "Setting up husky git hooks..."
+                husky install
+              fi
             '';
           };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling/config and a `shellHook` side effect that runs `husky install` when entering the Nix dev shell.
> 
> **Overview**
> Adds `.claude/settings.json` to explicitly allow a curated set of common `pnpm`/`cargo`/Python/test-related Bash commands for Claude tooling.
> 
> Updates `flake.nix` dev shell `shellHook` to automatically run `husky install` (once, when `.husky/_` is missing) so git hooks are initialized when entering the Nix environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de2b4a57f56c1c7ca1e116b28b6d7d01d27f65db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->