### PR TITLE
Remove Boreal branding from CLI help command

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -243,7 +243,7 @@ pub fn prompt_password(prompt_text: &str) -> Result<String, RoutineFailure> {
   Email:          hello@fiveonefour.com
 
 \x1b[1;4mHOSTING\x1b[0m
-  Try Boreal, Fiveonefour's hosting platform built for MooseStack apps.
+  Try Fiveonefour's hosting platform built for MooseStack apps.
   Sign up for a free trial: https://fiveonefour.boreal.cloud/sign-up"
 )]
 pub struct Cli {


### PR DESCRIPTION
Keep the hosting URL since we have not migrated yet.

Slack thread: https://fiveonefour-workspace.slack.com/archives/C08BYKG5P7C/p1771346376263729?thread_ts=1771346350.772869&cid=C08BYKG5P7C

https://claude.ai/code/session_01H6MAHHAsAYoc36xtm1mXaQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string help text update; no behavioral, data, or security-impacting changes.
> 
> **Overview**
> Updates the CLI `--help`/after-help banner to remove the “Boreal” product name from the hosting blurb, while keeping the existing Fiveonefour hosting sign-up URL unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f04b0d4fc749643ed069b3d34c19a9aa1bc571ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->