### PR TITLE
Add --claude flag to moose docs command

### DIFF
--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -515,6 +515,10 @@ Guide sections (guides are large — navigate to specific sections):
   moose docs guides/chat-in-your-app#setup          View just the Setup section
   moose docs guides/performant-dashboards --web     Open full guide in the browser
 
+Claude integration (pipe docs to claude CLI):
+  moose docs <slug> --claude \"execute this step\"
+  moose docs guides/performant-dashboards#prepare --claude \"explain this\"
+
 Slugs are case-insensitive. Run `moose docs` to see all available slugs.")]
 pub struct DocsArgs {
     #[command(subcommand)]
@@ -538,6 +542,10 @@ pub struct DocsArgs {
     /// Open documentation page in your web browser instead of printing
     #[arg(long, global = true)]
     pub web: bool,
+
+    /// Pipe documentation to claude CLI with the given instruction
+    #[arg(long, global = true, value_name = "INSTRUCTION")]
+    pub claude: Option<String>,
 }
 
 /// Subcommands for the docs command


### PR DESCRIPTION
## Summary
Adds a `--claude <INSTRUCTION>` flag to the `moose docs` command that pipes documentation content directly to the claude CLI tool for AI-assisted processing.

## Motivation
Users requested the ability to quickly pipe documentation to Claude for execution or explanation, similar to:
```bash
moose docs guides/performant-dashboards#prepare --raw | claude "execute this step"
```

This PR makes it cleaner and more intuitive:
```bash
moose docs guides/performant-dashboards#prepare --claude "execute this step"
```

## Changes
- **Added `--claude <INSTRUCTION>` flag** to `DocsArgs` in `commands.rs`
- **Created `fetch_raw_content()` helper** in `docs.rs` to return raw documentation as a String
- **Integrated subprocess spawning** in `cli.rs` to pipe content to `claude` CLI
- **Added validation** to reject conflicting flags (`--web`) and subcommands (`browse`, `search`)
- **Updated help text** with examples of `--claude` usage

## Usage Examples
```bash
# Execute a documentation step
moose docs guides/performant-dashboards#prepare --claude "execute this step"

# Get an explanation
moose docs moosestack/olap --claude "explain this"

# Pipe the full TOC
moose docs --claude "list the main sections"

# Work with specific sections
moose docs guides/chat-in-your-app#overview --claude "summarize this"
```

## Testing
Thoroughly tested with "clumsy user" scenarios:
- ✅ Works with: pages, sections (#anchors), TOC, empty instructions
- ✅ Properly rejects: invalid slugs, conflicting flags, subcommands
- ✅ Clear error messages for all edge cases
- ✅ Clippy passes with 0 warnings

## Error Handling
```bash
# Conflicting flags
$ moose docs <slug> --web --claude "..."
❌ Error: --claude and --web cannot be used together

# Subcommands
$ moose docs browse --claude "..."
❌ Error: --claude cannot be used with subcommands (browse, search)

# Invalid page
$ moose docs fake/page --claude "..."
❌ Error: Page not found: 'fake/page'
```

@callicles Please review when you have a chance!

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs an external `claude` subprocess and streams fetched content into its stdin, so failures depend on user environment/PATH and process handling; core docs fetching behavior is otherwise minimally changed.
> 
> **Overview**
> Adds **Claude CLI piping** to `moose docs` via a new `--claude <INSTRUCTION>` flag, which fetches the requested docs (or TOC) and writes the raw markdown to a spawned `claude` subprocess.
> 
> Introduces `routines::docs::fetch_raw_content()` to return cleaned page/section content for piping, updates docs help text with examples, and adds validation to reject incompatible usage (`--claude` with `--web` or `browse`/`search`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22375d1400f7197f76c787f423773531f73af064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->