### PR TITLE
Add documentation for externally managed tables in dev

### DIFF
--- a/apps/framework-cli/src/cli/routines/code_generation.rs
+++ b/apps/framework-cli/src/cli/routines/code_generation.rs
@@ -509,7 +509,7 @@ pub async fn db_pull_from_remote(
 /// Shared implementation for db pull operations.
 ///
 /// Introspects the remote ClickHouse, finds external/unknown tables,
-/// regenerates the external models file, and creates a git commit.
+/// and regenerates the external models file.
 async fn db_pull_with_client(
     client: ConfiguredDBClient,
     db: &str,
@@ -592,31 +592,6 @@ async fn db_pull_with_client(
             details: format!("refreshed ({} table(s))", tables_for_external_file.len()),
         }
     );
-
-    match create_code_generation_commit(
-        ".".as_ref(),
-        "chore(cli): commit db pull external model refresh",
-    ) {
-        Ok(Some(oid)) => {
-            show_message!(
-                MessageType::Info,
-                Message {
-                    action: "Git".to_string(),
-                    details: format!("created commit {}", &oid.to_string()[..7]),
-                }
-            );
-        }
-        Ok(None) => {}
-        Err(e) => {
-            return Err(RoutineFailure::new(
-                Message::new(
-                    "Failure".to_string(),
-                    "creating code generation commit".to_string(),
-                ),
-                e,
-            ));
-        }
-    }
 
     Ok(())
 }

--- a/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
@@ -96,6 +96,59 @@ services:
 **Do not** use this file to configure Moose-managed services (ClickHouse, Redpanda, Redis, Temporal). Use `moose.config.toml` for those components to avoid configuration conflicts.
 </Callout>
 
+## Externally Managed Tables
+
+When working with tables marked as `EXTERNALLY_MANAGED` (tables that exist in a production database but are managed outside Moose), you can configure the dev environment to create local mirror tables for development and testing.
+
+### Configuration
+
+```toml
+[dev.externally_managed.tables]
+# Create local mirror tables for EXTERNALLY_MANAGED tables
+create_local_mirrors = true
+
+# Number of sample rows to seed (0 = schema only, no data)
+sample_size = 1000
+
+# Re-create tables on every dev server start
+refresh_on_startup = false
+```
+
+| Key | Type | Default | Description |
+|:----|:-----|:--------|:------------|
+| `create_local_mirrors` | Boolean | `false` | When `true`, creates local tables matching the schema of externally managed tables. |
+| `sample_size` | Integer | `0` | Number of rows to copy from the remote database. Set to `0` to create empty tables (schema only). |
+| `refresh_on_startup` | Boolean | `false` | When `true`, drops and recreates mirror tables on each `moose dev` start. |
+
+<Callout type="info" title="Remote Credentials">
+If you have a remote ClickHouse URL configured, Moose will mirror table schemas and sample data from the remote database. Without remote access, tables are created using local schema definitions (empty).
+</Callout>
+
+### Remote ClickHouse Connection
+
+To mirror data from a production or staging database, configure a remote ClickHouse connection:
+
+```toml
+[dev.remote_clickhouse]
+host = "your-clickhouse-host.example.com"
+port = 8443
+database = "production_db"
+use_ssl = true
+protocol = "http"
+```
+
+| Key | Type | Default | Description |
+|:----|:-----|:--------|:------------|
+| `host` | String | - | Hostname of the remote ClickHouse server. |
+| `port` | Integer | `8443` (SSL) / `8123` (non-SSL) | HTTP port for the remote server. |
+| `database` | String | - | Default database to query on the remote server. |
+| `use_ssl` | Boolean | `true` | Whether to use TLS (HTTPS) for connections. |
+| `protocol` | String | `http` | ClickHouse interface protocol — `http` selects the HTTP interface (vs native). TLS is controlled separately by `use_ssl`. |
+
+<Callout type="warning" title="Credential Storage">
+Credentials (username/password) are **not** stored in `moose.config.toml`. On first run, Moose will prompt for credentials and store them securely in your OS keychain. You can also set `MOOSE_REMOTE_CLICKHOUSE_USER` and `MOOSE_REMOTE_CLICKHOUSE_PASSWORD` environment variables.
+</Callout>
+
 ## Networking Reference
 
 Reference for default ports and URLs used by the Moose Runtime in development mode.

