### PR TITLE
chore: added command and docs for building just the dockerfile

### DIFF
--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -262,6 +262,8 @@ pub struct GenerateArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GenerateCommand {
+    /// Generate the Dockerfile without building the Docker image
+    Dockerfile {},
     /// Generate an API key hash and bearer token pair for authentication
     HashToken {
         /// Output in JSON format

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -321,22 +321,8 @@ CMD ["moose", "prod"]
 ///
 /// If monorepo detection fails or path analysis encounters errors, gracefully falls back
 /// to standard single-project Docker build to ensure robustness.
-pub fn create_dockerfile(
-    project: &Project,
-    docker_client: &DockerClient,
-) -> Result<RoutineSuccess, RoutineFailure> {
+pub fn create_dockerfile(project: &Project) -> Result<RoutineSuccess, RoutineFailure> {
     let internal_dir = project.internal_dir_with_routine_failure_err()?;
-
-    ensure_docker_running(docker_client).map_err(|err| {
-        error!("Failed to ensure docker is running: {}", err);
-        RoutineFailure::new(
-            Message::new(
-                "Failed".to_string(),
-                "to ensure docker is running".to_string(),
-            ),
-            err,
-        )
-    })?;
 
     let versions_file_path = internal_dir.join("packager/versions/.gitkeep");
 

--- a/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
@@ -1,14 +1,18 @@
 ---
 title: Docker Configuration
-description: Configure custom Dockerfile support for deployment
+description: Configure custom Dockerfile support for deployment packaging
 order: 50
 ---
+
+import { Callout } from "@/components/mdx";
 
 # Docker Configuration
 
 Configure how Moose generates and manages Dockerfiles for deployment packaging.
 
-By default, `moose build --docker` generates and builds a Dockerfile internally. Enable `custom_dockerfile` to have Moose place the Dockerfile at your project root so you can customize it.
+<Callout type="info" title="Configuration Source">
+Docker build settings can be configured in `moose.config.toml` for project-wide defaults, or overridden via environment variables (e.g., `MOOSE_DOCKER_CONFIG__CUSTOM_DOCKERFILE=true`) for specific environments.
+</Callout>
 
 ```toml filename="moose.config.toml"
 [docker_config]
@@ -20,49 +24,33 @@ dockerfile_path = "./Dockerfile"
 
 | Key | Env Variable | Default | Description |
 |:----|:-------------|:--------|:------------|
-| `custom_dockerfile` | `MOOSE_DOCKER_CONFIG__CUSTOM_DOCKERFILE` | `false` | When `true`, Moose writes the Dockerfile to your project root on first build and preserves it on subsequent builds so you can customize it. |
+| `custom_dockerfile` | `MOOSE_DOCKER_CONFIG__CUSTOM_DOCKERFILE` | `false` | When `true`, Moose writes the Dockerfile to your project root (via `moose generate dockerfile` or on first `moose build --docker`) and preserves it on subsequent runs so you can customize it. |
 | `dockerfile_path` | `MOOSE_DOCKER_CONFIG__DOCKERFILE_PATH` | `"./Dockerfile"` | Path to the Dockerfile relative to the project root. Only used when `custom_dockerfile` is `true`. |
 
-## How It Works
+## Behavior
 
-### Default Behavior (`custom_dockerfile = false`)
+By default, `moose build --docker` generates a Dockerfile internally (in `.moose/packager/`), builds the Docker image(s), and cleans up. To get an editable copy, enable `custom_dockerfile` and run `moose generate dockerfile`.
 
-Running `moose build --docker` generates a Dockerfile internally (in `.moose/packager/`), builds the Docker image(s), and cleans up. The Dockerfile is never exposed for editing.
+When `custom_dockerfile = true`:
 
-### Custom Dockerfile Mode (`custom_dockerfile = true`)
-
-1. **First run** of `moose build --docker`: Moose generates a Dockerfile at `dockerfile_path` (default: `./Dockerfile` in your project root) and then builds the image.
-2. **Subsequent runs**: Moose detects the existing Dockerfile, skips generation to preserve your customizations, and builds the image from your Dockerfile.
+1. **First run**: Moose generates a Dockerfile at `dockerfile_path` — either via `moose generate dockerfile` or on the first `moose build --docker`.
+2. **Subsequent runs**: Moose detects the existing Dockerfile, skips generation to preserve your customizations, and builds from your Dockerfile.
 
 This lets you iterate on the Dockerfile — add system dependencies, configure caching, adjust build stages — while still using `moose build --docker` to build images.
 
-## Setup
+## Related CLI Commands
 
-You can enable custom Dockerfile mode in two ways:
-
-### Option 1: During Project Init
+To generate the Dockerfile without building a Docker image:
 
 ```bash
-moose init my-app typescript --custom-dockerfile
+moose generate dockerfile
 ```
 
-This sets `custom_dockerfile = true` in `moose.config.toml` automatically.
+<Callout type="warning" title="Requires Custom Dockerfile Mode">
+The `generate dockerfile` command requires `custom_dockerfile = true` in your `moose.config.toml`. If it's not enabled, the CLI will return an error with instructions on how to enable it.
+</Callout>
 
-### Option 2: Edit Config Manually
-
-Add or update the `[docker_config]` section in your `moose.config.toml`:
-
-```toml filename="moose.config.toml"
-[docker_config]
-custom_dockerfile = true
-dockerfile_path = "./Dockerfile"
-```
-
-Then run `moose build --docker` to generate the initial Dockerfile.
-
-## Architecture Flags
-
-You can target specific architectures when building:
+To build Docker images:
 
 ```bash
 # Build for both architectures (default)
@@ -73,4 +61,10 @@ moose build --docker --amd64
 
 # Build for ARM64 only
 moose build --docker --arm64
+```
+
+You can also enable custom Dockerfile mode during project initialization:
+
+```bash
+moose init my-app typescript --custom-dockerfile
 ```

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -35,7 +35,7 @@ Builds your Moose project.
 ```bash
 moose build [--docker] [--amd64] [--arm64]
 ```
-- `--docker`: Build for Docker
+- `--docker`: Generate a Dockerfile and build Docker image(s)
 - `--amd64`: Build for AMD64 architecture
 - `--arm64`: Build for ARM64 architecture
 
@@ -301,6 +301,13 @@ EOF
 **Use case:** Iterate on SQL queries in the CLI, then format and paste into your application code without manual escaping. Use `--prettify` to clean up messy one-line queries.
 
 ## Generation Commands
+
+### Generate Dockerfile
+Generate a Dockerfile for your project without building Docker images.
+```bash
+moose generate dockerfile
+```
+Requires `custom_dockerfile = true` in `moose.config.toml`. The generated Dockerfile is placed at `dockerfile_path` (default: `./Dockerfile`) and can be customized for your deployment needs.
 
 ### Generate Hash Token
 Generate authentication tokens for API access.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches CLI command routing and Docker packaging flow; behavior changes around when Docker is required and how Dockerfile generation is invoked could impact existing build workflows if assumptions about Docker availability or telemetry timing were relied upon.
> 
> **Overview**
> Adds a new `moose generate dockerfile` subcommand that writes the Dockerfile without building images, and errors with guidance unless `docker_config.custom_dockerfile = true` is enabled.
> 
> Refactors `moose build` so usage capture is initialized once (tracking `DockerCommand` vs `BuildCommand`) and awaited after the build path completes, and updates Dockerfile generation (`create_dockerfile`) to no longer depend on a `DockerClient`/Docker daemon check so it can run independently of Docker image builds.
> 
> Updates docs to describe the new command, clarify custom Dockerfile behavior/config sources, and adjust CLI reference text for `--docker`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7152bdfdb6c0adf6f92c6ece5df69fd866162f6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->