### PR TITLE
feat(cli): add infrastructure boot with TUI status channels

### DIFF
--- a/apps/framework-cli/src/cli/routines/dev.rs
+++ b/apps/framework-cli/src/cli/routines/dev.rs
@@ -8,10 +8,16 @@ use super::{
 use crate::cli::display::{
     show_message_wrapper, with_spinner_completion, with_timing, Message, MessageType,
 };
+use crate::cli::routines::dev_tui::infra_status::{
+    BootPhase, InfraStatusSender, InfraStatusUpdate, ServiceStatus,
+};
 use crate::cli::settings::Settings;
 use crate::framework::languages::SupportedLanguages;
 use crate::project::Project;
-use crate::utilities::constants::{CLI_PROJECT_INTERNAL_DIR, SHOW_TIMING};
+use crate::utilities::constants::{
+    CLICKHOUSE_CONTAINER_NAME, CLI_PROJECT_INTERNAL_DIR, REDPANDA_CONTAINER_NAME, SHOW_TIMING,
+    TEMPORAL_CONTAINER_NAME,
+};
 use crate::utilities::package_managers::{
     check_local_pnpm_version_warning, detect_pnpm_deploy_mode, find_pnpm_workspace_root,
     legacy_deploy_terminal_message, legacy_deploy_warning_message, PnpmDeployMode,
@@ -19,6 +25,9 @@ use crate::utilities::package_managers::{
 use crate::{cli::routines::util::ensure_docker_running, utilities::docker::DockerClient};
 use lazy_static::lazy_static;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
 
 pub fn run_local_infrastructure(
     project: &Project,
@@ -156,4 +165,248 @@ pub fn create_docker_compose_file(
             err,
         )),
     }
+}
+
+/// Infrastructure boot error type for TUI mode
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
+pub enum InfraBootError {
+    #[error("Docker is not running")]
+    DockerNotRunning,
+    #[error("Failed to create docker-compose file: {0}")]
+    ComposeFileError(String),
+    #[error("Failed to start containers: {0}")]
+    ContainerStartError(String),
+    #[error("Service validation failed for {service}: {message}")]
+    ValidationError { service: String, message: String },
+}
+
+/// Run infrastructure startup with status updates sent to the TUI
+///
+/// This function performs the same operations as `run_local_infrastructure`
+/// but sends progress updates through a channel for display in the TUI.
+///
+/// # Arguments
+/// * `project` - The project configuration
+/// * `settings` - Application settings
+/// * `tx` - Channel sender for status updates
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
+pub async fn run_infrastructure_with_updates(
+    project: Arc<Project>,
+    settings: Settings,
+    tx: InfraStatusSender,
+) -> Result<(), InfraBootError> {
+    let docker_client = DockerClient::new(&settings);
+
+    // Phase 1: Check Docker
+    let _ = tx.send(InfraStatusUpdate::PhaseChanged(BootPhase::CheckingDocker));
+    let _ = tx.send(InfraStatusUpdate::DockerStatus(ServiceStatus::Starting));
+
+    if let Err(_e) = ensure_docker_running(&docker_client) {
+        let _ = tx.send(InfraStatusUpdate::DockerStatus(ServiceStatus::Failed(
+            "Docker daemon not running".to_string(),
+        )));
+        let _ = tx.send(InfraStatusUpdate::BootFailed(
+            "Docker is not running".to_string(),
+        ));
+        return Err(InfraBootError::DockerNotRunning);
+    }
+    let _ = tx.send(InfraStatusUpdate::DockerStatus(ServiceStatus::Healthy));
+
+    // Phase 2: Create compose file
+    let _ = tx.send(InfraStatusUpdate::PhaseChanged(
+        BootPhase::CreatingComposeFile,
+    ));
+
+    if let Err(e) = docker_client.create_compose_file(&project, &settings) {
+        let error_msg = format!("{}", e);
+        let _ = tx.send(InfraStatusUpdate::BootFailed(format!(
+            "Failed to create compose file: {}",
+            error_msg
+        )));
+        return Err(InfraBootError::ComposeFileError(error_msg));
+    }
+
+    // Check if we should skip container startup
+    if !project.should_load_infra() {
+        let _ = tx.send(InfraStatusUpdate::BootCompleted);
+        return Ok(());
+    }
+
+    // Phase 3: Start containers
+    let _ = tx.send(InfraStatusUpdate::PhaseChanged(
+        BootPhase::StartingContainers,
+    ));
+
+    // Mark services as starting
+    if project.features.olap {
+        let _ = tx.send(InfraStatusUpdate::ClickHouseStatus(ServiceStatus::Starting));
+    }
+    if project.features.streaming_engine {
+        let _ = tx.send(InfraStatusUpdate::RedpandaStatus(ServiceStatus::Starting));
+    }
+    if project.features.workflows || settings.features.scripts {
+        let _ = tx.send(InfraStatusUpdate::TemporalStatus(ServiceStatus::Starting));
+    }
+    let _ = tx.send(InfraStatusUpdate::RedisStatus(ServiceStatus::Starting));
+
+    if let Err(e) = docker_client.start_containers(&project) {
+        let error_msg = format!("{}", e);
+        let _ = tx.send(InfraStatusUpdate::BootFailed(format!(
+            "Failed to start containers: {}",
+            error_msg
+        )));
+        return Err(InfraBootError::ContainerStartError(error_msg));
+    }
+
+    // Phase 4: Validate services
+    let _ = tx.send(InfraStatusUpdate::PhaseChanged(
+        BootPhase::ValidatingServices,
+    ));
+
+    // Validate ClickHouse
+    if project.features.olap {
+        validate_service_with_updates(
+            &project,
+            &docker_client,
+            CLICKHOUSE_CONTAINER_NAME,
+            Some("healthy"),
+            &tx,
+            InfraStatusUpdate::ClickHouseStatus,
+        )?;
+    }
+
+    // Validate Redpanda
+    if project.features.streaming_engine {
+        validate_service_with_updates(
+            &project,
+            &docker_client,
+            REDPANDA_CONTAINER_NAME,
+            None, // Redpanda doesn't have health check
+            &tx,
+            InfraStatusUpdate::RedpandaStatus,
+        )?;
+
+        // Also validate cluster
+        if let Err(e) = docker_client.run_rpk_cluster_info(&project.name(), 10) {
+            let _ = tx.send(InfraStatusUpdate::RedpandaStatus(ServiceStatus::Failed(
+                format!("Cluster validation failed: {}", e),
+            )));
+            return Err(InfraBootError::ValidationError {
+                service: "Redpanda".to_string(),
+                message: format!("Cluster validation failed: {}", e),
+            });
+        }
+    }
+
+    // Validate Temporal
+    if project.features.workflows || settings.features.scripts {
+        validate_service_with_updates(
+            &project,
+            &docker_client,
+            TEMPORAL_CONTAINER_NAME,
+            Some("healthy"),
+            &tx,
+            InfraStatusUpdate::TemporalStatus,
+        )?;
+    }
+
+    // Mark Redis as healthy (it doesn't have a separate container validation)
+    let _ = tx.send(InfraStatusUpdate::RedisStatus(ServiceStatus::Healthy));
+
+    // All done!
+    let _ = tx.send(InfraStatusUpdate::PhaseChanged(BootPhase::Ready));
+    let _ = tx.send(InfraStatusUpdate::BootCompleted);
+
+    Ok(())
+}
+
+/// Validate a service container with status updates
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
+fn validate_service_with_updates<F>(
+    project: &Project,
+    docker_client: &DockerClient,
+    container_name: &str,
+    expected_health: Option<&str>,
+    tx: &InfraStatusSender,
+    status_update: F,
+) -> Result<(), InfraBootError>
+where
+    F: Fn(ServiceStatus) -> InfraStatusUpdate,
+{
+    let _full_container_name = format!("{}-{}-1", project.name().to_lowercase(), container_name);
+
+    // Find the container
+    let containers = docker_client.list_containers(project).map_err(|e| {
+        let _ = tx.send(status_update(ServiceStatus::Failed(format!(
+            "Failed to list containers: {}",
+            e
+        ))));
+        InfraBootError::ValidationError {
+            service: container_name.to_string(),
+            message: format!("Failed to list containers: {}", e),
+        }
+    })?;
+
+    let mut container = containers
+        .into_iter()
+        .find(|c| c.name.contains(container_name))
+        .ok_or_else(|| {
+            let _ = tx.send(status_update(ServiceStatus::Failed(
+                "Container not found".to_string(),
+            )));
+            InfraBootError::ValidationError {
+                service: container_name.to_string(),
+                message: "Container not found".to_string(),
+            }
+        })?;
+
+    // Wait for health check if required
+    if let Some(expected) = expected_health {
+        const MAX_ATTEMPTS: u8 = 30;
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            let _ = tx.send(status_update(ServiceStatus::WaitingHealthy {
+                attempt,
+                max_attempts: MAX_ATTEMPTS,
+            }));
+
+            if let Some(ref effective_health) = container.health {
+                if effective_health == expected {
+                    break;
+                }
+            } else {
+                // No health info available, skip health check
+                break;
+            }
+
+            if attempt == MAX_ATTEMPTS {
+                let _ = tx.send(status_update(ServiceStatus::Failed(
+                    "Health check timeout".to_string(),
+                )));
+                return Err(InfraBootError::ValidationError {
+                    service: container_name.to_string(),
+                    message: "Health check timeout".to_string(),
+                });
+            }
+
+            // Re-fetch container status
+            sleep(Duration::from_secs(1));
+            let containers = docker_client.list_containers(project).map_err(|e| {
+                InfraBootError::ValidationError {
+                    service: container_name.to_string(),
+                    message: format!("Failed to list containers: {}", e),
+                }
+            })?;
+            if let Some(c) = containers
+                .into_iter()
+                .find(|c| c.name.contains(container_name))
+            {
+                container = c;
+            }
+        }
+    }
+
+    let _ = tx.send(status_update(ServiceStatus::Healthy));
+    Ok(())
 }

