### PR TITLE
Add external table mirroring in dev mode

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -86,6 +86,7 @@
 //! - Organize routines better in the file hiearchy
 //!
 
+use crate::cli::display::status::STATUS_ERROR;
 use crate::cli::local_webserver::{IntegrateChangesRequest, RouteMeta};
 use crate::cli::routines::code_generation::prompt_user_for_remote_ch_http;
 use crate::cli::routines::openapi::openapi;
@@ -120,6 +121,7 @@ use crate::framework::core::plan::InfraPlan;
 use crate::framework::core::state_storage::StateStorageBuilder;
 use crate::framework::languages::SupportedLanguages;
 use crate::infrastructure::olap::clickhouse::diff_strategy::ClickHouseTableDiffStrategy;
+use crate::infrastructure::olap::clickhouse::remote::{ClickHouseRemote, Protocol};
 use crate::infrastructure::olap::clickhouse::{check_ready, create_client};
 use crate::infrastructure::olap::OlapOperations;
 use crate::infrastructure::orchestration::temporal_client::{
@@ -355,6 +357,96 @@ async fn process_pubsub_message(
     Ok(())
 }
 
+/// Creates local tables for EXTERNALLY_MANAGED tables.
+/// Uses remote mirroring if config available, otherwise creates from local schema.
+async fn create_external_mirrors(
+    project: &Project,
+    infra_map: &InfrastructureMap,
+    remote: Option<&ClickHouseRemote>,
+) {
+    if !project.dev.externally_managed.tables.create_local_mirrors {
+        return;
+    }
+
+    match remote {
+        Some(r) => {
+            show_message!(
+                MessageType::Info,
+                Message {
+                    action: "Mirrors".to_string(),
+                    details: "Creating local mirror tables from remote...".to_string(),
+                }
+            );
+            match seed_data::create_external_table_mirrors(project, infra_map, r).await {
+                Ok(summary) if !summary.is_empty() => {
+                    let has_errors = summary.iter().any(|s| s.contains(STATUS_ERROR));
+                    show_message!(
+                        if has_errors {
+                            MessageType::Highlight
+                        } else {
+                            MessageType::Success
+                        },
+                        Message {
+                            action: "Mirrors".to_string(),
+                            details: format!("Results:\n{}", summary.join("\n")),
+                        }
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    error!("Mirror creation from remote failed: {}", e.message.details);
+                    show_message!(
+                        MessageType::Error,
+                        Message {
+                            action: "Mirrors".to_string(),
+                            details: format!("Failed: {}", e.message.details),
+                        }
+                    );
+                }
+            }
+        }
+        None => {
+            show_message!(
+                MessageType::Info,
+                Message {
+                    action: "Tables".to_string(),
+                    details: "No remote access. Creating from local schema (empty)...".to_string(),
+                }
+            );
+            match seed_data::create_external_tables_from_local_schema(project, infra_map).await {
+                Ok(summary) if !summary.is_empty() => {
+                    let has_errors = summary.iter().any(|s| s.contains(STATUS_ERROR));
+                    show_message!(
+                        if has_errors {
+                            MessageType::Highlight
+                        } else {
+                            MessageType::Success
+                        },
+                        Message {
+                            action: "Tables".to_string(),
+                            details: format!("Results:\n{}", summary.join("\n")),
+                        }
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    error!(
+                        "External table creation from local schema failed: {}",
+                        e.message.details
+                    );
+                    show_message!(
+                        MessageType::Error,
+                        Message {
+                            action: "Tables".to_string(),
+                            details: format!("Failed: {}", e.message.details),
+                        }
+                    );
+                }
+            }
+        }
+    }
+}
+
 /// Starts the application in development mode.
 /// This mode is optimized for development workflows and includes additional debugging features.
 ///
@@ -419,7 +511,22 @@ pub async fn start_development_mode(
         .values()
         .filter(|t| t.life_cycle == LifeCycle::ExternallyManaged)
         .collect();
-    if !externally_managed.is_empty() {
+    let remote_for_mirrors: Option<ClickHouseRemote> = if !externally_managed.is_empty() {
+        if !project.dev.externally_managed.tables.create_local_mirrors {
+            show_message!(
+                MessageType::Highlight,
+                Message {
+                    action: "ExternalTables".to_string(),
+                    details: format!(
+                        "Detected {} EXTERNALLY_MANAGED table(s).\n\
+                         To create local dev tables, add to moose.config.toml:\n\n\
+                         [dev.externally_managed.tables]\n\
+                         create_local_mirrors = true",
+                        externally_managed.len()
+                    ),
+                }
+            );
+        }
         show_message!(
             MessageType::Info,
             Message::new(
@@ -523,6 +630,14 @@ pub async fn start_development_mode(
                             }
                         );
                     }
+
+                    // Reuse the already-parsed config instead of re-parsing the URL
+                    Some(ClickHouseRemote::from_config(
+                        &client.config,
+                        Protocol::Http,
+                    ))
+                } else {
+                    None
                 }
             }
             Err(e) => {
@@ -533,9 +648,12 @@ pub async fn start_development_mode(
                         details: format!("failed to fetch stored remote URL. {e:?}")
                     }
                 );
+                None
             }
-        };
-    }
+        }
+    } else {
+        None
+    };
 
     maybe_warmup_connections(&project, &redis_client).await;
 
