### PR TITLE
Add custom help command with documentation links

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -215,7 +215,16 @@ pub fn prompt_password(prompt_text: &str) -> Result<String, RoutineFailure> {
 }
 
 #[derive(Parser)]
-#[command(author, version = constants::CLI_VERSION, about, long_about = None, arg_required_else_help(true), next_display_order = None)]
+#[command(
+    author,
+    version = constants::CLI_VERSION,
+    about = "Build data-intensive apps and services with Moose",
+    long_about = None,
+    arg_required_else_help(true),
+    next_display_order = None,
+    disable_help_subcommand = true,
+    after_help = "Run 'moose help' for detailed documentation and links"
+)]
 pub struct Cli {
     /// Turn debugging information on
     #[arg(short, long)]
@@ -412,6 +421,13 @@ pub async fn top_command_handler(
     machine_id: String,
 ) -> Result<RoutineSuccess, RoutineFailure> {
     match commands {
+        Commands::Help {} => {
+            routines::help::display_help();
+            Ok(RoutineSuccess::success(Message::new(
+                "".to_string(),
+                "".to_string(),
+            )))
+        }
         Commands::Init {
             name,
             location,

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -7,6 +7,9 @@ use clap::{Args, Subcommand};
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Display help information with links to documentation
+    Help {},
+
     // Initializes the developer environment with all the necessary directories including temporary ones for data storage
     /// Initialize your data-intensive app or service
     Init {

--- a/apps/framework-cli/src/cli/routines/help.rs
+++ b/apps/framework-cli/src/cli/routines/help.rs
@@ -1,0 +1,96 @@
+//! Help command display module
+//!
+//! Provides a styled help output following Graphite CLI best practices.
+
+use crate::utilities::constants::CLI_VERSION;
+
+/// Documentation and community URLs
+const DOCS_URL: &str = "https://docs.moosejs.com";
+const QUICKSTART_URL: &str = "https://docs.moosejs.com/moosestack/getting-started/quickstart";
+const TROUBLESHOOTING_URL: &str = "https://docs.moosejs.com/moosestack/help/troubleshooting";
+const GITHUB_ISSUES_URL: &str = "https://github.com/514-labs/moose/issues";
+const SLACK_COMMUNITY_URL: &str =
+    "https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg";
+
+/// Display the styled help output
+pub fn display_help() {
+    let help_text = format!(
+        r#"
+Moose (moose) is a type-safe, code-first toolkit for building real-time
+analytical backends. Declare all infrastructure and pipelines in TypeScript
+or Python, and Moose auto-wires everything together.
+
+USAGE
+  $ moose <command> [options]
+
+TERMS
+  data model:  A typed schema definition that represents your data structure.
+               Used to create tables, streams, and APIs automatically.
+  stream:      A Kafka/Redpanda topic for real-time data ingestion and
+               processing. Connects ingest APIs to tables.
+  table:       A ClickHouse OLAP table for storing and querying data.
+               Automatically created from your data models.
+  workflow:    A Temporal-powered background task for ETL pipelines,
+               scheduled jobs, and complex data processing.
+  api:         HTTP endpoints for data ingestion (POST) and analytics (GET).
+               Auto-generated with type validation.
+
+CORE COMMANDS
+  moose init:           Create a new Moose project with your preferred language
+  moose dev:            Start local development server with hot reload
+  moose build:          Build your project for production deployment
+  moose plan:           Preview infrastructure changes before deployment
+  moose migrate:        Execute migration plan against production database
+
+  Run moose <command> --help for specific command help
+  (e.g., moose init --help)
+
+CORE WORKFLOW
+  1. Initialize your project:
+     $ moose init my-app typescript   # or python
+
+  2. Start development server:
+     $ cd my-app && moose dev
+
+  3. Define data models in code - infrastructure auto-updates on save
+
+  4. Build and deploy to production:
+     $ moose build
+     $ moose plan --clickhouse-url <url>
+     $ moose migrate --clickhouse-url <url>
+
+LEARN MORE
+  Documentation:     {docs}
+  Quickstart Guide:  {quickstart}
+  Troubleshooting:   {troubleshooting}
+
+FEEDBACK
+  We'd love to hear your feedback! Join our Slack community at:
+      {slack}
+
+  Report issues or request features on GitHub:
+      {github}
+
+  Include your Moose version ({version}) when reporting issues.
+"#,
+        docs = DOCS_URL,
+        quickstart = QUICKSTART_URL,
+        troubleshooting = TROUBLESHOOTING_URL,
+        slack = SLACK_COMMUNITY_URL,
+        github = GITHUB_ISSUES_URL,
+        version = CLI_VERSION,
+    );
+
+    println!("{}", help_text);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_help_runs_without_panic() {
+        // This test just ensures the function doesn't panic
+        display_help();
+    }
+}

--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -163,6 +163,7 @@ pub mod code_generation;
 pub mod dev;
 pub mod docker_packager;
 pub mod format_query;
+pub mod help;
 pub mod kafka_pull;
 pub mod logs;
 pub mod ls;


### PR DESCRIPTION
## Summary
This PR adds a custom `help` command to the Moose CLI that displays styled help information with links to documentation, quickstart guides, troubleshooting resources, and community channels. It also improves the top-level `--help` flag handling to show this custom help instead of the default clap output.

## Key Changes
- **New `help` command**: Added a new `Commands::Help` variant that displays comprehensive help text with:
  - Overview of Moose's capabilities
  - Key terminology (data models, streams, tables, workflows, APIs)
  - Core commands and typical workflow
  - Links to documentation, quickstart, troubleshooting, GitHub issues, and Slack community
  
- **Custom help module**: Created `apps/framework-cli/src/cli/routines/help.rs` with a `display_help()` function that formats and prints styled help output

- **Improved top-level `--help` handling**: Modified `main.rs` to detect when `--help` or `-h` is used at the top level (without a subcommand) and display the custom help instead of clap's default output

- **Enhanced CLI metadata**: Updated the `#[command]` attribute in `cli.rs` with:
  - Custom `about` description
  - `disable_help_subcommand = true` to prevent clap's default help subcommand
  - `after_help` message directing users to the new help command

- **Subcommand detection**: Added `is_known_subcommand()` helper function to distinguish between top-level `--help` and subcommand-level `--help` requests

## Implementation Details
- The help text includes version information from `CLI_VERSION` constant
- All documentation URLs are defined as constants for easy maintenance
- The custom help is only shown for top-level `--help`; subcommand help still uses clap's default behavior
- Includes a basic test to ensure the help function doesn't panic

https://claude.ai/code/session_01DDaPuUzeURndDkZ2Dbz7XB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CLI UX/output changes; behavior impact is limited to help routing and should not affect command execution paths.
> 
> **Overview**
> Adds a custom `moose help` subcommand that prints a curated, long-form help page including core terminology, common workflows, and links to docs/community resources.
> 
> Updates CLI metadata to disable clap’s built-in help subcommand and adds an `after_help` hint, plus changes `main.rs` to intercept *top-level* `--help`/`-h` and show the custom help while preserving clap’s default help for subcommands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e42d56caa09761c250fd0ca2ceefd0876f9296d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->