### PR TITLE
chore: added docs for custom dockerfiles

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/configuration.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration.mdx
@@ -339,6 +339,16 @@ workflows = false
 olap = true
 # Enable Analytics APIs server (Default: true)
 apis = true
+
+# Docker build configuration
+[docker_config]
+# Use a custom Dockerfile instead of auto-generating one (Default: false)
+# When true, Moose writes the Dockerfile to your project root on first build
+# and preserves it on subsequent builds so you can customize it.
+# custom_dockerfile = false
+# Path to the Dockerfile relative to project root (Default: "./Dockerfile")
+# Only used when custom_dockerfile is true.
+# dockerfile_path = "./Dockerfile"
 ```
 
 ## Common Environment Variables
@@ -389,6 +399,12 @@ MOOSE_FEATURES__APIS=true
 MOOSE_LOGGER__LEVEL=info
 MOOSE_LOGGER__STDOUT=true
 MOOSE_LOGGER__FORMAT=Json
+```
+
+### Docker
+```bash
+MOOSE_DOCKER_CONFIG__CUSTOM_DOCKERFILE=true
+MOOSE_DOCKER_CONFIG__DOCKERFILE_PATH=./Dockerfile
 ```
 
 For a complete list of all available configuration options, see the [moose.config.toml Reference](#mooseconfigtoml-reference) above.

--- a/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
@@ -1,0 +1,76 @@
+---
+title: Docker Configuration
+description: Configure custom Dockerfile support for deployment
+order: 50
+---
+
+# Docker Configuration
+
+Configure how Moose generates and manages Dockerfiles for deployment packaging.
+
+By default, `moose build --docker` generates and builds a Dockerfile internally. Enable `custom_dockerfile` to have Moose place the Dockerfile at your project root so you can customize it.
+
+```toml filename="moose.config.toml"
+[docker_config]
+# Use a custom Dockerfile instead of auto-generating one (Default: false)
+custom_dockerfile = false
+# Path to the Dockerfile relative to project root (Default: "./Dockerfile")
+dockerfile_path = "./Dockerfile"
+```
+
+| Key | Env Variable | Default | Description |
+|:----|:-------------|:--------|:------------|
+| `custom_dockerfile` | `MOOSE_DOCKER_CONFIG__CUSTOM_DOCKERFILE` | `false` | When `true`, Moose writes the Dockerfile to your project root on first build and preserves it on subsequent builds so you can customize it. |
+| `dockerfile_path` | `MOOSE_DOCKER_CONFIG__DOCKERFILE_PATH` | `"./Dockerfile"` | Path to the Dockerfile relative to the project root. Only used when `custom_dockerfile` is `true`. |
+
+## How It Works
+
+### Default Behavior (`custom_dockerfile = false`)
+
+Running `moose build --docker` generates a Dockerfile internally (in `.moose/packager/`), builds the Docker image(s), and cleans up. The Dockerfile is never exposed for editing.
+
+### Custom Dockerfile Mode (`custom_dockerfile = true`)
+
+1. **First run** of `moose build --docker`: Moose generates a Dockerfile at `dockerfile_path` (default: `./Dockerfile` in your project root) and then builds the image.
+2. **Subsequent runs**: Moose detects the existing Dockerfile, skips generation to preserve your customizations, and builds the image from your Dockerfile.
+
+This lets you iterate on the Dockerfile — add system dependencies, configure caching, adjust build stages — while still using `moose build --docker` to build images.
+
+## Setup
+
+You can enable custom Dockerfile mode in two ways:
+
+### Option 1: During Project Init
+
+```bash
+moose init my-app typescript --custom-dockerfile
+```
+
+This sets `custom_dockerfile = true` in `moose.config.toml` automatically.
+
+### Option 2: Edit Config Manually
+
+Add or update the `[docker_config]` section in your `moose.config.toml`:
+
+```toml filename="moose.config.toml"
+[docker_config]
+custom_dockerfile = true
+dockerfile_path = "./Dockerfile"
+```
+
+Then run `moose build --docker` to generate the initial Dockerfile.
+
+## Architecture Flags
+
+You can target specific architectures when building:
+
+```bash
+# Build for both architectures (default)
+moose build --docker
+
+# Build for AMD64 only
+moose build --docker --amd64
+
+# Build for ARM64 only
+moose build --docker --arm64
+```

--- a/apps/framework-docs-v2/content/moosestack/configuration/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/index.mdx
@@ -64,6 +64,7 @@ Moose Runtime automatically loads `.env` files in order of precedence. Files loa
 - **[Git](/moosestack/configuration/git)** - Version control integration settings.
 - **[Features](/moosestack/configuration/features)** - Feature flags to enable or disable capabilities.
 - **[Migrations](/moosestack/configuration/migrations)** - Database migration behavior and operations.
+- **[Docker](/moosestack/configuration/docker)** - Custom Dockerfile support for deployment packaging.
 
 ### Infrastructure
 

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -833,6 +833,12 @@ const moosestackNavigationConfig: NavigationConfig = [
         title: "Migrations",
         languages: ["typescript", "python"],
       },
+      {
+        type: "page",
+        slug: "moosestack/configuration/docker",
+        title: "Docker",
+        languages: ["typescript", "python"],
+      },
       { type: "separator" },
       { type: "label", title: "Infrastructure" },
       {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change that adds a new configuration reference page and navigation entry; no runtime or build logic changes.
> 
> **Overview**
> Adds documentation for Docker build customization via a new `[docker_config]` section, including `custom_dockerfile` and `dockerfile_path` plus their env var overrides.
> 
> Introduces a dedicated `Docker Configuration` page explaining default vs custom Dockerfile behavior and related `moose build --docker` flags, and wires it into the configuration index and site navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ad699a88a435532c643c658355f67efd511999d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->