--- a/apps/framework-docs-v2/content/moosestack/dev/cdc-managed-tables.mdx
+++ b/apps/framework-docs-v2/content/moosestack/dev/cdc-managed-tables.mdx
@@ -1,0 +1,565 @@
+---
+title: Building on CDC-Enabled ClickHouse
+description: Get started with Moose when your ClickHouse database has tables managed by CDC pipelines like ClickPipes, PeerDB, or Debezium
+order: 2
+---
+
+import { Callout, LanguageTabs, LanguageTabContent } from "@/components/mdx";
+
+# Building on CDC-Enabled ClickHouse
+
+This guide walks you through setting up a Moose project on top of an existing ClickHouse database that uses CDC (Change Data Capture) pipelines—ClickPipes, PeerDB, Debezium, or similar tools—to replicate data from external sources.
+
+## What You'll Learn
+
+By the end of this guide, you'll understand how to:
+
+1. **Bootstrap a Moose project** from an existing ClickHouse database
+2. **Work with externally managed tables** that CDC services control
+3. **Develop locally** with realistic sample data from production
+4. **Keep your models in sync** as upstream schemas evolve
+
+## Prerequisites
+
+- A ClickHouse database with CDC-replicated tables
+- Your ClickHouse connection URL (e.g., `https://user:pass@host:8443/database`)
+- Node.js 20+ (TypeScript) or Python 3.10+ (Python)
+
+---
+
+## Step 1: Initialize Your Project
+
+The fastest way to get started is with `moose init --from-remote`. This single command:
+
+- Creates a new Moose project
+- Connects to your ClickHouse and introspects all tables
+- Generates type-safe models for every table
+- Automatically detects PeerDB-managed tables (via `_peerdb_*` columns) and marks them as `EXTERNALLY_MANAGED`. Tables managed by other CDC tools (ClickPipes, Debezium, etc.) can be manually marked with `lifeCycle: LifeCycle.EXTERNALLY_MANAGED`
+- Saves your connection config to `moose.config.toml`
+- Stores credentials securely in your OS keychain
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```bash
+moose init my-analytics-app --from-remote "https://user:pass@host:8443/database" --language typescript
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```bash
+moose init my-analytics-app --from-remote "https://user:pass@host:8443/database" --language python
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+You'll see output like:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```
+        Created my-analytics-app from typescript-empty template
+        Success Project created at my-analytics-app
+     Connecting to remote ClickHouse...
+  Introspecting tables in 'database'...
+         Config Wrote [dev.remote_clickhouse] to moose.config.toml (host: host, database: database)
+       Keychain Stored credentials securely for project 'my-analytics-app'
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```
+        Created my-analytics-app from python-empty template
+        Success Project created at my-analytics-app
+     Connecting to remote ClickHouse...
+  Introspecting tables in 'database'...
+         Config Wrote [dev.remote_clickhouse] to moose.config.toml (host: host, database: database)
+       Keychain Stored credentials securely for project 'my-analytics-app'
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+<Callout type="info" title="What About Interactive Setup?">
+If you don't want to put credentials in the command, run without the URL:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```bash
+moose init my-analytics-app --from-remote --language typescript
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```bash
+moose init my-analytics-app --from-remote --language python
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+Moose will prompt you for host, username, password, and database interactively.
+</Callout>
+
+After initialization, navigate into your project and install dependencies:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```bash
+cd my-analytics-app
+npm install
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```bash
+cd my-analytics-app
+pip install -e .
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+---
+
+## Step 2: Understanding Externally Managed Tables
+
+Open your project and look at the generated files. You'll find your tables split into two categories:
+
+### Regular Tables (in your main file)
+
+Tables that Moose fully manages—you control the schema, and Moose creates/migrates them:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```ts filename="app/index.ts"
+import { OlapTable } from "@514labs/moose-lib";
+
+export interface analytics_events {
+  id: string;
+  event_type: string;
+  timestamp: string;
+}
+
+export const AnalyticsEventsTable = new OlapTable<analytics_events>("analytics_events", {
+  orderByFields: ["timestamp", "id"],
+});
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```py filename="app/main.py"
+from datetime import datetime
+from pydantic import BaseModel
+from moose_lib import OlapTable, OlapConfig
+
+class AnalyticsEvents(BaseModel):
+    id: str
+    event_type: str
+    timestamp: datetime
+
+analytics_events_table = OlapTable[AnalyticsEvents]("analytics_events", OlapConfig(
+    order_by_fields=["timestamp", "id"],
+))
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+### Externally Managed Tables (in a separate file)
+
+Tables where an external process (your CDC pipeline) owns the schema. Moose generates these in a dedicated file:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```ts filename="app/externalModels.ts"
+// AUTO-GENERATED FILE. DO NOT EDIT.
+// This file will be replaced when you run `moose db pull`.
+
+import typia from "typia";
+import { OlapTable, LifeCycle, ClickHouseEngines } from "@514labs/moose-lib";
+
+export interface users {
+  id: string & typia.tags.Format<"uuid">;
+  email: string;
+  name: string;
+  created_at: string & typia.tags.Format<"date-time">;
+  // PeerDB metadata columns (added by CDC)
+  _peerdb_synced_at: string & typia.tags.Format<"date-time">;
+  _peerdb_is_deleted: number;
+  _peerdb_version: number;
+}
+
+export const UsersTable = new OlapTable<users>("users", {
+  orderByFields: ["id"],
+  engine: ClickHouseEngines.ReplacingMergeTree,
+  ver: "_peerdb_version",
+  lifeCycle: LifeCycle.EXTERNALLY_MANAGED,  // <-- Key difference
+});
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```py filename="app/external_models.py"
+# AUTO-GENERATED FILE. DO NOT EDIT.
+# This file will be replaced when you run `moose db pull`.
+
+from datetime import datetime
+from pydantic import BaseModel
+from moose_lib import OlapTable, OlapConfig, LifeCycle, ReplacingMergeTreeEngine
+
+class Users(BaseModel):
+    id: str
+    email: str
+    name: str
+    created_at: datetime
+    # PeerDB metadata columns (added by CDC)
+    _peerdb_synced_at: datetime
+    _peerdb_is_deleted: int
+    _peerdb_version: int
+
+users_table = OlapTable[Users]("users", OlapConfig(
+    order_by_fields=["id"],
+    engine=ReplacingMergeTreeEngine(ver="_peerdb_version"),
+    life_cycle=LifeCycle.EXTERNALLY_MANAGED,  # <-- Key difference
+))
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+### What Does `EXTERNALLY_MANAGED` Mean?
+
+The `lifeCycle: LifeCycle.EXTERNALLY_MANAGED` setting tells Moose:
+
+| Moose Behavior | Regular Tables | Externally Managed |
+|:---------------|:---------------|:-------------------|
+| **Creates table in production** | Yes | No |
+| **Runs migrations** | Yes | No |
+| **Generates type-safe models** | Yes | Yes |
+| **Allows building views/APIs on top** | Yes | Yes |
+| **You edit the schema** | Yes | No (regenerated by `db pull`) |
+
+In short: Moose gives you all the developer experience benefits (types, autocomplete, views, APIs) without touching the tables your CDC pipeline owns.
+
+<Callout type="warning" title="Don't Edit External Models Directly">
+The `externalModels.ts` / `external_models.py` file is regenerated every time you run `moose db pull`. Any manual changes will be overwritten. If you need to customize how a table is modeled, move it to your main file and remove `EXTERNALLY_MANAGED`.
+</Callout>
+
+---
+
+## Step 3: Local Development Setup
+
+Now let's configure how Moose handles these external tables during local development. Open your `moose.config.toml`:
+
+```toml filename="moose.config.toml"
+# This was auto-generated by moose init --from-remote
+[dev.remote_clickhouse]
+host = "your-clickhouse-host.example.com"
+port = 8443
+database = "production_db"
+use_ssl = true
+protocol = "http"
+```
+
+### Creating Local Mirror Tables
+
+When you run `moose dev`, Moose creates the schema for externally managed tables in your local ClickHouse, but they start out empty. To populate them with sample data from your remote ClickHouse for local development, enable local mirrors:
+
+```toml filename="moose.config.toml"
+[dev.externally_managed.tables]
+# Create local copies of external tables
+create_local_mirrors = true
+
+# Seed with sample data from remote (0 = empty tables)
+sample_size = 1000
+
+# Re-seed on every moose dev start (false = only if missing)
+refresh_on_startup = false
+```
+
+### Configuration Options Explained
+
+| Option | Default | Description |
+|:-------|:--------|:------------|
+| `create_local_mirrors` | `false` | When `true`, Moose creates local tables matching your external table schemas |
+| `sample_size` | `0` | Number of rows to copy from remote for each table. Set to `0` for schema-only (empty tables) |
+| `refresh_on_startup` | `false` | When `true`, drops and recreates mirrors on every `moose dev` start. When `false`, only creates if missing |
+
+### When Does Seeding Happen?
+
+Understanding when data is pulled is important for your workflow:
+
+| Scenario | What Happens |
+|:---------|:-------------|
+| **First `moose dev` run** | Mirror tables created, `sample_size` rows seeded from remote |
+| **Subsequent runs (`refresh_on_startup = false`)** | Nothing—existing local data preserved |
+| **Subsequent runs (`refresh_on_startup = true`)** | Tables dropped, recreated, and reseeded |
+| **Remote unreachable** | Tables created from local model definitions, no data seeded |
+
+### Materialized Views and Sample Data
+
+Here's something important to understand: **Materialized Views only process new data as it arrives**.
+
+In production, your CDC pipeline continuously inserts data, which triggers your materialized views. But locally, you have static seeded data—the MV won't retroactively process it.
+
+**Solutions for local MV development:**
+
+1. **Seed enough data** - Set `sample_size` high enough to have meaningful test data in your base tables
+
+2. **Use `refresh_on_startup = true`** - This re-inserts data on each startup, triggering MVs (but slower startup)
+
+3. **Manually trigger with `moose seed`** - Insert test data while `moose dev` is running (requires the local dev server to be up):
+   ```bash
+   moose seed clickhouse --limit 100
+   ```
+
+4. **Test MVs with direct inserts** - During development, insert test rows manually to trigger MV logic
+
+<Callout type="info" title="Production Behavior">
+In production, this isn't an issue—CDC continuously streams data, and your MVs process it in real-time.
+</Callout>
+
+---
+
+## Step 4: Running Local Development
+
+With your config set up, start the dev server:
+
+```bash
+moose dev
+```
+
+### First Run with Credentials
+
+If credentials aren't in your keychain (e.g., you manually edited the config), Moose prompts you:
+
+```
+Credentials Remote ClickHouse credentials required:
+            Host:     your-clickhouse-host.example.com
+            Database: production_db
+
+Enter username (default: default)
+> your_username
+
+Enter password
+> ********
+
+Keychain Stored credentials securely for project 'my-analytics-app'
+```
+
+Credentials are stored in your OS keychain and reused automatically on subsequent runs—no additional configuration needed.
+
+### What Happens on Startup
+
+1. **Local infrastructure starts** — Docker containers for ClickHouse, Redpanda, etc.
+2. **External tables detected** — credentials resolved from OS keychain (you'll be prompted if missing)
+3. **Remote schema compared** — local mirrors created if `create_local_mirrors = true`
+4. **Data seeded** (if `sample_size > 0` and remote is reachable)
+5. **Dev server starts** at `http://localhost:4000`
+
+### Developing Locally
+
+Now you can build on top of your CDC data:
+
+- **Create views** that aggregate or transform external table data
+- **Build APIs** that query across managed and external tables
+- **Test queries** against realistic sample data
+- **Iterate quickly** with hot-reload—no production impact
+
+---
+
+## Step 5: Syncing Schema Changes
+
+CDC pipelines evolve. Your DBA adds columns, the CDC service updates metadata fields, or new tables appear. When this happens, your local models need to sync.
+
+### Manual Sync
+
+Run `moose db pull` to refresh your external models:
+
+```bash
+moose db pull
+```
+
+This:
+- Connects to your remote ClickHouse (using saved credentials)
+- Introspects current schemas for all externally managed tables
+- Regenerates `externalModels.ts` / `external_models.py`
+- Adds any new tables that appeared in the remote database
+
+### Example: A New Column Appears
+
+Say your CDC pipeline starts syncing a new `phone` column to the `users` table:
+
+```
+     Connecting to remote ClickHouse...
+  Introspecting remote tables...
+External models refreshed (3 table(s))
+```
+
+Your external models file now includes the new column:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```ts filename="app/externalModels.ts"
+export interface users {
+  id: string;
+  email: string;
+  name: string;
+  phone: string;  // <-- New column!
+  created_at: string;
+  // ...
+}
+```
+
+TypeScript immediately catches any code that now needs updating.
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```py filename="app/external_models.py"
+class Users(BaseModel):
+    id: str
+    email: str
+    name: str
+    phone: str  # <-- New column!
+    created_at: datetime
+    # ...
+```
+
+Pydantic will validate data against the updated schema automatically.
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+### Automatic Sync on Dev Start
+
+For active development where schemas change frequently, auto-sync on startup:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```toml filename="moose.config.toml"
+[http_server_config]
+on_first_start_script = "moose db pull"
+
+[watcher_config]
+# Prevent reload loop from generated file changes
+ignore_patterns = ["app/externalModels.ts"]
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```toml filename="moose.config.toml"
+[http_server_config]
+on_first_start_script = "moose db pull"
+
+[watcher_config]
+# Prevent reload loop from generated file changes
+ignore_patterns = ["app/external_models.py"]
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+Now every `moose dev` starts by pulling the latest schemas.
+
+---
+
+## Complete Configuration Reference
+
+Here's a full `moose.config.toml` for a CDC-based project:
+
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+
+```toml filename="moose.config.toml"
+language = "typescript"
+
+# Remote ClickHouse connection (auto-generated by moose init --from-remote)
+[dev.remote_clickhouse]
+host = "abc123.us-east-1.aws.clickhouse.cloud"
+port = 8443
+database = "production"
+use_ssl = true
+protocol = "http"
+
+# Local development with external tables
+[dev.externally_managed.tables]
+create_local_mirrors = true
+sample_size = 500
+refresh_on_startup = false
+
+# Auto-sync schemas on startup
+[http_server_config]
+on_first_start_script = "moose db pull"
+
+# Don't trigger reloads on generated files
+[watcher_config]
+ignore_patterns = ["app/externalModels.ts"]
+```
+
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+
+```toml filename="moose.config.toml"
+language = "python"
+
+# Remote ClickHouse connection (auto-generated by moose init --from-remote)
+[dev.remote_clickhouse]
+host = "abc123.us-east-1.aws.clickhouse.cloud"
+port = 8443
+database = "production"
+use_ssl = true
+protocol = "http"
+
+# Local development with external tables
+[dev.externally_managed.tables]
+create_local_mirrors = true
+sample_size = 500
+refresh_on_startup = false
+
+# Auto-sync schemas on startup
+[http_server_config]
+on_first_start_script = "moose db pull"
+
+# Don't trigger reloads on generated files
+[watcher_config]
+ignore_patterns = ["app/external_models.py"]
+```
+
+  </LanguageTabContent>
+</LanguageTabs>
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|:-----|:--------|
+| Start new project from existing ClickHouse | `moose init my-app --from-remote <URL> --language <typescript\|python>` |
+| Sync external models after schema change | `moose db pull` |
+| Start local development | `moose dev` |
+| Seed more data locally | `moose seed clickhouse --limit 1000` |
+
+---
+
+## Next Steps
+
+- [External Tables Reference](/moosestack/olap/external-tables) - Deep dive into `EXTERNALLY_MANAGED` lifecycle
+- [Materialized Views](/moosestack/olap/model-materialized-view) - Build real-time aggregations on CDC data
+- [APIs & Web Apps](/moosestack/apis) - Expose your data through type-safe endpoints

