### PR TITLE
docs: fix chat-in-your-app frontmatter

### DIFF
--- a/apps/framework-docs-v2/content/guides/chat-in-your-app/build.mdx
+++ b/apps/framework-docs-v2/content/guides/chat-in-your-app/build.mdx
@@ -1,6 +1,5 @@
 ---
 title: Build
-status: "beta"
 description: Architecture decisions and implementation choices
 languages: ["typescript"]
 tags: ["MCP"]

--- a/apps/framework-docs-v2/content/guides/chat-in-your-app/overview.mdx
+++ b/apps/framework-docs-v2/content/guides/chat-in-your-app/overview.mdx
@@ -1,6 +1,5 @@
 ---
 title: Overview
-status: "beta"
 description: When and why to build data-connected chat
 languages: ["typescript"]
 tags: ["MCP"]

--- a/apps/framework-docs-v2/content/guides/chat-in-your-app/tutorial.mdx
+++ b/apps/framework-docs-v2/content/guides/chat-in-your-app/tutorial.mdx
@@ -1,6 +1,5 @@
 ---
 title: Tutorial
-status: "beta"
 description: Build chat from scratch or add to existing Next.js app
 languages: ["typescript"]
 tags: ["MCP"]
@@ -9,7 +8,7 @@ tags: ["MCP"]
 import { FileTree, Callout, BulletPointsCard, ToggleBlock } from "@/components/mdx";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 
-## Tutorial: From Parquet in S3 to Chat Application
+# Tutorial: From Parquet in S3 to Chat Application
 
 :::include /shared/chat-guide/prerequisites.mdx
 


### PR DESCRIPTION
Removes `status: "beta"` from chat-in-your-app guide pages that were missed in PR #3561.

## Changes
- Remove `status: "beta"` from overview.mdx, build.mdx, tutorial.mdx  
- Fix tutorial.mdx heading from h2 to h1

## Context
These files were part of the merged guides-reformatting PR but this commit landed 2 minutes after the PR was merged.

✅ Local build passes (244 pages generated successfully)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes affecting metadata and markdown heading structure; no runtime or data-handling impact.
> 
> **Overview**
> Removes the `status: "beta"` frontmatter field from the `chat-in-your-app` guide pages (`overview.mdx`, `build.mdx`, `tutorial.mdx`) so they no longer render as beta.
> 
> Also promotes the tutorial title from an H2 to an H1 (`##` → `#`) to fix page heading hierarchy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88bf66de8d17b8542b93eb57656a1b1b69811a05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->