### PR TITLE
Add moose help command with Graphite-style output

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -215,7 +215,16 @@ pub fn prompt_password(prompt_text: &str) -> Result<String, RoutineFailure> {
 }
 
 #[derive(Parser)]
-#[command(author, version = constants::CLI_VERSION, about, long_about = None, arg_required_else_help(true), next_display_order = None)]
+#[command(
+    author,
+    version = constants::CLI_VERSION,
+    about = "Build data-intensive apps and services with Moose",
+    long_about = None,
+    arg_required_else_help(true),
+    next_display_order = None,
+    disable_help_subcommand = true,
+    after_help = "Run 'moose help' for detailed documentation and links"
+)]
 pub struct Cli {
     /// Turn debugging information on
     #[arg(short, long)]
@@ -412,6 +421,13 @@ pub async fn top_command_handler(
     machine_id: String,
 ) -> Result<RoutineSuccess, RoutineFailure> {
     match commands {
+        Commands::Help {} => {
+            routines::help::display_help();
+            Ok(RoutineSuccess::success(Message::new(
+                "".to_string(),
+                "".to_string(),
+            )))
+        }
         Commands::Init {
             name,
             location,

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -7,6 +7,9 @@ use clap::{Args, Subcommand};
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Display help information with links to documentation
+    Help {},
+
     // Initializes the developer environment with all the necessary directories including temporary ones for data storage
     /// Initialize your data-intensive app or service
     Init {

--- a/apps/framework-cli/src/cli/routines/help.rs
+++ b/apps/framework-cli/src/cli/routines/help.rs
@@ -1,0 +1,96 @@
+//! Help command display module
+//!
+//! Provides a styled help output following Graphite CLI best practices.
+
+use crate::utilities::constants::CLI_VERSION;
+
+/// Documentation and community URLs
+const DOCS_URL: &str = "https://docs.moosejs.com";
+const QUICKSTART_URL: &str = "https://docs.moosejs.com/moosestack/getting-started/quickstart";
+const TROUBLESHOOTING_URL: &str = "https://docs.moosejs.com/moosestack/help/troubleshooting";
+const GITHUB_ISSUES_URL: &str = "https://github.com/514-labs/moose/issues";
+const SLACK_COMMUNITY_URL: &str =
+    "https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg";
+
+/// Display the styled help output
+pub fn display_help() {
+    let help_text = format!(
+        r#"
+Moose (moose) is a type-safe, code-first toolkit for building real-time
+analytical backends. Declare all infrastructure and pipelines in TypeScript
+or Python, and Moose auto-wires everything together.
+
+USAGE
+  $ moose <command> [options]
+
+TERMS
+  data model:  A typed schema definition that represents your data structure.
+               Used to create tables, streams, and APIs automatically.
+  stream:      A Kafka/Redpanda topic for real-time data ingestion and
+               processing. Connects ingest APIs to tables.
+  table:       A ClickHouse OLAP table for storing and querying data.
+               Automatically created from your data models.
+  workflow:    A Temporal-powered background task for ETL pipelines,
+               scheduled jobs, and complex data processing.
+  api:         HTTP endpoints for data ingestion (POST) and analytics (GET).
+               Auto-generated with type validation.
+
+CORE COMMANDS
+  moose init:           Create a new Moose project with your preferred language
+  moose dev:            Start local development server with hot reload
+  moose build:          Build your project for production deployment
+  moose plan:           Preview infrastructure changes before deployment
+  moose migrate:        Execute migration plan against production database
+
+  Run moose <command> --help for specific command help
+  (e.g., moose init --help)
+
+CORE WORKFLOW
+  1. Initialize your project:
+     $ moose init my-app typescript   # or python
+
+  2. Start development server:
+     $ cd my-app && moose dev
+
+  3. Define data models in code - infrastructure auto-updates on save
+
+  4. Build and deploy to production:
+     $ moose build
+     $ moose plan --clickhouse-url <url>
+     $ moose migrate --clickhouse-url <url>
+
+LEARN MORE
+  Documentation:     {docs}
+  Quickstart Guide:  {quickstart}
+  Troubleshooting:   {troubleshooting}
+
+FEEDBACK
+  We'd love to hear your feedback! Join our Slack community at:
+      {slack}
+
+  Report issues or request features on GitHub:
+      {github}
+
+  Include your Moose version ({version}) when reporting issues.
+"#,
+        docs = DOCS_URL,
+        quickstart = QUICKSTART_URL,
+        troubleshooting = TROUBLESHOOTING_URL,
+        slack = SLACK_COMMUNITY_URL,
+        github = GITHUB_ISSUES_URL,
+        version = CLI_VERSION,
+    );
+
+    println!("{}", help_text);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_help_runs_without_panic() {
+        // This test just ensures the function doesn't panic
+        display_help();
+    }
+}

--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -163,6 +163,7 @@ pub mod code_generation;
 pub mod dev;
 pub mod docker_packager;
 pub mod format_query;
+pub mod help;
 pub mod kafka_pull;
 pub mod logs;
 pub mod ls;


### PR DESCRIPTION
## Summary
Implements a new `moose help` command that displays detailed documentation and community links following the Graphite CLI best practices pattern.

## Changes
- Add `Help` command to `Commands` enum with styled help output
- Create `help.rs` module with sections for:
  - **TERMS**: Explains Moose concepts (data model, stream, table, workflow, api)
  - **CORE COMMANDS**: Lists key commands (init, dev, build, plan, migrate)
  - **CORE WORKFLOW**: Step-by-step guide for getting started
  - **LEARN MORE**: Documentation links
  - **FEEDBACK**: Community resources (Slack, GitHub)
- Forward top-level `--help` to custom help (subcommand help uses clap's default)
- Include links to docs, quickstart, troubleshooting, Slack, and GitHub

## Why
The default clap help is functional but doesn't highlight community resources or provide context about Moose concepts. This custom help improves the first-run experience by:
1. Explaining key terms before listing commands
2. Showing a clear workflow for getting started
3. Making it easy to find documentation and get support

## Test Plan
- [x] `moose --help` shows custom help
- [x] `moose help` shows custom help
- [x] `moose init --help` shows clap's subcommand-specific help (unchanged)
- [x] All links are valid and up-to-date

## Notes
There are merge conflicts with main that will need to be resolved (primarily in `apps/framework-cli/src/cli.rs` due to import changes). The conflicts are straightforward and related to import ordering/additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX changes (help routing/output) with minimal impact on command execution paths.
> 
> **Overview**
> Introduces a new `moose help` subcommand that prints a curated, Graphite-style help page (terms, core commands/workflow, and links to docs/Slack/GitHub).
> 
> Updates CLI metadata to disable Clap’s built-in help subcommand and adds an `after_help` hint; `main.rs` now intercepts top-level `-h/--help` to show the custom help while allowing `moose <subcommand> --help` to continue using Clap’s default output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e42d56caa09761c250fd0ca2ceefd0876f9296d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->