### PR TITLE
feat(cli): add display suppression infrastructure for TUI mode

### DIFF
--- a/apps/framework-cli/src/cli/display/context.rs
+++ b/apps/framework-cli/src/cli/display/context.rs
@@ -12,6 +12,17 @@ pub enum DisplayContext {
     Tui(DisplaySender),
 }
 
+/// Type of infrastructure change for semantic display
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InfrastructureChangeType {
+    /// Addition of new infrastructure (green/+)
+    Added,
+    /// Removal of infrastructure (red/-)
+    Removed,
+    /// Update to existing infrastructure (yellow/~)
+    Updated,
+}
+
 /// Messages that can be displayed
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Fields will be read in TUI integration
@@ -28,6 +39,11 @@ pub enum DisplayMessage {
     },
     InfrastructureDetail {
         lines: Vec<String>,
+    },
+    InfrastructureChange {
+        change_type: InfrastructureChangeType,
+        action: String,
+        details: String,
     },
     SpinnerCompletion {
         message: String,

--- a/apps/framework-cli/src/cli/display/context.rs
+++ b/apps/framework-cli/src/cli/display/context.rs
@@ -1,0 +1,117 @@
+use tokio::sync::mpsc;
+
+use super::message::MessageType;
+
+/// Display context determines where messages are routed
+#[derive(Clone)]
+pub enum DisplayContext {
+    /// Normal terminal output (stdout/stderr)
+    Terminal,
+    /// Route messages to TUI via channel
+    #[allow(dead_code)] // Will be used in TUI integration
+    Tui(DisplaySender),
+}
+
+/// Messages that can be displayed
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields will be read in TUI integration
+pub enum DisplayMessage {
+    Message {
+        message_type: MessageType,
+        action: String,
+        details: String,
+    },
+    Table {
+        title: String,
+        headers: Vec<String>,
+        rows: Vec<Vec<String>>,
+    },
+    InfrastructureDetail {
+        lines: Vec<String>,
+    },
+    SpinnerCompletion {
+        message: String,
+    },
+}
+
+/// Sender wrapper for display messages
+#[derive(Clone)]
+pub struct DisplaySender {
+    tx: mpsc::UnboundedSender<DisplayMessage>,
+}
+
+impl DisplaySender {
+    #[allow(dead_code)] // Will be used in TUI integration
+    pub fn new(tx: mpsc::UnboundedSender<DisplayMessage>) -> Self {
+        Self { tx }
+    }
+
+    pub fn send(&self, msg: DisplayMessage) {
+        let _ = self.tx.send(msg);
+    }
+}
+
+// Task-local storage for display context
+tokio::task_local! {
+    pub static DISPLAY_CONTEXT: DisplayContext;
+}
+
+/// Helper to get current context, defaulting to Terminal
+pub fn current_context() -> DisplayContext {
+    DISPLAY_CONTEXT
+        .try_with(|ctx| ctx.clone())
+        .unwrap_or(DisplayContext::Terminal)
+}
+
+/// Helper to check if a TUI channel is available
+pub fn tui_channel() -> Option<DisplaySender> {
+    match current_context() {
+        DisplayContext::Tui(sender) => Some(sender),
+        DisplayContext::Terminal => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_default_context_is_terminal() {
+        let ctx = current_context();
+        assert!(matches!(ctx, DisplayContext::Terminal));
+    }
+
+    #[tokio::test]
+    async fn test_tui_context_available() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let sender = DisplaySender::new(tx);
+        let context = DisplayContext::Tui(sender);
+
+        DISPLAY_CONTEXT
+            .scope(context, async {
+                assert!(tui_channel().is_some());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_messages_routed_to_tui() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sender = DisplaySender::new(tx);
+        let context = DisplayContext::Tui(sender);
+
+        DISPLAY_CONTEXT
+            .scope(context, async {
+                let sender = tui_channel().unwrap();
+                sender.send(DisplayMessage::Message {
+                    message_type: MessageType::Info,
+                    action: "Test".to_string(),
+                    details: "Details".to_string(),
+                });
+
+                let msg = rx.try_recv().unwrap();
+                assert!(matches!(msg, DisplayMessage::Message { .. }));
+            })
+            .await;
+    }
+}

--- a/apps/framework-cli/src/cli/display/context.rs
+++ b/apps/framework-cli/src/cli/display/context.rs
@@ -1,9 +1,10 @@
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use super::message::MessageType;
 
 /// Display context determines where messages are routed
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum DisplayContext {
     /// Normal terminal output (stdout/stderr)
     Terminal,
@@ -23,47 +24,115 @@ pub enum InfrastructureChangeType {
     Updated,
 }
 
-/// Messages that can be displayed
+/// Messages that can be displayed in the terminal or routed to TUI
+///
+/// This enum represents all types of display output that can be sent to either
+/// the terminal (normal mode) or to a TUI via a message channel when in TUI mode.
+/// Each variant carries the necessary data to render the message appropriately.
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Fields will be read in TUI integration
 pub enum DisplayMessage {
+    /// Generic message with typed severity and content
+    ///
+    /// Used for standard log-style messages with a type (Info/Success/Error/Warning),
+    /// an action label, and detailed description.
     Message {
+        /// The semantic type of the message (Info, Success, Error, Warning, Highlight)
         message_type: MessageType,
+        /// Short action label (e.g., "Loading", "Success", "Error")
         action: String,
+        /// Detailed message content
         details: String,
     },
+    /// Formatted table display
+    ///
+    /// Used to display structured tabular data with headers and rows.
     Table {
+        /// Title displayed above the table
         title: String,
+        /// Column headers
         headers: Vec<String>,
+        /// Table rows, where each row is a vector of column values
         rows: Vec<Vec<String>>,
     },
+    /// Infrastructure detail lines
+    ///
+    /// Used for displaying detailed infrastructure information with proper indentation.
     InfrastructureDetail {
+        /// Lines of detail text to display
         lines: Vec<String>,
     },
+    /// Infrastructure change notification with semantic type
+    ///
+    /// Used for infrastructure changes (add/remove/update) with explicit semantic type
+    /// information preserved from the styled terminal output.
     InfrastructureChange {
+        /// Type of infrastructure change (Added/Removed/Updated)
         change_type: InfrastructureChangeType,
+        /// Action text including prefix symbol (e.g., "+ Table", "- View")
         action: String,
+        /// Details about what changed
         details: String,
     },
+    /// Spinner completion message
+    ///
+    /// Used when a long-running operation completes to show completion status.
     SpinnerCompletion {
+        /// Completion message (e.g., "Build complete", "Deploy finished")
         message: String,
     },
 }
 
-/// Sender wrapper for display messages
+/// Sender wrapper for display messages to TUI
+///
+/// Wraps an `mpsc::UnboundedSender` to provide a convenient interface for sending
+/// display messages to the TUI. Messages are sent asynchronously and failures are
+/// logged but not propagated (fire-and-forget semantics).
 #[derive(Clone)]
 pub struct DisplaySender {
     tx: mpsc::UnboundedSender<DisplayMessage>,
 }
 
 impl DisplaySender {
+    /// Creates a new display sender from an mpsc channel
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - The unbounded sender channel for display messages
+    ///
+    /// # Returns
+    ///
+    /// A new `DisplaySender` instance wrapping the provided channel
     #[allow(dead_code)] // Will be used in TUI integration
     pub fn new(tx: mpsc::UnboundedSender<DisplayMessage>) -> Self {
         Self { tx }
     }
 
+    /// Sends a display message to the TUI
+    ///
+    /// Attempts to send a message through the channel. If the receiver has been
+    /// dropped (TUI exited), the error is logged via `tracing::warn!` but not
+    /// propagated, allowing the caller to continue without errors.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - The display message to send
+    ///
+    /// # Behavior
+    ///
+    /// - **Success**: Message is queued for the TUI receiver
+    /// - **Failure**: Logs a warning if the channel is closed but does not panic
     pub fn send(&self, msg: DisplayMessage) {
-        let _ = self.tx.send(msg);
+        if let Err(e) = self.tx.send(msg) {
+            warn!("Display channel closed, message dropped: {:?}", e.0);
+        }
+    }
+}
+
+// Manual Debug impl for DisplaySender (channel doesn't need detailed debug output)
+impl std::fmt::Debug for DisplaySender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DisplaySender").finish_non_exhaustive()
     }
 }
 

--- a/apps/framework-cli/src/cli/display/infrastructure.rs
+++ b/apps/framework-cli/src/cli/display/infrastructure.rs
@@ -626,6 +626,8 @@ pub fn show_olap_changes(olap_changes: &[OlapChange]) {
                     details: message.clone(),
                 });
             } else {
+                // Log for consistency with TUI path
+                error!("Validation error: {}", message.replace('\n', " "));
                 eprintln!("{}", message);
             }
         }

