### PR TITLE
Docs: Add interactive components architecture to GUIDES_README

### DIFF
--- a/apps/framework-docs-v2/GUIDES_README.md
+++ b/apps/framework-docs-v2/GUIDES_README.md
@@ -228,7 +228,7 @@ Guides use interactive MDX components (`SelectField`, `CheckboxGroup`, `Conditio
 
 ### Data Flow Overview
 
-```
+```text
 ┌─────────────────────┐     localStorage      ┌──────────────────────┐
 │  GlobalGuideCustomizer│ ──────────────────► │   ConditionalContent  │
 │  (wizard modal)      │  writes per-key:     │   (reads & renders)   │
@@ -284,6 +284,7 @@ Guides use interactive MDX components (`SelectField`, `CheckboxGroup`, `Conditio
 ### Adding a New Global Setting
 
 1. Add an entry to `GUIDE_SETTINGS_CONFIG` in `src/config/guide-settings-config.ts`:
+
    ```typescript
    {
      id: "newSetting",
@@ -298,6 +299,7 @@ Guides use interactive MDX components (`SelectField`, `CheckboxGroup`, `Conditio
      syncToUrl: false,      // Whether to include in URL params on guide pages
    },
    ```
+
 2. That's it — the wizard, summary panel, types, and storage all derive from this config automatically.
 3. Use `<ConditionalContent whenId="newSetting" whenValue="option1">` in MDX to show conditional content.
 


### PR DESCRIPTION
## Summary
- Documents the settings data flow for interactive guide components
- Explains storage namespaces (global vs page-level), the priority chain, and URL sync behavior
- Adds a file reference table and instructions for adding new global settings
- No code changes, docs only

## Test plan
- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds architectural guidance; no runtime or behavior changes.
> 
> **Overview**
> Adds a new **“Interactive Components & Settings Architecture”** section to `GUIDES_README.md` documenting how interactive MDX guide settings persist and resolve (global wizard vs per-page controls, localStorage key namespaces, and `ConditionalContent` priority order).
> 
> Also documents URL param syncing behavior, lists the key implementation files involved, and provides steps for adding a new global setting, plus links to related config and demo docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf823bdf1fd26cbeee8ec335a88e5e4766cbb559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->