@@ -559,6 +677,14 @@ pub async fn start_development_mode(
     .await?;
 
     let process_registry = Arc::new(RwLock::new(process_registry));
+
+    // Create mirrors after infra is set up (databases exist)
+    create_external_mirrors(
+        &project,
+        &plan.target_infra_map,
+        remote_for_mirrors.as_ref(),
+    )
+    .await;
 
     let openapi_file = openapi(&project, &plan.target_infra_map).await?;
 

--- a/apps/framework-cli/src/cli/routines/seed_data.rs
+++ b/apps/framework-cli/src/cli/routines/seed_data.rs
@@ -1,18 +1,22 @@
 use crate::cli::commands::SeedSubcommands;
 use crate::cli::display;
+use crate::cli::display::status::{format_error, format_success, format_warning};
 use crate::cli::display::{with_spinner_completion_async, Message, MessageType};
 use crate::cli::routines::RoutineFailure;
 use crate::cli::routines::RoutineSuccess;
+use crate::framework::core::infrastructure::table::Table;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
 use crate::infrastructure::olap::clickhouse::client::ClickHouseClient;
 use crate::infrastructure::olap::clickhouse::config::{
     parse_clickhouse_connection_string, ClickHouseConfig,
 };
+use crate::infrastructure::olap::clickhouse::mapper::std_table_to_clickhouse_table;
+use crate::infrastructure::olap::clickhouse::queries::create_table_query;
+use crate::infrastructure::olap::clickhouse::remote::ClickHouseRemote;
 use crate::project::Project;
 use crate::utilities::constants::KEY_REMOTE_CLICKHOUSE_URL;
 use crate::utilities::keyring::{KeyringSecretRepository, SecretRepository};
 
-use crate::framework::core::infrastructure::table::Table;
 use std::cmp::min;
 use std::collections::HashSet;
 use tracing::{debug, info, warn};
@@ -632,6 +636,272 @@ pub async fn seed_clickhouse_tables(
 
     info!("ClickHouse seeding completed");
     Ok(summary)
+}
+
+// =============================================================================
+// External Table Mirroring Functions
+// =============================================================================
+
+/// Context for mirror table operations
+struct MirrorContext<'a> {
+    local_client: &'a ClickHouseClient,
+    local_db: String,
+    remote: &'a ClickHouseRemote,
+    sample_size: usize,
+    refresh_on_startup: bool,
+}
+
+/// Orchestrates create/drop/seed for a single mirror table.
+///
+/// Returns a status string using format_success/warning/error.
+async fn create_single_mirror(ctx: &MirrorContext<'_>, table: &Table) -> String {
+    let table_name = &table.name;
+    let remote_db = table.database.as_deref().unwrap_or(&ctx.remote.database);
+
+    // Check if table already exists
+    let exists = match ctx
+        .local_client
+        .table_exists(&ctx.local_db, table_name)
+        .await
+    {
+        Ok(exists) => exists,
+        Err(e) => {
+            return format_error(table_name, &format!("failed to check existence: {}", e));
+        }
+    };
+
+    // Skip if exists and not refreshing
+    if exists && !ctx.refresh_on_startup {
+        return format_warning(table_name, "already exists (skipped)");
+    }
+
+    // Drop existing table if refreshing
+    if exists {
+        debug!("Dropping existing mirror table: {}", table_name);
+        if let Err(e) = ctx
+            .local_client
+            .drop_table_if_exists(&ctx.local_db, table_name)
+            .await
+        {
+            return format_error(table_name, &format!("failed to drop: {}", e));
+        }
+    }
+
+    // Create schema from local table definition (avoids LIMIT 0 empty-response issues with remote)
+    let ch_table = match std_table_to_clickhouse_table(table) {
+        Ok(t) => t,
+        Err(e) => {
+            return format_error(table_name, &format!("failed to convert schema: {}", e));
+        }
+    };
+
+    let create_sql = match create_table_query(&ctx.local_db, ch_table, true) {
+        Ok(sql) => sql,
+        Err(e) => {
+            return format_error(table_name, &format!("failed to generate DDL: {}", e));
+        }
+    };
+
+    if let Err(e) = ctx.local_client.execute_sql(&create_sql).await {
+        return format_error(table_name, &format!("failed to create mirror table: {}", e));
+    }
+
+    // Seed data if sample_size > 0
+    if ctx.sample_size > 0 {
+        let columns: Vec<String> = table.columns.iter().map(|c| c.name.clone()).collect();
+        match ctx
+            .local_client
+            .insert_from_remote(
+                &ctx.local_db,
+                table_name,
+                ctx.remote,
+                remote_db,
+                ctx.sample_size,
+                &columns,
+            )
+            .await
+        {
+            Ok(()) => format_success(
+                table_name,
+                &format!("mirrored (limit {} rows)", ctx.sample_size),
+            ),
+            Err(e) => format_error(
+                table_name,
+                &format!("schema created but seeding failed: {}", e),
+            ),
+        }
+    } else {
+        format_success(table_name, "mirrored (schema only)")
+    }
+}
+
+/// Creates local mirror tables for EXTERNALLY_MANAGED tables.
+///
+/// Uses HTTP-based queries via `ClickHouseRemote` to fetch schema and sample data
+/// from a remote ClickHouse instance. Mirror tables use the engine and ordering
+/// defined in the local table schema.
+///
+/// # Arguments
+/// * `project` - The current project configuration
+/// * `infra_map` - The infrastructure map containing table definitions
+/// * `remote` - The remote ClickHouse connection to mirror from
+///
+/// # Returns
+/// A vector of status messages for each table processed
+pub async fn create_external_table_mirrors(
+    project: &Project,
+    infra_map: &InfrastructureMap,
+    remote: &ClickHouseRemote,
+) -> Result<Vec<String>, RoutineFailure> {
+    let local_client = ClickHouseClient::new(&project.clickhouse_config).map_err(|e| {
+        RoutineFailure::error(Message::new(
+            "CreateMirrors".to_string(),
+            format!("Failed to create local ClickHouse client: {}", e),
+        ))
+    })?;
+
+    let mirrorable_tables = infra_map.get_mirrorable_external_tables();
+    if mirrorable_tables.is_empty() {
+        debug!("No mirrorable external tables found");
+        return Ok(vec![]);
+    }
+
+    let config = &project.dev.externally_managed.tables;
+    let ctx = MirrorContext {
+        local_client: &local_client,
+        local_db: local_client.config().db_name.clone(),
+        remote,
+        sample_size: config.sample_size,
+        refresh_on_startup: config.refresh_on_startup,
+    };
+
+    info!(
+        "Mirroring {} external tables (sample_size={}, refresh={})",
+        mirrorable_tables.len(),
+        config.sample_size,
+        config.refresh_on_startup
+    );
+
+    let mut results = Vec::with_capacity(mirrorable_tables.len());
+    for table in mirrorable_tables {
+        let status = create_single_mirror(&ctx, table).await;
+        results.push(status);
+    }
+
+    Ok(results)
+}
+
+/// Creates empty local tables for EXTERNALLY_MANAGED tables using local schema definitions.
+///
+/// This is a fallback for when no remote ClickHouse is configured. Tables are created
+/// using the schema from user code, but no data is seeded.
+///
+/// # Arguments
+/// * `project` - The current project configuration
+/// * `infra_map` - The infrastructure map containing table definitions
+///
+/// # Returns
+/// A vector of status messages for each table processed
+pub async fn create_external_tables_from_local_schema(
+    project: &Project,
+    infra_map: &InfrastructureMap,
+) -> Result<Vec<String>, RoutineFailure> {
+    let local_client = ClickHouseClient::new(&project.clickhouse_config).map_err(|e| {
+        RoutineFailure::error(Message::new(
+            "CreateExternalTables".to_string(),
+            format!("Failed to create local ClickHouse client: {}", e),
+        ))
+    })?;
+
+    let mirrorable_tables = infra_map.get_mirrorable_external_tables();
+    if mirrorable_tables.is_empty() {
+        debug!("No mirrorable external tables found");
+        return Ok(vec![]);
+    }
+
+    let local_db = local_client.config().db_name.clone();
+    let refresh_on_startup = project.dev.externally_managed.tables.refresh_on_startup;
+    let is_dev = !project.is_production;
+
+    info!(
+        "Creating {} external tables from local schema (refresh={})",
+        mirrorable_tables.len(),
+        refresh_on_startup
+    );
+
+    let mut results = Vec::with_capacity(mirrorable_tables.len());
+
+    for table in mirrorable_tables {
+        // Check if table already exists
+        let exists = match local_client.table_exists(&local_db, &table.name).await {
+            Ok(exists) => exists,
+            Err(e) => {
+                results.push(format_error(
+                    &table.name,
+                    &format!("failed to check existence: {}", e),
+                ));
+                continue;
+            }
+        };
+
+        // Skip if exists and not refreshing
+        if exists && !refresh_on_startup {
+            results.push(format_warning(&table.name, "already exists (skipped)"));
+            continue;
+        }
+
+        // Drop existing table if refreshing
+        if exists {
+            debug!("Dropping existing table: {}", table.name);
+            if let Err(e) = local_client
+                .drop_table_if_exists(&local_db, &table.name)
+                .await
+            {
+                results.push(format_error(&table.name, &format!("failed to drop: {}", e)));
+                continue;
+            }
+        }
+
+        // Convert to ClickHouse table and generate DDL
+        let ch_table = match std_table_to_clickhouse_table(table) {
+            Ok(t) => t,
+            Err(e) => {
+                results.push(format_error(
+                    &table.name,
+                    &format!("failed to convert schema: {}", e),
+                ));
+                continue;
+            }
+        };
+
+        let create_sql = match create_table_query(&local_db, ch_table, is_dev) {
+            Ok(sql) => sql,
+            Err(e) => {
+                results.push(format_error(
+                    &table.name,
+                    &format!("failed to generate DDL: {}", e),
+                ));
+                continue;
+            }
+        };
+
+        // Execute the create table query
+        debug!("Creating table from local schema: {}", table.name);
+        if let Err(e) = local_client.execute_sql(&create_sql).await {
+            results.push(format_error(
+                &table.name,
+                &format!("failed to create: {}", e),
+            ));
+            continue;
+        }
+
+        results.push(format_success(
+            &table.name,
+            "created (empty, from local schema)",
+        ));
+    }
+
+    Ok(results)
 }
 
 #[cfg(test)]

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2981,6 +2981,22 @@ impl InfrastructureMap {
         self.tables.values().find(|table| table.name == name)
     }
 