--- a/apps/framework-docs-v2/content/moosestack/dev/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/dev/index.mdx
@@ -1,0 +1,36 @@
+---
+title: Moose Dev
+description: Local development environment for MooseStack
+order: 1
+---
+
+import { Callout } from "@/components/mdx";
+
+# Moose Dev
+
+The `moose dev` command starts a local development environment with hot-reload, containerized infrastructure (ClickHouse, Redpanda, Temporal, Redis), and automatic schema synchronization.
+
+## What Happens When You Run `moose dev`
+
+1. **Infrastructure starts** - Docker containers spin up for ClickHouse, Redpanda, Redis, and Temporal
+2. **Code compiles** - Your data models, streams, and functions are compiled and validated
+3. **Schema syncs** - Tables, views, and topics are created/updated in local infrastructure
+4. **Server starts** - The Moose runtime serves your APIs and processes data
+5. **File watcher activates** - Changes to your code trigger automatic reloads
+
+## Key Capabilities
+
+| Capability | Description |
+|:-----------|:------------|
+| **Hot Reload** | Code changes are detected and applied without restarting |
+| **Local Infrastructure** | Full ClickHouse, Redpanda, Redis, and Temporal stack |
+| **Schema Sync** | Tables and topics are created/updated automatically |
+| **External Table Mirroring** | Optionally mirror remote tables for local development |
+
+<Callout type="info" title="Configuration Reference">
+For detailed configuration options including lifecycle hooks, Docker extensions, and networking, see [Dev Environment Configuration](/moosestack/configuration/dev-environment).
+</Callout>
+
+## Development Topics
+
+- **[CDC Managed Tables](/moosestack/dev/cdc-managed-tables)** - Work locally with tables managed by CDC pipelines like ClickPipes, PeerDB, or Debezium