--- a/apps/framework-cli/src/cli/routines/dev_tui/infra_status.rs
+++ b/apps/framework-cli/src/cli/routines/dev_tui/infra_status.rs
@@ -3,9 +3,6 @@
 //! This module defines the status types used to communicate infrastructure boot
 //! progress from the background infrastructure task to the TUI for real-time display.
 
-// TODO(PR4): Remove this allow once dev.rs uses these types
-#![allow(dead_code)]
-
 use tokio::sync::mpsc;
 
 /// Boot phase during infrastructure startup
@@ -206,9 +203,11 @@ pub enum InfraStatusUpdate {
 pub type InfraStatusSender = mpsc::UnboundedSender<InfraStatusUpdate>;
 
 /// Receiver for infrastructure status updates
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
 pub type InfraStatusReceiver = mpsc::UnboundedReceiver<InfraStatusUpdate>;
 
 /// Creates a new channel for infrastructure status updates
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
 pub fn infra_status_channel() -> (InfraStatusSender, InfraStatusReceiver) {
     mpsc::unbounded_channel()
 }

--- a/apps/framework-cli/src/cli/routines/dev_tui/resource_panel.rs
+++ b/apps/framework-cli/src/cli/routines/dev_tui/resource_panel.rs
@@ -3,9 +3,6 @@
 //! This module provides types for displaying and filtering infrastructure resources
 //! in the Dev TUI.
 
-// TODO(PR4): Remove this allow once watcher.rs uses these types
-#![allow(dead_code)]
-
 use crate::framework::core::infrastructure::api_endpoint::APIType;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
 use std::collections::HashSet;
@@ -284,9 +281,11 @@ impl ChangeType {
 /// Sender for resource updates
 pub type ResourceUpdateSender = mpsc::UnboundedSender<ResourceUpdate>;
 /// Receiver for resource updates
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
 pub type ResourceUpdateReceiver = mpsc::UnboundedReceiver<ResourceUpdate>;
 
 /// Create a new resource update channel
+#[allow(dead_code)] // TODO(PR5): Remove once entry point uses this
 pub fn resource_update_channel() -> (ResourceUpdateSender, ResourceUpdateReceiver) {
     mpsc::unbounded_channel()
 }

--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -777,6 +777,7 @@ pub async fn start_development_mode(
                 settings.clone(),
                 processing_coordinator.clone(),
                 watcher_shutdown_rx,
+                None, // No TUI resource updates in non-TUI mode
             )?;
         }
     }

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -36,6 +36,9 @@ use tracing::info;
 
 use super::display::{self, with_spinner_completion_async, Message, MessageType};
 use super::processing_coordinator::ProcessingCoordinator;