--- a/apps/framework-cli/src/cli/display/infrastructure.rs
+++ b/apps/framework-cli/src/cli/display/infrastructure.rs
@@ -28,7 +28,7 @@
 //! consistent display formatting while reducing code duplication and maintenance overhead.
 
 use super::{
-    context::{tui_channel, DisplayMessage},
+    context::{tui_channel, DisplayMessage, InfrastructureChangeType},
     terminal::{write_styled_line, StyledText, ACTION_WIDTH},
 };
 use crate::framework::core::{
@@ -84,6 +84,39 @@ fn write_detail_lines(details: &[String]) {
                 .expect("failed to write detail to terminal");
         }
     }
+}
+
+/// Emits an infrastructure change with explicit semantic type.
+///
+/// In TUI mode this sends a typed `DisplayMessage::InfrastructureChange`.
+/// In terminal mode this renders the corresponding styled line directly.
+fn emit_infrastructure_change(change_type: InfrastructureChangeType, message: &str) {
+    let (action, styled_text) = match change_type {
+        InfrastructureChangeType::Added => ("+ ", StyledText::from_str("+ ").green()),
+        InfrastructureChangeType::Removed => ("- ", StyledText::from_str("- ").red()),
+        InfrastructureChangeType::Updated => ("~ ", StyledText::from_str("~ ").yellow()),
+    };
+
+    if let Some(sender) = tui_channel() {
+        sender.send(DisplayMessage::InfrastructureChange {
+            change_type,
+            action: action.to_string(),
+            details: message.to_string(),
+        });
+        return;
+    }
+
+    let no_ansi = NO_ANSI.load(Ordering::Relaxed);
+    let show_timestamps = SHOW_TIMESTAMPS.load(Ordering::Relaxed);
+    let quiet_stdout = QUIET_STDOUT.load(Ordering::Relaxed);
+    write_styled_line(
+        &styled_text,
+        message,
+        no_ansi,
+        show_timestamps,
+        quiet_stdout,
+    )
+    .expect("failed to write message to terminal");
 }
 
 /// Macro to handle common change patterns for infrastructure components.