+    /// Returns EXTERNALLY_MANAGED tables that support SELECT operations
+    ///
+    /// Filters tables to find those marked as EXTERNALLY_MANAGED and have engines
+    /// that support SELECT queries (excludes Kafka, S3Queue which are write-only).
+    /// Useful for operations like mirroring, seeding, and creating local copies.
+    pub fn get_mirrorable_external_tables(&self) -> Vec<&Table> {
+        let mut tables: Vec<&Table> = self
+            .tables
+            .values()
+            .filter(|t| t.life_cycle == LifeCycle::ExternallyManaged)
+            .filter(|t| t.engine.supports_select())
+            .collect();
+        tables.sort_by_key(|t| &t.name);
+        tables
+    }
+
     /// Masks sensitive credentials before exporting to JSON migration files.
     pub fn mask_credentials_for_json_export(mut self) -> Self {
         for table in self.tables.values_mut() {
@@ -7865,5 +7881,142 @@ mod version_tests {
 
         let json = serde_json::to_string(&map).unwrap();
         assert!(json.contains("\"moose_version\":\"1.2.3\""));
+    }
+}
+
+#[cfg(test)]
+mod mirrorable_external_tables_tests {
+    use super::*;
+    use crate::framework::core::infrastructure::table::{Column, ColumnType, IntType};
+    use crate::framework::versions::Version;
+    use crate::infrastructure::olap::clickhouse::config::DEFAULT_DATABASE_NAME;
+
+    #[test]
+    fn test_get_mirrorable_external_tables() {
+        let mut map = InfrastructureMap::default();
+
+        // 1. ExternallyManaged table with MergeTree engine (supports SELECT) - SHOULD be returned
+        let external_mergetree = Table {
+            name: "external_mergetree".to_string(),
+            engine: ClickhouseEngine::MergeTree,
+            columns: vec![Column {
+                name: "id".to_string(),
+                data_type: ColumnType::Int(IntType::Int64),
+                required: true,
+                unique: false,
+                primary_key: true,
+                default: None,
+                annotations: vec![],
+                comment: None,
+                ttl: None,
+                codec: None,
+                materialized: None,
+            }],
+            order_by: OrderBy::Fields(vec!["id".to_string()]),
+            partition_by: None,
+            sample_by: None,
+            version: Some(Version::from_string("1.0".to_string())),
+            source_primitive: PrimitiveSignature {
+                name: "test".to_string(),
+                primitive_type: PrimitiveTypes::DataModel,
+            },
+            metadata: None,
+            life_cycle: LifeCycle::ExternallyManaged,
+            engine_params_hash: None,
+            table_settings_hash: None,
+            table_settings: None,
+            indexes: vec![],
+            database: None,
+            table_ttl_setting: None,
+            cluster_name: None,
+            primary_key_expression: None,
+        };
+
+        // 2. ExternallyManaged table with Kafka engine (write-only) - should NOT be returned
+        let external_kafka = Table {
+            name: "external_kafka".to_string(),
+            engine: ClickhouseEngine::Kafka {
+                broker_list: "localhost:9092".to_string(),
+                topic_list: "test_topic".to_string(),
+                group_name: "test_group".to_string(),
+                format: "JSONEachRow".to_string(),
+            },
+            columns: vec![Column {
+                name: "id".to_string(),
+                data_type: ColumnType::Int(IntType::Int64),
+                required: true,
+                unique: false,
+                primary_key: false,
+                default: None,
+                annotations: vec![],
+                comment: None,
+                ttl: None,
+                codec: None,
+                materialized: None,
+            }],
+            order_by: OrderBy::Fields(vec![]),
+            partition_by: None,
+            sample_by: None,
+            version: Some(Version::from_string("1.0".to_string())),
+            source_primitive: PrimitiveSignature {
+                name: "test".to_string(),
+                primitive_type: PrimitiveTypes::DataModel,
+            },
+            metadata: None,
+            life_cycle: LifeCycle::ExternallyManaged,
+            engine_params_hash: None,
+            table_settings_hash: None,
+            table_settings: None,
+            indexes: vec![],
+            database: None,
+            table_ttl_setting: None,
+            cluster_name: None,
+            primary_key_expression: None,
+        };
+
+        // 3. FullyManaged table with MergeTree (supports SELECT but wrong lifecycle) - should NOT be returned
+        let mut managed_mergetree = external_mergetree.clone();
+        managed_mergetree.name = "managed_mergetree".to_string();
+        managed_mergetree.life_cycle = LifeCycle::FullyManaged;
+
+        // Insert tables into the map
+        map.tables.insert(
+            external_mergetree.id(DEFAULT_DATABASE_NAME),
+            external_mergetree.clone(),
+        );
+        map.tables.insert(
+            external_kafka.id(DEFAULT_DATABASE_NAME),
+            external_kafka.clone(),
+        );
+        map.tables.insert(
+            managed_mergetree.id(DEFAULT_DATABASE_NAME),
+            managed_mergetree.clone(),
+        );
+
+        // Call the method under test
+        let mirrorable = map.get_mirrorable_external_tables();
+
+        // Assert: should only return the ExternallyManaged MergeTree table
+        assert_eq!(
+            mirrorable.len(),
+            1,
+            "Should return exactly 1 mirrorable table"
+        );
+        assert_eq!(
+            mirrorable[0].name, "external_mergetree",
+            "Should return the ExternallyManaged MergeTree table"
+        );
+
+        // Verify the Kafka table (write-only engine) is NOT included
+        assert!(
+            !mirrorable.iter().any(|t| t.name == "external_kafka"),
+            "Kafka table should not be mirrorable (write-only engine)"
+        );
+
+        // Verify the FullyManaged table is NOT included
+        assert!(
+            !mirrorable.iter().any(|t| t.name == "managed_mergetree"),
+            "FullyManaged table should not be mirrorable (wrong lifecycle)"
+        );
     }
 }


### PR DESCRIPTION
When [dev.externally_managed.tables] create_local_mirrors = true,
automatically create local MergeTree copies of EXTERNALLY_MANAGED
tables during moose dev startup. Supports remote schema mirroring
with optional sample data seeding, or fallback to local schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically creates/drops and optionally seeds ClickHouse tables during `moose dev` startup, which can be disruptive if misconfigured and depends on remote connectivity/credentials, but is gated behind dev-only config.
> 
> **Overview**
> Adds an opt-in dev-mode startup step to **create local mirror tables for `EXTERNALLY_MANAGED` ClickHouse tables** when `dev.externally_managed.tables.create_local_mirrors = true`, running after initial infra setup.
> 
> If a remote ClickHouse URL is available, the CLI reuses the parsed remote config to create mirror tables from local schema and optionally seed a configurable row sample via a new `ClickHouseClient::insert_from_remote` (HTTP `url()` JSONEachRow) path; otherwise it falls back to creating empty tables from the local schema. Includes a new `InfrastructureMap::get_mirrorable_external_tables` filter (excludes non-`SELECT` engines) plus tests, and improved user messaging when external tables are detected but mirroring is not enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90120f60933949ea19863b13235130e059606b06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->