### PR TITLE
docs: add example for using moose docs --raw with AI clients

### DIFF
--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -515,6 +515,9 @@ Guide sections (guides are large — navigate to specific sections):
   moose docs guides/chat-in-your-app#setup          View just the Setup section
   moose docs guides/performant-dashboards --web     Open full guide in the browser
 
+Example: use with your AI client
+  moose docs --raw guides/chat-in-your-app#setup | claude \"do this step, ask me any questions you need to execute\"
+
 Slugs are case-insensitive. Run `moose docs` to see all available slugs.")]
 pub struct DocsArgs {
     #[command(subcommand)]

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -476,6 +476,16 @@ moose docs guides/chat-in-your-app#setup
 ```
 If the section is not found, available sections are listed. When using `browse` on a guide page, a secondary section picker is shown.
 
+#### Use with AI Clients
+
+The `--raw` flag outputs unformatted markdown, making it easy to pipe documentation to AI clients for processing:
+
+```bash
+moose docs --raw guides/chat-in-your-app#setup | claude "do this step, ask me any questions you need to execute"
+```
+
+This pattern works with any AI client that accepts stdin, allowing you to get AI assistance on specific documentation sections.
+
 ### Feedback
 Submit feedback, report bugs, or join the community.
 ```bash


### PR DESCRIPTION
## Summary
Add documentation showing users how to pipe `moose docs --raw` output to AI clients, addressing @nico's feedback that a separate `--claude` flag is unnecessary.

## Changes
- Updated `moose docs --help` examples to show piping to AI clients
- Added "Use with AI Clients" section to CLI reference docs at `/moosestack/moose-cli`

## Example
```bash
moose docs --raw guides/chat-in-your-app#setup | claude "do this step, ask me any questions you need to execute"
```

This pattern works with any AI client that accepts stdin (Claude CLI, ChatGPT CLI, etc.), making a dedicated flag unnecessary.

cc @callicles 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates (CLI help text and docs site content) with no behavioral or runtime changes.
> 
> **Overview**
> Updates the `moose docs` help text to include an example of piping `--raw` guide-section output into an AI client via stdin.
> 
> Extends the CLI reference docs with a new **Use with AI Clients** section that explains `--raw` and provides the same pipe example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c50dfd53ee6e75effa902b2bd9f63d269b28182. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->