@@ -292,18 +325,7 @@ fn format_table_display(
 /// infra_added("Database table 'users' created");
 /// ```
 pub fn infra_added(message: &str) {
-    let styled_text = StyledText::from_str("+ ").green();
-    let no_ansi = NO_ANSI.load(Ordering::Relaxed);
-    let show_timestamps = SHOW_TIMESTAMPS.load(Ordering::Relaxed);
-    let quiet_stdout = QUIET_STDOUT.load(Ordering::Relaxed);
-    write_styled_line(
-        &styled_text,
-        message,
-        no_ansi,
-        show_timestamps,
-        quiet_stdout,
-    )
-    .expect("failed to write message to terminal");
+    emit_infrastructure_change(InfrastructureChangeType::Added, message);
     info!("+ {}", message.trim());
 }
 
@@ -340,18 +362,7 @@ pub fn infra_added_detailed(title: &str, details: &[String]) {
 /// infra_removed("Database table 'temp_data' dropped");
 /// ```
 pub fn infra_removed(message: &str) {
-    let styled_text = StyledText::from_str("- ").red();
-    let no_ansi = NO_ANSI.load(Ordering::Relaxed);
-    let show_timestamps = SHOW_TIMESTAMPS.load(Ordering::Relaxed);
-    let quiet_stdout = QUIET_STDOUT.load(Ordering::Relaxed);
-    write_styled_line(
-        &styled_text,
-        message,
-        no_ansi,
-        show_timestamps,
-        quiet_stdout,
-    )
-    .expect("failed to write message to terminal");
+    emit_infrastructure_change(InfrastructureChangeType::Removed, message);
     info!("- {}", message.trim());
 }
 
@@ -388,18 +399,7 @@ pub fn infra_removed_detailed(title: &str, details: &[String]) {
 /// infra_updated("Database table 'users' schema modified");
 /// ```
 pub fn infra_updated(message: &str) {
-    let styled_text = StyledText::from_str("~ ").yellow();
-    let no_ansi = NO_ANSI.load(Ordering::Relaxed);
-    let show_timestamps = SHOW_TIMESTAMPS.load(Ordering::Relaxed);
-    let quiet_stdout = QUIET_STDOUT.load(Ordering::Relaxed);
-    write_styled_line(
-        &styled_text,
-        message,
-        no_ansi,
-        show_timestamps,
-        quiet_stdout,
-    )
-    .expect("failed to write message to terminal");
+    emit_infrastructure_change(InfrastructureChangeType::Updated, message);
     info!("~ {}", message.trim());
 }
 
@@ -971,7 +971,9 @@ pub fn show_changes(infra_plan: &InfraPlan) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::display::context::{DisplayContext, DisplaySender, DISPLAY_CONTEXT};
     use crate::framework::core::infrastructure::table::{DataEnum, EnumMember};
+    use tokio::sync::mpsc;
 
     // Note: These tests primarily verify that the functions don't panic
     // and have correct signatures. Testing actual terminal output would
@@ -1015,6 +1017,72 @@ mod tests {
         show_streaming_changes(empty_streaming);
         show_process_changes(empty_process);
         show_api_changes(empty_api);
+    }
+
+    #[tokio::test]
+    async fn test_infra_added_routes_semantic_change_to_tui() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let context = DisplayContext::Tui(DisplaySender::new(tx));
+
+        DISPLAY_CONTEXT
+            .scope(context, async {
+                infra_added("Table users");
+            })
+            .await;
+
+        let msg = rx.try_recv().expect("expected an infrastructure change");
+        assert!(matches!(
+            msg,
+            DisplayMessage::InfrastructureChange {
+                change_type: InfrastructureChangeType::Added,
+                action,
+                details
+            } if action == "+ " && details == "Table users"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_infra_removed_routes_semantic_change_to_tui() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let context = DisplayContext::Tui(DisplaySender::new(tx));
+
+        DISPLAY_CONTEXT
+            .scope(context, async {
+                infra_removed("Table users");
+            })
+            .await;
+
+        let msg = rx.try_recv().expect("expected an infrastructure change");
+        assert!(matches!(
+            msg,
+            DisplayMessage::InfrastructureChange {
+                change_type: InfrastructureChangeType::Removed,
+                action,
+                details
+            } if action == "- " && details == "Table users"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_infra_updated_routes_semantic_change_to_tui() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let context = DisplayContext::Tui(DisplaySender::new(tx));
+
+        DISPLAY_CONTEXT
+            .scope(context, async {
+                infra_updated("Table users");
+            })
+            .await;
+
+        let msg = rx.try_recv().expect("expected an infrastructure change");
+        assert!(matches!(
+            msg,
+            DisplayMessage::InfrastructureChange {
+                change_type: InfrastructureChangeType::Updated,
+                action,
+                details
+            } if action == "~ " && details == "Table users"
+        ));
     }
 
     #[test]

--- a/apps/framework-cli/src/cli/display/message_display.rs
+++ b/apps/framework-cli/src/cli/display/message_display.rs
@@ -8,7 +8,7 @@ use super::{
     message::{Message, MessageType},
     terminal::{write_styled_line, StyledText},
 };
-use crate::utilities::constants::{NO_ANSI, QUIET_STDOUT, SHOW_TIMESTAMPS, SUPPRESS_DISPLAY};
+use crate::utilities::constants::{NO_ANSI, QUIET_STDOUT, SHOW_TIMESTAMPS};
 use std::sync::atomic::Ordering;
 use tracing::info;
 
@@ -107,7 +107,7 @@ pub fn show_message_impl(
     show_timestamps: bool,
     quiet_stdout: bool,
 ) -> std::io::Result<()> {
-    // Check for TUI context first - route messages to TUI if available
+    // Check for TUI context - route messages to TUI if available
     if let Some(sender) = tui_channel() {
         sender.send(DisplayMessage::Message {
             message_type,
@@ -115,17 +115,6 @@ pub fn show_message_impl(
             details: message.details.clone(),
         });
 
-        if should_log {
-            let log_action = message.action.replace('\n', " ");
-            let log_details = message.details.replace('\n', " ");
-            info!("{} {}", log_action.trim(), log_details.trim());
-        }
-        return Ok(());
-    }
-
-    // In TUI mode, suppress all terminal output — the TUI manages its own display.
-    // We still log via tracing so the information is captured in log files.
-    if SUPPRESS_DISPLAY.load(Ordering::Relaxed) {
         if should_log {
             let log_action = message.action.replace('\n', " ");
             let log_details = message.details.replace('\n', " ");

--- a/apps/framework-cli/src/cli/display/message_display.rs
+++ b/apps/framework-cli/src/cli/display/message_display.rs
@@ -4,6 +4,7 @@
 //! the show_message macro and related display functions for CLI output.
 
 use super::{
+    context::{tui_channel, DisplayMessage},
     message::{Message, MessageType},
     terminal::{write_styled_line, StyledText},
 };
@@ -106,6 +107,22 @@ pub fn show_message_impl(
     show_timestamps: bool,
     quiet_stdout: bool,
 ) -> std::io::Result<()> {
+    // Check for TUI context first - route messages to TUI if available
+    if let Some(sender) = tui_channel() {
+        sender.send(DisplayMessage::Message {
+            message_type,
+            action: message.action.clone(),
+            details: message.details.clone(),
+        });
+
+        if should_log {
+            let log_action = message.action.replace('\n', " ");
+            let log_details = message.details.replace('\n', " ");
+            info!("{} {}", log_action.trim(), log_details.trim());
+        }
+        return Ok(());
+    }
+
     // In TUI mode, suppress all terminal output — the TUI manages its own display.
     // We still log via tracing so the information is captured in log files.
     if SUPPRESS_DISPLAY.load(Ordering::Relaxed) {

--- a/apps/framework-cli/src/cli/display/mod.rs
+++ b/apps/framework-cli/src/cli/display/mod.rs
@@ -84,7 +84,9 @@ pub mod timing;
 
 // Re-export commonly used types and functions for convenience
 #[allow(unused_imports)] // Will be used in TUI integration
-pub use context::{DisplayContext, DisplayMessage, DisplaySender, DISPLAY_CONTEXT};
+pub use context::{
+    DisplayContext, DisplayMessage, DisplaySender, InfrastructureChangeType, DISPLAY_CONTEXT,
+};
 pub use infrastructure::show_changes;
 pub use message::{Message, MessageType};
 pub use message_display::{batch_inserted, show_message_wrapper};

--- a/apps/framework-cli/src/cli/display/mod.rs
+++ b/apps/framework-cli/src/cli/display/mod.rs
@@ -73,6 +73,7 @@
 #[macro_use]
 pub mod message_display;
 
+pub mod context;
 pub mod infrastructure;
 pub mod message;
 pub mod spinner;
@@ -82,6 +83,8 @@ pub mod terminal;
 pub mod timing;
 
 // Re-export commonly used types and functions for convenience
+#[allow(unused_imports)] // Will be used in TUI integration
+pub use context::{DisplayContext, DisplayMessage, DisplaySender, DISPLAY_CONTEXT};
 pub use infrastructure::show_changes;
 pub use message::{Message, MessageType};
 pub use message_display::{batch_inserted, show_message_wrapper};

--- a/apps/framework-cli/src/cli/display/spinner.rs
+++ b/apps/framework-cli/src/cli/display/spinner.rs
@@ -443,9 +443,9 @@ pub fn with_spinner_completion<F, R>(
 where
     F: FnOnce() -> R,
 {
-    let has_tui = tui_channel().is_some();
+    let tui_sender = tui_channel();
 
-    let sp = if activate && !has_tui && stdout().is_terminal() {
+    let sp = if activate && tui_sender.is_none() && stdout().is_terminal() {
         let mut spinner = SpinnerComponent::new(message);
         let _ = spinner.start();
         Some(spinner)
@@ -458,13 +458,13 @@ where
     if let Some(mut spinner) = sp {
         let _ = spinner.done(completion_message);
         let _ = spinner.cleanup();
-    } else if activate && !has_tui {
+    } else if activate && tui_sender.is_none() {
         // In non-TTY mode (e.g., CI), still print the completion message
         // so tests can detect when operations complete
         println!("✓ {completion_message}");
-    } else if activate && has_tui {
+    } else if activate && tui_sender.is_some() {
         // Send completion message to TUI
-        if let Some(sender) = tui_channel() {
+        if let Some(sender) = tui_sender {
             sender.send(DisplayMessage::SpinnerCompletion {
                 message: completion_message.to_string(),
             });
@@ -568,9 +568,9 @@ pub async fn with_spinner_completion_async<F, R>(
 where
     F: Future<Output = R>,
 {
-    let has_tui = tui_channel().is_some();
+    let tui_sender = tui_channel();
 
-    let sp = if activate && !has_tui && stdout().is_terminal() {
+    let sp = if activate && tui_sender.is_none() && stdout().is_terminal() {
         let mut spinner = SpinnerComponent::new(message);
         let _ = spinner.start();
         Some(spinner)
@@ -583,13 +583,13 @@ where
     if let Some(mut spinner) = sp {
         let _ = spinner.done(completion_message);
         let _ = spinner.cleanup();
-    } else if activate && !has_tui {
+    } else if activate && tui_sender.is_none() {
         // In non-TTY mode (e.g., CI), still print the completion message
         // so tests can detect when operations complete
         println!("✓ {completion_message}");
-    } else if activate && has_tui {
+    } else if activate && tui_sender.is_some() {
         // Send completion message to TUI
-        if let Some(sender) = tui_channel() {
+        if let Some(sender) = tui_sender {
             sender.send(DisplayMessage::SpinnerCompletion {
                 message: completion_message.to_string(),
             });

--- a/apps/framework-cli/src/cli/display/spinner.rs
+++ b/apps/framework-cli/src/cli/display/spinner.rs
@@ -9,7 +9,6 @@ use super::{
     context::{tui_channel, DisplayMessage},
     terminal::TerminalComponent,
 };
-use crate::utilities::constants::SUPPRESS_DISPLAY;
 use crossterm::{
     cursor::{position, MoveTo, RestorePosition, SavePosition},
     execute, queue,
@@ -444,10 +443,9 @@ pub fn with_spinner_completion<F, R>(
 where
     F: FnOnce() -> R,
 {
-    let suppressed = SUPPRESS_DISPLAY.load(Ordering::Relaxed);
     let has_tui = tui_channel().is_some();
 
-    let sp = if activate && !suppressed && !has_tui && stdout().is_terminal() {
+    let sp = if activate && !has_tui && stdout().is_terminal() {
         let mut spinner = SpinnerComponent::new(message);
         let _ = spinner.start();
         Some(spinner)
@@ -460,7 +458,7 @@ where
     if let Some(mut spinner) = sp {
         let _ = spinner.done(completion_message);
         let _ = spinner.cleanup();
-    } else if activate && !suppressed && !has_tui {
+    } else if activate && !has_tui {
         // In non-TTY mode (e.g., CI), still print the completion message
         // so tests can detect when operations complete
         println!("✓ {completion_message}");
@@ -570,10 +568,9 @@ pub async fn with_spinner_completion_async<F, R>(
 where
     F: Future<Output = R>,
 {
-    let suppressed = SUPPRESS_DISPLAY.load(Ordering::Relaxed);
     let has_tui = tui_channel().is_some();
 
-    let sp = if activate && !suppressed && !has_tui && stdout().is_terminal() {
+    let sp = if activate && !has_tui && stdout().is_terminal() {
         let mut spinner = SpinnerComponent::new(message);
         let _ = spinner.start();
         Some(spinner)
@@ -586,7 +583,7 @@ where
     if let Some(mut spinner) = sp {
         let _ = spinner.done(completion_message);
         let _ = spinner.cleanup();
-    } else if activate && !suppressed && !has_tui {
+    } else if activate && !has_tui {
         // In non-TTY mode (e.g., CI), still print the completion message
         // so tests can detect when operations complete
         println!("✓ {completion_message}");

--- a/apps/framework-cli/src/cli/display/table.rs
+++ b/apps/framework-cli/src/cli/display/table.rs
@@ -3,6 +3,7 @@
 //! This module provides utilities for displaying data in formatted tables
 //! with consistent styling and layout.
 
+use super::context::{tui_channel, DisplayMessage};
 use crate::utilities::constants::SUPPRESS_DISPLAY;
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, ContentArrangement, Table};
 use std::sync::atomic::Ordering;
@@ -32,6 +33,16 @@ use std::sync::atomic::Ordering;
 /// );
 /// ```
 pub fn show_table(title: String, headers: Vec<String>, rows: Vec<Vec<String>>) {
+    // Check for TUI context first - route to TUI if available
+    if let Some(sender) = tui_channel() {
+        sender.send(DisplayMessage::Table {
+            title,
+            headers,
+            rows,
+        });
+        return;
+    }
+
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)

--- a/apps/framework-cli/src/cli/display/table.rs
+++ b/apps/framework-cli/src/cli/display/table.rs
@@ -3,7 +3,9 @@
 //! This module provides utilities for displaying data in formatted tables
 //! with consistent styling and layout.
 
+use crate::utilities::constants::SUPPRESS_DISPLAY;
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, ContentArrangement, Table};
+use std::sync::atomic::Ordering;
 
 /// Displays a formatted table with headers and data rows.
 ///
@@ -41,7 +43,9 @@ pub fn show_table(title: String, headers: Vec<String>, rows: Vec<Vec<String>>) {
         table.add_row(row);
     }
 
-    println!("{title}\n{table}");
+    if !SUPPRESS_DISPLAY.load(Ordering::Relaxed) {
+        println!("{title}\n{table}");
+    }
 }
 
 #[cfg(test)]

--- a/apps/framework-cli/src/cli/display/table.rs
+++ b/apps/framework-cli/src/cli/display/table.rs
@@ -4,9 +4,7 @@
 //! with consistent styling and layout.
 
 use super::context::{tui_channel, DisplayMessage};
-use crate::utilities::constants::SUPPRESS_DISPLAY;
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, ContentArrangement, Table};
-use std::sync::atomic::Ordering;
 
 /// Displays a formatted table with headers and data rows.
 ///
@@ -33,7 +31,7 @@ use std::sync::atomic::Ordering;
 /// );
 /// ```
 pub fn show_table(title: String, headers: Vec<String>, rows: Vec<Vec<String>>) {
-    // Check for TUI context first - route to TUI if available
+    // Check for TUI context - route to TUI if available
     if let Some(sender) = tui_channel() {
         sender.send(DisplayMessage::Table {
             title,
@@ -43,6 +41,7 @@ pub fn show_table(title: String, headers: Vec<String>, rows: Vec<Vec<String>>) {
         return;
     }
 
+    // Build and display table normally
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
@@ -54,9 +53,7 @@ pub fn show_table(title: String, headers: Vec<String>, rows: Vec<Vec<String>>) {
         table.add_row(row);
     }
 
-    if !SUPPRESS_DISPLAY.load(Ordering::Relaxed) {
-        println!("{title}\n{table}");
-    }
+    println!("{title}\n{table}");
 }
 
 #[cfg(test)]

--- a/apps/framework-cli/src/cli/display/terminal.rs
+++ b/apps/framework-cli/src/cli/display/terminal.rs
@@ -4,6 +4,7 @@
 //! crate. It includes components for displaying styled text and managing
 //! terminal state during CLI operations.
 
+use crate::utilities::constants::SUPPRESS_DISPLAY;
 use crossterm::{
     execute,
     style::{
@@ -11,6 +12,7 @@ use crossterm::{
     },
 };
 use std::io::{stderr, stdout, Result as IoResult};
+use std::sync::atomic::Ordering;
 
 /// Width of the action column in terminal output
 pub const ACTION_WIDTH: usize = 15;
@@ -276,6 +278,11 @@ pub fn write_styled_line(
     show_timestamps: bool,
     quiet_stdout: bool,
 ) -> IoResult<()> {
+    // In TUI mode, suppress all direct terminal writes.
+    if SUPPRESS_DISPLAY.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
     // When quiet_stdout is set, redirect messages to stderr to keep stdout clean
     // for structured/JSON output
     if quiet_stdout {

--- a/apps/framework-cli/src/cli/display/terminal.rs
+++ b/apps/framework-cli/src/cli/display/terminal.rs
@@ -8,7 +8,6 @@ use super::{
     context::{tui_channel, DisplayMessage},
     message::MessageType,
 };
-use crate::utilities::constants::SUPPRESS_DISPLAY;
 use crossterm::{
     execute,
     style::{
@@ -16,7 +15,6 @@ use crossterm::{
     },
 };
 use std::io::{stderr, stdout, Result as IoResult};
-use std::sync::atomic::Ordering;
 
 /// Width of the action column in terminal output
 pub const ACTION_WIDTH: usize = 15;
@@ -282,19 +280,13 @@ pub fn write_styled_line(
     show_timestamps: bool,
     quiet_stdout: bool,
 ) -> IoResult<()> {
-    // Check for TUI context first - route messages to TUI if available
+    // Check for TUI context - route messages to TUI if available
     if let Some(sender) = tui_channel() {
-        // Convert styled text to plain message for TUI
         sender.send(DisplayMessage::Message {
             message_type: MessageType::Info,
             action: styled_text.text.clone(),
             details: message.to_string(),
         });
-        return Ok(());
-    }
-
-    // In TUI mode, suppress all direct terminal writes.
-    if SUPPRESS_DISPLAY.load(Ordering::Relaxed) {
         return Ok(());
     }
 

--- a/apps/framework-cli/src/cli/display/terminal.rs
+++ b/apps/framework-cli/src/cli/display/terminal.rs
@@ -4,10 +4,6 @@
 //! crate. It includes components for displaying styled text and managing
 //! terminal state during CLI operations.
 
-use super::{
-    context::{tui_channel, DisplayMessage, InfrastructureChangeType},
-    message::MessageType,
-};
 use crossterm::{
     execute,
     style::{
@@ -192,6 +188,8 @@ impl StyledText {
 /// * `styled_text` - The styled text configuration for the action portion
 /// * `message` - The main message content to display
 /// * `no_ansi` - If true, disable ANSI color codes and formatting
+/// * `show_timestamps` - If true, prepends a timestamp to each output line
+/// * `quiet_stdout` - If true, writes to stderr instead of stdout
 ///
 /// # Returns
 ///
@@ -207,7 +205,13 @@ impl StyledText {
 /// ```rust
 /// # use crate::cli::display::terminal::{StyledText, write_styled_line};
 /// let styled = StyledText::new("Success".to_string()).green().bold();
-/// write_styled_line(&styled, "Operation completed successfully", false)?;
+/// write_styled_line(
+///     &styled,
+///     "Operation completed successfully",
+///     false,
+///     false,
+///     false,
+/// )?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
 /// Internal helper that writes a styled action line to any writer.
@@ -280,47 +284,6 @@ pub fn write_styled_line(
     show_timestamps: bool,
     quiet_stdout: bool,
 ) -> IoResult<()> {
-    // Check for TUI context - route messages to TUI if available
-    if let Some(sender) = tui_channel() {
-        // Detect infrastructure changes by prefix and color
-        let change_type = match (styled_text.text.as_str(), styled_text.foreground) {
-            (text, Some(Color::Green)) if text.starts_with("+ ") => {
-                Some(InfrastructureChangeType::Added)
-            }
-            (text, Some(Color::Red)) if text.starts_with("- ") => {
-                Some(InfrastructureChangeType::Removed)
-            }
-            (text, Some(Color::Yellow)) if text.starts_with("~ ") => {
-                Some(InfrastructureChangeType::Updated)
-            }
-            _ => None,
-        };
-
-        // Route infrastructure changes with semantic type, others as generic messages
-        if let Some(change_type) = change_type {
-            sender.send(DisplayMessage::InfrastructureChange {
-                change_type,
-                action: styled_text.text.clone(),
-                details: message.to_string(),
-            });
-        } else {
-            // Infer message type from color for non-infrastructure messages
-            let message_type = match styled_text.foreground {
-                Some(Color::Green) => MessageType::Success,
-                Some(Color::Red) => MessageType::Error,
-                Some(Color::Yellow) => MessageType::Warning,
-                Some(Color::Cyan) | None => MessageType::Info,
-                _ => MessageType::Info,
-            };
-            sender.send(DisplayMessage::Message {
-                message_type,
-                action: styled_text.text.clone(),
-                details: message.to_string(),
-            });
-        }
-        return Ok(());
-    }
-
     // When quiet_stdout is set, redirect messages to stderr to keep stdout clean
     // for structured/JSON output
     if quiet_stdout {

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -83,7 +83,7 @@ pub enum PlanningError {
     DmV2Loading(#[from] crate::framework::core::partial_infrastructure_map::DmV2LoadingError),
 
     /// Other unspecified errors
-    #[error("Unknown error")]
+    #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -106,7 +106,6 @@ pub static IS_DEV_MODE: AtomicBool = AtomicBool::new(false);
 /// Used in TUI mode where the terminal is managed by ratatui and any direct
 /// writes to stdout/stderr would corrupt the display.
 pub static SUPPRESS_DISPLAY: AtomicBool = AtomicBool::new(false);
-
 pub const README_PREFIX: &str = r#"
 This is a [MooseJs](https://www.moosejs.com/) project bootstrapped with the
 [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -101,6 +101,12 @@ pub static SHOW_TIMING: AtomicBool = AtomicBool::new(false);
 /// This is set once at the start of `start_development_mode`.
 pub static IS_DEV_MODE: AtomicBool = AtomicBool::new(false);
 
+/// Global flag to completely suppress all display output (stdout and stderr)
+/// When true, show_message_impl and related display functions become no-ops.
+/// Used in TUI mode where the terminal is managed by ratatui and any direct
+/// writes to stdout/stderr would corrupt the display.
+pub static SUPPRESS_DISPLAY: AtomicBool = AtomicBool::new(false);
+
 pub const README_PREFIX: &str = r#"
 This is a [MooseJs](https://www.moosejs.com/) project bootstrapped with the
 [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).


### PR DESCRIPTION
Add SUPPRESS_DISPLAY constant and guard checks in all display modules
to enable TUI mode to own terminal output without corruption.

Also includes small fixes:
- plan.rs: Use transparent error for better error context
- local_webserver.rs: Replace println! with show_message! for consistency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI output paths and introduces conditional routing away from stdout/stderr, which could alter or drop user-visible output if the context is mis-scoped or channels are closed.
> 
> **Overview**
> Adds a new `display::context` layer (`DISPLAY_CONTEXT`, `DisplaySender`, `DisplayMessage`) so display code can either write to the terminal or emit structured events for a future TUI.
> 
> Updates core display helpers to use this routing: `show_message_impl` emits `DisplayMessage::Message`, `show_table` emits `DisplayMessage::Table`, infrastructure change/detail output emits typed `InfrastructureChange`/`InfrastructureDetail` events, and spinner completion can emit `DisplayMessage::SpinnerCompletion` while disabling terminal spinners in TUI mode. Also routes OLAP validation errors through the display channel (and logs via `tracing::error!`), replaces route-listing `println!`s in `local_webserver` with `show_message!`, and improves `PlanningError::Other` to be `#[error(transparent)]` for better error context. Adds `SUPPRESS_DISPLAY` constant (not yet wired into the display paths) and new tests verifying TUI routing for infrastructure output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f95cd855bb10bc65a250951fdd2bbad293fc6fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->