### PR TITLE
Allow hyphens in ClickHouse identifiers

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/client.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/client.rs
@@ -551,6 +551,8 @@ mod tests {
         assert!(validate_clickhouse_identifier("my_table", "Table").is_ok());
         assert!(validate_clickhouse_identifier("Table123", "Table").is_ok());
         assert!(validate_clickhouse_identifier("_private", "Table").is_ok());
+        assert!(validate_clickhouse_identifier("my-table", "Table").is_ok());
+        assert!(validate_clickhouse_identifier("project-db-main-123", "Database").is_ok());
     }
 
     #[test]
@@ -562,15 +564,12 @@ mod tests {
 
     #[test]
     fn test_validate_identifier_invalid_characters() {
-        let result = validate_clickhouse_identifier("my-table", "Table");
+        let result = validate_clickhouse_identifier("my.table", "Table");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
             .contains("invalid characters"));
-
-        let result = validate_clickhouse_identifier("my.table", "Table");
-        assert!(result.is_err());
 
         let result = validate_clickhouse_identifier("my table", "Table");
         assert!(result.is_err());
@@ -588,6 +587,19 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("cannot start with a digit"));
+    }
+
+    #[test]
+    fn test_validate_identifier_starts_with_hyphen() {
+        let result = validate_clickhouse_identifier("-my-db", "Database");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot start with a hyphen"));
+
+        let result = validate_clickhouse_identifier("--", "Table");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/errors.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/errors.rs
@@ -23,15 +23,22 @@ pub enum ClickhouseError {
 ///
 /// ClickHouse identifiers (database names, table names, cluster names, etc.) must:
 /// - Be non-empty
-/// - Contain only alphanumeric characters and underscores
+/// - Contain only alphanumeric characters, underscores, and hyphens
 /// - Not start with a digit
+///
+/// Hyphens are allowed because cloud-hosted ClickHouse instances commonly use
+/// hyphenated database names (e.g. `my-project-db-main`). All SQL queries use
+/// backtick quoting (`\`name\``) to handle these safely.
 ///
 /// This prevents SQL/XML injection and ensures compatibility with ClickHouse's naming rules.
 /// Used by both the ClickHouse client and Docker utilities.
 pub fn is_valid_clickhouse_identifier(name: &str) -> bool {
     !name.is_empty()
-        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
         && !name.chars().next().unwrap().is_ascii_digit()
+        && !name.starts_with('-')
 }
 
 /// Validates that a string is a valid ClickHouse identifier, returning a typed error on failure.
@@ -51,8 +58,10 @@ pub fn validate_clickhouse_identifier(
         "cannot be empty"
     } else if name.chars().next().unwrap().is_ascii_digit() {
         "cannot start with a digit"
+    } else if name.starts_with('-') {
+        "cannot start with a hyphen"
     } else {
-        "contains invalid characters (only alphanumeric and underscore allowed)"
+        "contains invalid characters (only alphanumeric, underscore, and hyphen allowed)"
     };
 
     Err(ClickhouseError::InvalidIdentifier {

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/queries.rs
@@ -122,7 +122,7 @@ pub fn create_alias_for_table(
 
 static CREATE_TABLE_TEMPLATE: &str = r#"
 CREATE TABLE IF NOT EXISTS `{{db_name}}`.`{{table_name}}`{{#if cluster_name}}
-ON CLUSTER {{cluster_name}}{{/if}}
+ON CLUSTER `{{cluster_name}}`{{/if}}
 (
 {{#each fields}} `{{field_name}}` {{{field_type}}} {{field_nullable}}{{#if field_default}} DEFAULT {{{field_default}}}{{/if}}{{#if field_materialized}} MATERIALIZED {{{field_materialized}}}{{/if}}{{#if field_codec}} CODEC({{{field_codec}}}){{/if}}{{#if field_ttl}} TTL {{{field_ttl}}}{{/if}}{{#if field_comment}} COMMENT '{{{field_comment}}}'{{/if}}{{#unless @last}},
 {{/unless}}{{/each}}{{#if has_indexes}}, {{#each indexes}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}}
@@ -3430,7 +3430,7 @@ pub fn create_table_query(
 }
 
 pub static DROP_TABLE_TEMPLATE: &str = r#"
-DROP TABLE IF EXISTS `{{db_name}}`.`{{table_name}}`{{#if cluster_name}} ON CLUSTER {{cluster_name}} SYNC{{/if}};
+DROP TABLE IF EXISTS `{{db_name}}`.`{{table_name}}`{{#if cluster_name}} ON CLUSTER `{{cluster_name}}` SYNC{{/if}};
 "#;
 
 pub fn drop_table_query(
@@ -3451,12 +3451,12 @@ pub fn drop_table_query(
 }
 
 pub static ALTER_TABLE_MODIFY_SETTINGS_TEMPLATE: &str = r#"
-ALTER TABLE `{{db_name}}`.`{{table_name}}`{{#if cluster_name}} ON CLUSTER {{cluster_name}}{{/if}}
+ALTER TABLE `{{db_name}}`.`{{table_name}}`{{#if cluster_name}} ON CLUSTER `{{cluster_name}}`{{/if}}
 MODIFY SETTING {{settings}};
 "#;
 
 pub static ALTER_TABLE_RESET_SETTINGS_TEMPLATE: &str = r#"
-ALTER TABLE `{{db_name}}`.`{{table_name}}`{{#if cluster_name}} ON CLUSTER {{cluster_name}}{{/if}}
+ALTER TABLE `{{db_name}}`.`{{table_name}}`{{#if cluster_name}} ON CLUSTER `{{cluster_name}}`{{/if}}
 RESET SETTING {{settings}};
 "#;
 
@@ -5757,7 +5757,7 @@ ENGINE = S3Queue('s3://my-bucket/data/*.csv', NOSIGN, 'CSV')"#;
 
         // Should include ON CLUSTER clause
         assert!(
-            query.contains("ON CLUSTER test_cluster"),
+            query.contains("ON CLUSTER `test_cluster`"),
             "Query should contain ON CLUSTER clause"
         );
 
@@ -5816,7 +5816,7 @@ ENGINE = S3Queue('s3://my-bucket/data/*.csv', NOSIGN, 'CSV')"#;
 
         // Should include ON CLUSTER clause
         assert!(
-            query.contains("ON CLUSTER test_cluster"),
+            query.contains("ON CLUSTER `test_cluster`"),
             "DROP query should contain ON CLUSTER clause"
         );
 
@@ -5868,7 +5868,7 @@ ENGINE = S3Queue('s3://my-bucket/data/*.csv', NOSIGN, 'CSV')"#;
         .unwrap();
 
         assert!(
-            query.contains("ON CLUSTER test_cluster"),
+            query.contains("ON CLUSTER `test_cluster`"),
             "MODIFY SETTING query should contain ON CLUSTER clause"
         );
         assert!(query.contains("ALTER TABLE"));
@@ -5891,7 +5891,7 @@ ENGINE = S3Queue('s3://my-bucket/data/*.csv', NOSIGN, 'CSV')"#;
         };
 
         let cluster_clause = Some("test_cluster")
-            .map(|c| format!(" ON CLUSTER {}", c))
+            .map(|c| format!(" ON CLUSTER `{}`", c))
             .unwrap_or_default();
 
         let query = format!(
@@ -5900,7 +5900,7 @@ ENGINE = S3Queue('s3://my-bucket/data/*.csv', NOSIGN, 'CSV')"#;
         );
 
         assert!(
-            query.contains("ON CLUSTER test_cluster"),
+            query.contains("ON CLUSTER `test_cluster`"),
             "ADD COLUMN query should contain ON CLUSTER clause"
         );
         assert!(query.contains("ALTER TABLE"));

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -388,7 +388,7 @@ impl DockerClient {
             // Validate cluster name is a safe identifier to prevent XML injection
             if !is_valid_clickhouse_identifier(&cluster.name) {
                 warn!(
-                    "Skipping cluster '{}': cluster names must be alphanumeric with underscores only and cannot start with a digit",
+                    "Skipping cluster '{}': cluster names must be alphanumeric with underscores/hyphens only and cannot start with a digit or a hyphen",
                     cluster.name
                 );
                 continue;
@@ -941,7 +941,7 @@ mod tests {
                 name: "valid_cluster".to_string(),
             },
             crate::infrastructure::olap::clickhouse::config::ClusterConfig {
-                name: "invalid-cluster".to_string(), // Has hyphen - invalid
+                name: "invalid.cluster".to_string(), // Has dot - invalid
             },
             crate::infrastructure::olap::clickhouse::config::ClusterConfig {
                 name: "another_valid".to_string(),
@@ -955,8 +955,8 @@ mod tests {
         assert!(xml.contains("<another_valid>"));
 
         // Invalid cluster should be skipped
-        assert!(!xml.contains("invalid-cluster"));
-        assert!(!xml.contains("<invalid-cluster>"));
+        assert!(!xml.contains("invalid.cluster"));
+        assert!(!xml.contains("<invalid.cluster>"));
     }
 
     #[test]
@@ -969,7 +969,7 @@ mod tests {
         );
         project.clickhouse_config.clusters = Some(vec![
             crate::infrastructure::olap::clickhouse::config::ClusterConfig {
-                name: "invalid-name".to_string(),
+                name: "invalid.name".to_string(),
             },
             crate::infrastructure::olap::clickhouse::config::ClusterConfig {
                 name: "123invalid".to_string(),


### PR DESCRIPTION
Cloud-hosted ClickHouse instances commonly use hyphenated database
names (e.g. my-project-db-main). Relax identifier validation to
allow hyphens alongside underscores, with backtick quoting in SQL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identifier validation and DDL rendering paths; mistakes could break clustered deployments or change what names are accepted, but changes are narrow and add upfront validation/quoting to reduce injection risk.
> 
> **Overview**
> Supports hyphenated ClickHouse identifiers by relaxing `is_valid_clickhouse_identifier` / `validate_clickhouse_identifier` to allow `-` (while still rejecting leading digits and now also leading hyphens), and updates tests/error messages accordingly.
> 
> Hardens `ON CLUSTER` handling by wrapping cluster names in backticks across generated templates and ad-hoc DDL strings, and adds a preflight pass in `execute_changes` to validate all cluster names before running any SQL; Docker cluster XML generation is updated to accept hyphens and continue rejecting other unsafe characters (e.g. `.`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd9f02b88b126d0e9c7b2d35b350c203749adf46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->