### PR TITLE
Improve moose --help output with better organization and docs link

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -215,7 +215,26 @@ pub fn prompt_password(prompt_text: &str) -> Result<String, RoutineFailure> {
 }
 
 #[derive(Parser)]
-#[command(author, version = constants::CLI_VERSION, about, long_about = None, arg_required_else_help(true), next_display_order = None)]
+#[command(
+    author,
+    version = constants::CLI_VERSION,
+    about = "MooseStack is a type-safe code-first developer framework for building real-time analytical backends, by the team at Fiveonefour.",
+    long_about = None,
+    arg_required_else_help(true),
+    next_display_order = None,
+    after_help = "\x1b[1;4mLEARN MORE\x1b[0m
+  Documentation:         https://docs.fiveonefour.com/moosestack
+  Implementation guides: https://docs.fiveonefour.com/guides?lang=typescript
+
+\x1b[1;4mFEEDBACK\x1b[0m
+  We'd love to hear from you! Join our Slack community:
+    https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg
+  Or email us at: hello@fiveonefour.com
+
+\x1b[1;4mHOSTING\x1b[0m
+  Try Boreal, Fiveonefour's hosting platform built for MooseStack apps.
+  Sign up for a free trial: https://fiveonefour.boreal.cloud/sign-up"
+)]
 pub struct Cli {
     /// Turn debugging information on
     #[arg(short, long)]


### PR DESCRIPTION
- Add documentation link (https://docs.moosejs.com) to help footer
- Improve about text to be more action-oriented
- Reorganize commands into logical groups with display_order
- Update command descriptions to be clearer and more concise
- Group commands: Getting Started, Development, Data & Queries, Infrastructure & Monitoring, Deployment & Migration, Utilities

Resolves 514-359

https://claude.ai/code/session_01GGPPt4FQ5w5seWLfdd2P7D

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-text-only changes to Clap metadata; no runtime logic or command behavior changes.
> 
> **Overview**
> Updates the top-level `moose` CLI `--help` output by replacing the generic `about` text with a more descriptive product blurb and adding a formatted `after_help` footer.
> 
> The new footer includes **Learn More** links (docs + implementation guides), **Feedback** contact info (Slack invite + email), and **Hosting** promotion (Boreal free trial).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0904a5dcccbeddd96d14ef61e925fcc1c4033a3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->