### PR TITLE
docs: update CLAUDE.md references and remove hardcoded paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ rm -rf node_modules && pnpm install
 
 ## Repository Structure
 
-- **`apps/`**: CLI (`framework-cli/`), docs (`framework-docs/`), E2E tests (`framework-cli-e2e/`)
+- **`apps/`**: CLI (`framework-cli/`), docs (`framework-docs-v2/`, see its own CLAUDE.md for details), E2E tests (`framework-cli-e2e/`)
 - **`packages/`**: Libraries (`ts-moose-lib/`, `py-moose-lib/`), shared deps, protobuf definitions
 - **`templates/`**: Standalone Moose apps used by E2E tests (NOT for unit tests)
 

--- a/apps/framework-docs-v2/CLAUDE.md
+++ b/apps/framework-docs-v2/CLAUDE.md
@@ -11,8 +11,8 @@ Next.js 15 documentation site for MooseStack with language-specific content (Typ
 ### Setup
 **IMPORTANT**: This is a monorepo workspace package. Always install dependencies from the monorepo root:
 ```bash
-cd /Users/timdelisle/Dev/moose  # Navigate to monorepo root
-pnpm install                     # Install all workspace dependencies
+cd <monorepo-root>  # Navigate to monorepo root
+pnpm install        # Install all workspace dependencies
 ```
 
 Never run `pnpm install` from `apps/framework-docs-v2/` directly, as this will break the monorepo workspace setup.
@@ -179,7 +179,7 @@ POSTHOG_PROJECT_ID=<from PostHog settings>
 
 ## Important Context
 
-- **Monorepo integration**: This app is part of the larger MooseStack monorepo at `/Users/timdelisle/Dev/moose/`. Dependencies must be installed from the monorepo root using `pnpm install`, never from this workspace package directly.
+- **Monorepo integration**: This app is part of the larger MooseStack monorepo. Dependencies must be installed from the monorepo root using `pnpm install`, never from this workspace package directly.
 - **Static generation**: All pages use `generateStaticParams` for SSG, but API routes remain dynamic
 - **Search is static**: Pagefind provides client-side search without server dependency
 - **No TypeScript/Python URL prefixes**: Unlike earlier versions, URLs don't have `/typescript` or `/python` prefixes. Language switching handled via context.


### PR DESCRIPTION
- Update root AGENTS.md to reference framework-docs-v2 (correct directory name)
- Add note to check docs app's own CLAUDE.md for detailed docs info
- Remove hardcoded user paths in docs CLAUDE.md (use generic <monorepo-root>)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust references and example commands; no runtime or behavior impact.
> 
> **Overview**
> Updates `AGENTS.md` to reference the correct docs app (`framework-docs-v2`) and explicitly point readers to that app’s own `CLAUDE.md` for details.
> 
> Cleans up `apps/framework-docs-v2/CLAUDE.md` by replacing a user-specific absolute path with a generic `<monorepo-root>` placeholder and removing the hardcoded local path mention in the monorepo integration note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7011242a7aaca4bf8ec093613290fc8b9d070da5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->