### PR TITLE
enable typescript-mcp template for boreal deploy

### DIFF
--- a/templates/typescript-mcp/template.config.toml
+++ b/templates/typescript-mcp/template.config.toml
@@ -39,7 +39,7 @@ default_sloan_telemetry = "standard"
 
 # Boreal one-click deploy configuration
 [boreal]
-enabled = false
+enabled = true
 display_name = "Chat with your App"
 short_description = "Deploy an AI chat app that can query your data"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single config-flag change affecting deployment defaults only; no runtime code or security logic changes.
> 
> **Overview**
> Enables Boreal one-click deploy for the `templates/typescript-mcp` template by switching `[boreal].enabled` from `false` to `true`. This makes Boreal run the existing setup command (`moose generate hash-token --json`) to populate `MCP_API_KEY` and `MCP_API_TOKEN` during provisioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b610f427b70536f88055b84277cbb7d132c07106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->