--- a/apps/framework-docs-v2/content/moosestack/migrate/lifecycle-externally-managed.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/lifecycle-externally-managed.mdx
@@ -92,3 +92,7 @@ legacy_stream = Stream[ExternalUserData]("legacy_user_stream", StreamConfig(
 - **Local Updates**: Schema changes in code **WILL** update your local database.
 - **No Remote Impact**: These changes are **NEVER** applied to the remote database.
 </Callout>
+
+<Callout type="info" title="Working with CDC Pipelines?">
+See the [CDC Managed Tables](/moosestack/dev/cdc-managed-tables) guide for a complete walkthrough of developing locally with tables managed by ClickPipes, PeerDB, or other CDC services.
+</Callout>

--- a/apps/framework-docs-v2/content/moosestack/olap/db-pull.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/db-pull.mdx
@@ -11,7 +11,7 @@ import { Callout, LanguageTabs, LanguageTabContent, BulletPointsCard } from "@/c
 
 ## What this is
 
-Use `moose db pull` to refresh the definitions of tables you marked as `EXTERNALLY_MANAGED` from a live ClickHouse instance. It reads your code to find external tables, fetches their remote schemas, regenerates one external models file, and creates a small git commit if anything changed. If new external tables were added remotely (e.g., new CDC streams), they are added to the external models file as part of the same run.
+Use `moose db pull` to refresh the definitions of tables you marked as `EXTERNALLY_MANAGED` from a live ClickHouse instance. It reads your code to find external tables, fetches their remote schemas, and regenerates one external models file. If new external tables were added remotely (e.g., new CDC streams), they are added to the external models file as part of the same run.
 
 ## When to use it
 
@@ -24,19 +24,17 @@ Use `moose db pull` to refresh the definitions of tables you marked as `EXTERNAL
 ## Requirements
 
 - Tables are defined with `lifeCycle: EXTERNALLY_MANAGED` (TypeScript) or `life_cycle=LifeCycle.EXTERNALLY_MANAGED` (Python)
-- A ClickHouse connection string (native or HTTP/S)
+- A ClickHouse connection URL
 
 ## Connection strings
 
-`db pull` accepts both native and HTTP(S) URLs. Native strings are automatically converted to HTTP(S) with the appropriate ports.
-
-Examples:
+`db pull` accepts HTTP(S) URLs. Examples:
 
 ```bash filename="Terminal" copy
-# Native (auto-converted to HTTPS + 8443)
-moose db pull --clickhouse-url "clickhouse://explorer@play.clickhouse.com:9440/default"
+# HTTPS with credentials in URL
+moose db pull --clickhouse-url "https://user:pass@your-instance.clickhouse.cloud:8443/database"
 
-# HTTPS (explicit database via query param)
+# HTTPS with query params
 moose db pull --clickhouse-url "https://play.clickhouse.com/?user=explorer&database=default"
 
 # Local HTTP
@@ -74,7 +72,7 @@ When you run `db pull` the CLI does the following:
 - Regenerates a single external models file that mirrors the remote schema.
 - Adds any newly detected external tables from the remote database to the generated file so your code stays in sync as sources evolve.
 - Does not change any fully managed tables, your `app/index.ts` (TypeScript) or `app/main.py` (Python), or the database itself.
-- Creates a small git commit if the generated file changed, so you can review and share the update.
+- Leaves the changes unstaged so you can review them with `git diff` before committing.
 
 ### Example output
 
@@ -100,10 +98,13 @@ When you run `db pull` the CLI does the following:
 ## Command
 
 ```bash filename="Terminal" copy
-moose db pull --clickhouse-url <URL> [--file-path <OUTPUT_PATH>]
+moose db pull [--clickhouse-url <URL>] [--file-path <OUTPUT_PATH>]
 ```
 
-- **--clickhouse-url**: ClickHouse URL (e.g., `clickhouse://user:pass@host:port/database` or `https://user:pass@host:port/database`). Can also be set via `CLICKHOUSE_URL` environment variable.
+- **--clickhouse-url**: Optional. ClickHouse URL (e.g., `https://user:pass@host:8443/database`). If not provided, the URL is resolved in this order:
+  1. `MOOSE_CLICKHOUSE_CONFIG__URL` environment variable
+  2. Saved URL from `moose init --from-remote` (stored in keychain)
+  3. `[dev.remote_clickhouse]` config in `moose.config.toml` (with keychain credentials)
 - **--file-path**: Optional. Override the default output file. The file at this path will be regenerated (overwritten) on each run.
 
 ## Typical Use Cases
@@ -117,15 +118,22 @@ moose db pull --clickhouse-url <URL> [--file-path <OUTPUT_PATH>]
 
 ### Automatically run on dev startup (keep local fresh)
   In active development, schemas can drift faster than you commit updates. Running `db pull` on dev startup helps ensure your local code matches the live schema you depend on.
-  ```bash filename="Terminal" copy
-  export CLICKHOUSE_URL="clickhouse://<user>:<password>@<host>:<port>/<database>"
-  ```
+
   Add to `moose.config.toml`:
   ```toml filename="moose.config.toml" copy
   [http_server_config]
   on_first_start_script = "moose db pull"
   ```
-  This runs once when the dev server first starts. The CLI will read the URL from the `CLICKHOUSE_URL` environment variable. To run after code reloads, use `on_reload_complete_script`.
+  This runs once when the dev server first starts. The CLI will resolve credentials from:
+  - `MOOSE_CLICKHOUSE_CONFIG__URL` environment variable
+  - Saved URL from `moose init --from-remote` (stored in keychain)
+  - `[dev.remote_clickhouse]` config (if configured) with credentials from keychain
+
+  To run after every code reload instead, use `on_reload_complete_script`:
+  ```toml filename="moose.config.toml" copy
+  [http_server_config]
+  on_reload_complete_script = "moose db pull"
+  ```
 
 ### New project from an existing DB
   If you're starting with an existing ClickHouse database, bootstrap code with `init --from-remote`, then use `db pull` over time to keep external models fresh:
@@ -148,8 +156,7 @@ moose db pull --clickhouse-url <URL> [--file-path <OUTPUT_PATH>]
 
 - **No changes written**: Ensure tables are actually marked as `EXTERNALLY_MANAGED` and names match remote.
 - **Unsupported types**: The CLI will list tables with unsupported types; they're skipped in the generated file.
-- **Auth/TLS errors**: Verify scheme/ports (8123 or 8443) and credentials; try HTTPS if native URL fails.
-- **Git commit issues**: The command attempts a lightweight commit; commit manually if your working tree is dirty.
+- **Auth/TLS errors**: Verify scheme/ports (8123 for HTTP, 8443 for HTTPS) and credentials.
 
 ## Related
 

--- a/apps/framework-docs-v2/content/moosestack/olap/external-tables.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/external-tables.mdx
@@ -200,6 +200,10 @@ Moose will **not** apply schema changes to `EXTERNALLY_MANAGED` tables in produc
 For more on how migration plans are generated and what shows up in `plan.yaml`, see [/moosestack/olap/planned-migrations](/moosestack/olap/planned-migrations).
 </Callout>
 
+<Callout type="info" title="Automatic Local Mirroring">
+Configure Moose to automatically create and seed local mirror tables during `moose dev`. See [Dev Environment Configuration](/moosestack/configuration/dev-environment#externally-managed-tables) or the [CDC Managed Tables guide](/moosestack/dev/cdc-managed-tables) for setup.
+</Callout>
+
 ## Staying in sync with remote schema
 
 For `EXTERNALLY_MANAGED` tables, keep your code in sync with the live database by running DB Pull. You can do it manually or automate it in dev.

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -494,6 +494,21 @@ const moosestackNavigationConfig: NavigationConfig = [
   { type: "label", title: "Deployment & Lifecycle" },
   {
     type: "page",
+    slug: "moosestack/dev",
+    title: "Moose Dev",
+    icon: IconDeviceLaptop,
+    languages: ["typescript", "python"],
+    children: [
+      {
+        type: "page",
+        slug: "moosestack/dev/cdc-managed-tables",
+        title: "CDC Managed Tables",
+        languages: ["typescript", "python"],
+      },
+    ],
+  },
+  {
+    type: "page",
     slug: "moosestack/migrate",
     title: "Moose Migrate",
     icon: IconGitMerge,


### PR DESCRIPTION
Document CDC managed tables workflow, dev environment configuration,
db pull updates, and external table mirroring setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and navigation changes; the only behavioral change is removing auto-commit from `moose db pull`, which affects developer workflow but not runtime or data paths.
> 
> **Overview**
> **Docs:** Adds a new *Moose Dev* section and a detailed guide for working with CDC/`EXTERNALLY_MANAGED` ClickHouse tables, including local mirroring/seeding, keychain-backed remote credentials, and recommended `moose db pull` automation + watcher ignore patterns.
> 
> **Config/CLI docs updates:** Extends `Dev Environment Configuration` with `dev.externally_managed.tables` and `dev.remote_clickhouse` options, updates `db pull` docs to reflect *no auto git commit* and HTTP(S)-only URL expectations with new URL-resolution precedence, and cross-links the new guide from external-table lifecycle pages. Navigation is updated to surface the new section.
> 
> **CLI behavior:** `moose db pull` no longer creates an automatic codegen git commit (leaves changes unstaged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3ec49c25885d70805582312544ffa1bc1c55734. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->