### PR TITLE
docs: add explicit Node.js installation instructions for WSL2

### DIFF
--- a/apps/framework-docs-v2/content/shared/prerequisites/wsl-setup.mdx
+++ b/apps/framework-docs-v2/content/shared/prerequisites/wsl-setup.mdx
@@ -90,8 +90,42 @@ docker run hello-world
 
 The `hello-world` container should print a “Hello from Docker!” message and exit. You can also run `docker ps` to confirm the Docker daemon is reachable from WSL.
 
-**Troubleshooting:** If `docker run hello-world` fails, ensure Docker Desktop is running and WSL integration is enabled for your distro. Also verify Ubuntu is using WSL2 (Docker won’t work with WSL1).
+**Troubleshooting:** If `docker run hello-world` fails, ensure Docker Desktop is running and WSL integration is enabled for your distro. Also verify Ubuntu is using WSL2 (Docker won't work with WSL1).
 
-#### Step 4: Proceed with MooseStack requirements and installation
+#### Step 4: Install Node.js inside WSL2
 
-You now have a working Ubuntu instance on your Windows machine with Docker installed. You can proceed to install MooseStack and its requirements (Node.js 20+ and/or Python 3.12+) as if you were installing on a regular Linux machine. Just make sure to install from the Linux terminal prompt in the Ubuntu instance.
+You need to install Node.js inside the WSL2 Ubuntu environment—not the Windows version of Node.js. The recommended approach is to use **nvm** (Node Version Manager), which makes it easy to install and switch between Node.js versions.
+
+<Callout type="warning" title="Don't use the Windows Node.js installer">
+  If you download Node.js from nodejs.org using the default Windows installer, it installs Node.js on Windows, not inside your WSL2 Linux environment. MooseStack needs Node.js available in the Ubuntu terminal.
+</Callout>
+
+1. In your Ubuntu terminal, install nvm:
+
+   ```shell
+   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+   ```
+
+2. Close and reopen your terminal (or run `source ~/.bashrc`) to load nvm.
+
+3. Install Node.js 20 (LTS):
+
+   ```shell
+   nvm install 20
+   ```
+
+4. Verify the installation:
+
+   ```shell
+   node --version
+   ```
+
+   You should see a version like `v20.x.x`.
+
+<Callout type="info" title="Why nvm?">
+  Using nvm lets you easily switch Node.js versions and keeps your installation isolated to your user account. It's the approach recommended by Microsoft for [Node.js development on WSL](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl#install-nvm-nodejs-and-npm).
+</Callout>
+
+#### Step 5: Proceed with MooseStack installation
+
+You now have a working Ubuntu instance on your Windows machine with Docker and Node.js installed. Continue to the MooseStack CLI installation below—just make sure to run all commands in the Ubuntu terminal, not PowerShell or Command Prompt.


### PR DESCRIPTION
The previous WSL2 setup guide told users to install Node.js "as if on a regular Linux machine" without providing specific instructions. The prerequisites linked to nodejs.org/download, which defaults to Windows installers—not what WSL2 users need.

This adds a new Step 4 that explains how to install Node.js inside the WSL2 Ubuntu environment using nvm (Node Version Manager), following Microsoft's recommended approach. Includes:
- Warning callout about not using the Windows installer
- Step-by-step nvm installation commands
- Link to Microsoft's official WSL Node.js documentation

Fixes 514-417

https://claude.ai/code/session_01PbnRyEeTvsXBFCWkYXLpxH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that clarifies WSL2 prerequisites; no runtime or security-sensitive code is modified.
> 
> **Overview**
> Adds an explicit **Node.js-in-WSL2 installation step** to the Windows (WSL2) setup guide, replacing the previous “proceed with requirements” text.
> 
> The new Step 4 guides users to install Node.js 20 via `nvm`, includes a warning callout against using the Windows Node installer, links to Microsoft’s WSL Node.js guidance, and renumbers the follow-on section to Step 5.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a12daaa6fbb261d4ad602cb65942da55072ec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->