+use super::routines::dev_tui::resource_panel::{
+    ResourceList, ResourceUpdate, ResourceUpdateSender,
+};
 use super::settings::Settings;
 
 use crate::cli::routines::openapi::openapi;
@@ -197,6 +200,7 @@ impl EventBuckets {
 /// * `settings` - CLI settings configuration
 /// * `processing_coordinator` - Coordinator for synchronizing with MCP tools
 /// * `shutdown_rx` - Receiver to listen for shutdown signal
+/// * `resource_update_tx` - Optional channel for sending resource updates to TUI
 #[allow(clippy::too_many_arguments)]
 async fn watch(
     project: Arc<Project>,
@@ -213,6 +217,7 @@ async fn watch(
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
     ignore_matcher: Option<Arc<GlobSet>>,
     app_dir: PathBuf,
+    resource_update_tx: Option<ResourceUpdateSender>,
 ) -> Result<(), anyhow::Error> {
     tracing::debug!(
         "Starting file watcher for project: {:?}",
@@ -260,6 +265,13 @@ async fn watch(
                     receiver_ack.send_replace(EventBuckets::new(ignore_matcher.clone(), app_dir.clone()));
                     rx.mark_unchanged();
 
+                    // Notify TUI that changes are being applied
+                    if let Some(ref tx) = resource_update_tx {
+                        let _ = tx.send(ResourceUpdate::ApplyingChanges);
+                    }
+
+                    // Begin processing - guard will mark complete on drop
+                    let _processing_guard = processing_coordinator.begin_processing().await;
                     let result: anyhow::Result<()> = with_spinner_completion_async(
                         "Processing Infrastructure changes from file watcher",
                         "Infrastructure changes processed successfully",
@@ -309,11 +321,28 @@ async fn watch(
                                             })
                                             .await?;
 
+                                            // Notify TUI of successful changes with updated resource list
+                                            if let Some(ref tx) = resource_update_tx {
+                                                let resource_list = ResourceList::from_infrastructure_map(
+                                                    &plan_result.target_infra_map
+                                                );
+                                                let _ = tx.send(ResourceUpdate::ChangesApplied {
+                                                    resource_list,
+                                                    changes: Vec::new(), // TODO: Extract changes from plan_result
+                                                });
+                                            }
+
                                             let mut infra_ptr = infrastructure_map.write().await;
                                             *infra_ptr = plan_result.target_infra_map
                                         }
                                         Err(e) => {
                                             let error: anyhow::Error = e.into();
+                                            // Notify TUI of failure
+                                            if let Some(ref tx) = resource_update_tx {
+                                                let _ = tx.send(ResourceUpdate::ChangeFailed(
+                                                    format!("Execution failed: {error}")
+                                                ));
+                                            }
                                             show_message!(MessageType::Error, {
                                                 Message {
                                                     action: "\nFailed".to_string(),
@@ -327,6 +356,12 @@ async fn watch(
                                 }
                                 Err(e) => {
                                     let error: anyhow::Error = e.into();
+                                    // Notify TUI of failure
+                                    if let Some(ref tx) = resource_update_tx {
+                                        let _ = tx.send(ResourceUpdate::ChangeFailed(
+                                            format!("Planning failed: {error}")
+                                        ));
+                                    }
                                     show_message!(MessageType::Error, {
                                         Message {
                                             action: "\nFailed".to_string(),
@@ -354,6 +389,12 @@ async fn watch(
                                 .await;
                         }
                         Err(e) => {
+                            // Notify TUI of failure
+                            if let Some(ref tx) = resource_update_tx {
+                                let _ = tx.send(ResourceUpdate::ChangeFailed(
+                                    format!("Processing failed: {e}")
+                                ));
+                            }
                             show_message!(MessageType::Error, {
                                 Message {
                                     action: "Failed".to_string(),
@@ -395,6 +436,7 @@ impl FileWatcher {
     /// * `settings` - CLI settings configuration
     /// * `processing_coordinator` - Coordinator for synchronizing with MCP tools
     /// * `shutdown_rx` - Receiver to listen for shutdown signal
+    /// * `resource_update_tx` - Optional channel for sending resource updates to TUI
     #[allow(clippy::too_many_arguments)]
     pub fn start(
         &self,
@@ -410,6 +452,7 @@ impl FileWatcher {
         settings: Settings,
         processing_coordinator: ProcessingCoordinator,
         shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        resource_update_tx: Option<ResourceUpdateSender>,
     ) -> Result<(), Error> {
         // Validate ignore patterns early so errors are shown to the user
         let ignore_matcher = project
@@ -442,6 +485,7 @@ impl FileWatcher {
                 shutdown_rx,
                 ignore_matcher,
                 app_dir,
+                resource_update_tx,
             )
             .await
         };


### PR DESCRIPTION
Add infrastructure startup integration for TUI mode:
- dev.rs: InfraBootError + run_infrastructure_with_updates function
  that sends real-time status updates during infrastructure boot
- watcher.rs: Add resource_update_tx parameter for TUI resource updates
- routines/mod.rs: Update watcher.start() call to pass None

These functions are marked with #[allow(dead_code)] temporarily
as they'll be called from TUI entry point in PR5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev infrastructure boot/validation and watcher execution paths; while behavior is mostly additive behind optional channels, new health polling and error mapping could affect startup timing or failure reporting.
> 
> **Overview**
> Adds an async `run_infrastructure_with_updates` path (plus `InfraBootError`) that mirrors local infra startup but emits `InfraStatusUpdate` events for Docker checks, compose generation, container startup, and per-service validation/health polling.
> 
> Extends the Python `FileWatcher` to optionally send `ResourceUpdate` events (`ApplyingChanges`, `ChangesApplied` with a rebuilt `ResourceList`, and `ChangeFailed`) during plan/execute/persist, and wires non-TUI dev mode to pass `None`; removes module-wide `dead_code` allows in `dev_tui` types in favor of targeted annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 928d2e0b3ab8fad615f3b36b947279ba88ff8bf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->