### PR TITLE
Fix: Type error in URL_SYNCABLE_SETTINGS breaking Vercel build

### DIFF
--- a/apps/framework-docs-v2/src/config/guide-settings-config.ts
+++ b/apps/framework-docs-v2/src/config/guide-settings-config.ts
@@ -169,8 +169,8 @@ export const VISIBLE_SETTINGS = GUIDE_SETTINGS_CONFIG.filter(
 );
 
 // Get settings that should sync to URL (only global settings on guide pages)
-export const URL_SYNCABLE_SETTINGS = new Set(
-  GUIDE_SETTINGS_CONFIG.filter((config) => config.syncToUrl === true).map(
-    (config) => config.id,
-  ),
+export const URL_SYNCABLE_SETTINGS: Set<string> = new Set(
+  GUIDE_SETTINGS_CONFIG.filter(
+    (config) => "syncToUrl" in config && config.syncToUrl === true,
+  ).map((config) => config.id),
 );


### PR DESCRIPTION
## Summary
- Fixes Vercel build failure from #3501's URL param sync feature
- `as const` narrowed types caused `Set.has()` type mismatch
- Widened `URL_SYNCABLE_SETTINGS` to `Set<string>` and used `in` operator for property check

## Test plan
- [x] `next build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and small predicate changes in docs settings config; low risk aside from potentially altering which settings are considered URL-syncable if the guard logic is wrong.
> 
> **Overview**
> Fixes a Vercel/TypeScript build error around URL param syncing by changing `URL_SYNCABLE_SETTINGS` to an explicitly widened `Set<string>`, avoiding overly-narrow literal types from `as const`.
> 
> Also updates the filter to guard optional `syncToUrl` via an `in` check before testing `config.syncToUrl === true`, keeping URL-sync selection behavior the same while satisfying TS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e39930472de9b5bbe5c226490e0206d2da9e5c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->