### PR TITLE
Document Claude Code MCP server configuration options

### DIFF
--- a/templates/typescript-mcp/README.md
+++ b/templates/typescript-mcp/README.md
@@ -122,7 +122,7 @@ You can configure MCP clients to connect to this custom MCP server:
 ### Set up MCP with Claude Code using the CLI
 
 ```bash
-claude mcp add --transport http my-clickhouse-mcp http://localhost:4000/tools --header "Authorization: Bearer <your_bearer_token>"
+claude mcp add --transport http moose-tools http://localhost:4000/tools --header "Authorization: Bearer <your_bearer_token>"
 ```
 
 ### Set up MCP with other clients using mcp.json


### PR DESCRIPTION
## Summary
Updated the Claude Code integration documentation to provide clearer guidance on connecting to the custom MCP server, including both CLI and configuration file approaches.

## Key Changes
- Restructured the "Using with Claude Code" section with two distinct configuration options
- Added **Option 1: Using the CLI** - documents the `claude mcp add` command approach
- Added **Option 2: Using mcp.json Configuration File** - provides a complete example of the JSON configuration format with proper structure and formatting
- Added clarification on where the `mcp.json` file should be located (`~/.claude/mcp.json` or project root)
- Added explicit instruction to replace the bearer token placeholder with the actual token from `moose generate hash-token`
- Improved overall readability and user guidance for both configuration methods

## Implementation Details
- The configuration file example uses the server name `moose-tools` and includes the full HTTP transport configuration with headers
- Both options reference the same endpoint (`http://localhost:4000/tools`) and authentication mechanism
- Documentation now serves users with different preferences (CLI vs. configuration file management)

https://claude.ai/code/session_01KPTF74xDkNjNxfppv8p2UH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime behavior, security, or data-handling logic is modified.
> 
> **Overview**
> Updates the `templates/typescript-mcp/README.md` MCP client setup docs by replacing the single “Using with Claude Code” section with a more general **“Setting Up MCP with Your Clients”** section.
> 
> Adds two explicit connection paths: a `claude mcp add` CLI example (renaming the server to `moose-tools`) and a full `mcp.json` configuration example, plus a note to replace `<your_bearer_token>` with the token generated by `moose generate hash-token` and wording that applies to any MCP client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44f9f4d8d641aeb2e26d0a122ee4389796f6fd57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->