### PR TITLE
Refactor MaterializedView to use unknown instead of any

### DIFF
--- a/packages/ts-moose-lib/src/dmv2/index.ts
+++ b/packages/ts-moose-lib/src/dmv2/index.ts
@@ -46,7 +46,13 @@ export type SimpleAggregated<
   _argType?: ArgType;
 };
 
-export { OlapTable, OlapConfig, S3QueueTableSettings } from "./sdk/olapTable";
+export {
+  OlapTable,
+  OlapConfig,
+  S3QueueTableSettings,
+  TableReference,
+  formatTableReference,
+} from "./sdk/olapTable";
 export { ClickHouseEngines } from "../dataModels/types";
 export {
   Stream,

--- a/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/materializedView.ts
@@ -1,23 +1,16 @@
 import { ClickHouseEngines } from "../../dataModels/types";
 import { Sql, toStaticQuery } from "../../sqlHelpers";
-import { OlapConfig, OlapTable } from "./olapTable";
+import {
+  OlapConfig,
+  OlapTable,
+  TableReference,
+  formatTableReference,
+} from "./olapTable";
 import { View } from "./view";
 import { IJsonSchemaCollection } from "typia";
 import { Column } from "../../dataModels/dataModelTypes";
 import { getMooseInternal, isClientOnlyMode } from "../internal";
 import { getSourceFileFromStack } from "../utils/stackTrace";
-
-/**
- * Helper function to format a table reference as `database`.`table` or just `table`
- */
-function formatTableReference(table: OlapTable<any> | View): string {
-  const database =
-    table instanceof OlapTable ? table.config.database : undefined;
-  if (database) {
-    return `\`${database}\`.\`${table.name}\``;
-  }
-  return `\`${table.name}\``;
-}
 
 /**
  * Configuration options for creating a Materialized View.
@@ -27,7 +20,7 @@ export interface MaterializedViewConfig<T> {
   /** The SQL SELECT statement or `Sql` object defining the data to be materialized. Dynamic SQL (with parameters) is not allowed here. */
   selectStatement: string | Sql;
   /** An array of OlapTable or View objects that the `selectStatement` reads from. */
-  selectTables: (OlapTable<any> | View)[];
+  selectTables: (TableReference | View)[];
 
   /** @deprecated See {@link targetTable}
    *  The name for the underlying target OlapTable that stores the materialized data. */

--- a/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
@@ -626,6 +626,29 @@ type EngineConfig<T> =
 export type OlapConfig<T> = EngineConfig<T> | LegacyOlapConfig<T>;
 
 /**
+ * Non-generic interface for referencing an OlapTable or View by name,
+ * without depending on the table's row type parameter.
+ *
+ * Use this in signatures that only need the table identity (name and
+ * optional database), avoiding the invariance issues of OlapTable<T>.
+ */
+export interface TableReference {
+  name: string;
+  config?: { database?: string };
+}
+
+/**
+ * Format a table reference as `database`.`table` or just `table`.
+ */
+export function formatTableReference(table: TableReference): string {
+  const database = table.config?.database;
+  if (database) {
+    return `\`${database}\`.\`${table.name}\``;
+  }
+  return `\`${table.name}\``;
+}
+
+/**
  * Represents an OLAP (Online Analytical Processing) table, typically corresponding to a ClickHouse table.
  * Provides a typed interface for interacting with the table.
  *

--- a/packages/ts-moose-lib/src/dmv2/sdk/view.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/view.ts
@@ -1,19 +1,7 @@
 import { Sql, toStaticQuery } from "../../sqlHelpers";
-import { OlapTable } from "./olapTable";
+import { TableReference, formatTableReference } from "./olapTable";
 import { getMooseInternal, isClientOnlyMode } from "../internal";
 import { getSourceFileFromStack } from "../utils/stackTrace";
-
-/**
- * Helper function to format a table reference as `database`.`table` or just `table`
- */
-function formatTableReference(table: OlapTable<any> | View): string {
-  const database =
-    table instanceof OlapTable ? table.config.database : undefined;
-  if (database) {
-    return `\`${database}\`.\`${table.name}\``;
-  }
-  return `\`${table.name}\``;
-}
 
 /**
  * Represents a database View, defined by a SQL SELECT statement based on one or more base tables or other views.
@@ -33,7 +21,7 @@ export class View {
   sourceTables: string[];
 
   /** Optional metadata for the view */
-  metadata: { [key: string]: any };
+  metadata: { [key: string]: unknown };
 
   /**
    * Creates a new View instance.
@@ -45,8 +33,8 @@ export class View {
   constructor(
     name: string,
     selectStatement: string | Sql,
-    baseTables: (OlapTable<any> | View)[],
-    metadata?: { [key: string]: any },
+    baseTables: (TableReference | View)[],
+    metadata?: { [key: string]: unknown },
   ) {
     if (typeof selectStatement !== "string") {
       selectStatement = toStaticQuery(selectStatement);


### PR DESCRIPTION
Replace OlapTable<any> with OlapTable<unknown> and { [key: string]: any }
with { [key: string]: unknown } in MaterializedViewConfig and
MaterializedView class for stricter type safety.