### PR TITLE
docs: update the 514 cli docs

### DIFF
--- a/apps/framework-docs-v2/content/hosting/cli/auth.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/auth.mdx
@@ -8,7 +8,13 @@ order: 1
 
 Use `514 auth` to establish the trust boundary for the CLI agent harness.
 
-Once authenticated, every other command (`setup`, `link`, and follow-on workflow commands) can act on your cloud OLAP workloads with the correct account and project permissions.
+Once authenticated, follow-on commands (`orgs`, `projects`, `setup`, and `link`) can act on your cloud OLAP workloads with the correct account and project permissions.
+
+## Usage
+
+```bash
+514 auth [OPTIONS] <COMMAND>
+```
 
 ## Subcommands
 
@@ -63,8 +69,20 @@ Recovery:
 514 auth whoami
 ```
 
+## Options
+
+- `--api-url <API_URL>`: Override API base URL (`HOSTING_CLI_API_URL`).
+- `-o, --org <ORG>`: Organization name or ID.
+- `--json`: Output as JSON.
+- `-v, --verbose...`: Enable verbose output (`-v` debug, `-vv` trace).
+- `-h, --help`: Print help.
+
 ## Related
 
+- [`514 --help`](/hosting/cli)
+- [`514 orgs`](/hosting/cli/orgs)
+- [`514 projects`](/hosting/cli/projects)
 - [`514 setup`](/hosting/cli/setup)
 - [`514 link`](/hosting/cli/link)
+- [`514 update`](/hosting/cli/update)
 - [Setup failures](/hosting/troubleshooting/setup-failures)

--- a/apps/framework-docs-v2/content/hosting/cli/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/index.mdx
@@ -1,0 +1,56 @@
+---
+title: --help
+description: Root command reference for 514.
+order: 0
+---
+
+# 514 --help
+
+Use `514 --help` to view the complete top-level command surface and global flags.
+
+## Usage
+
+```bash
+514 [OPTIONS] [COMMAND]
+```
+
+## Commands
+
+- `auth`: Manage authentication.
+- `orgs`: Manage organizations.
+- `link`: Link local repository to an existing Boreal project.
+- `projects`: Manage projects.
+- `setup`: Set up a hosting project locally (clone, branch, dev environment).
+- `update`: Update installed CLIs (`514` and/or `moose`).
+- `help`: Print help for the given command.
+
+## Global Options
+
+- `--api-url <API_URL>`: Override the hosting control plane API URL (`HOSTING_CLI_API_URL`).
+- `-o, --org <ORG>`: Organization name or ID.
+- `--json`: Output as JSON.
+- `-v, --verbose...`: Enable verbose logging (`-v` debug, `-vv` trace).
+- `-h, --help`: Print help.
+- `-V, --version`: Print version.
+
+## Examples
+
+```bash
+# Show top-level help
+514 --help
+
+# Show help for a specific command
+514 help setup
+
+# Use JSON output for automation
+514 --json projects list
+```
+
+## Related
+
+- [`514 auth`](/hosting/cli/auth)
+- [`514 orgs`](/hosting/cli/orgs)
+- [`514 projects`](/hosting/cli/projects)
+- [`514 setup`](/hosting/cli/setup)
+- [`514 link`](/hosting/cli/link)
+- [`514 update`](/hosting/cli/update)

--- a/apps/framework-docs-v2/content/hosting/cli/link.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/link.mdx
@@ -13,15 +13,19 @@ In the agent harness model, `link` maps your local repo to the correct hosted wo
 ## Syntax
 
 ```bash
-514 link [options]
+514 link [OPTIONS]
 ```
 
 ## Common Options
 
+- `--api-url <API_URL>`: Override API base URL (`HOSTING_CLI_API_URL`).
 - `--project <org>/<project>`: Explicit project slug override.
+- `-o, --org <ORG>`: Organization name or ID.
 - `--yes`: Auto-confirm safe prompts.
+- `--json`: Output as JSON.
 - `--no-input`: Disable prompts; fail fast on missing required input.
 - `--force-relink`: Replace an existing repo-level link.
+- `-v, --verbose...`: Enable verbose output (`-v` debug, `-vv` trace).
 
 ## Example
 
@@ -38,5 +42,8 @@ Expected outcome:
 ## Related
 
 - [`514 auth`](/hosting/cli/auth)
+- [`514 orgs`](/hosting/cli/orgs)
+- [`514 projects`](/hosting/cli/projects)
 - [`514 setup`](/hosting/cli/setup)
+- [`514 update`](/hosting/cli/update)
 - [Setup failures](/hosting/troubleshooting/setup-failures)

--- a/apps/framework-docs-v2/content/hosting/cli/orgs.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/orgs.mdx
@@ -1,0 +1,58 @@
+---
+title: orgs
+description: Manage organizations in the 514 hosting control plane.
+order: 4
+---
+
+# 514 orgs
+
+Use `514 orgs` to inspect available organizations and switch your active organization context.
+
+## Usage
+
+```bash
+514 orgs [OPTIONS] <COMMAND>
+```
+
+## Subcommands
+
+### List
+
+List organizations available to the current authenticated user.
+
+```bash
+514 orgs list
+```
+
+### Switch
+
+Switch the active organization context.
+
+```bash
+514 orgs switch <ORG_REF>
+```
+
+- `<ORG_REF>`: Organization ID, slug, or name.
+
+## Options
+
+- `--api-url <API_URL>`: Override API base URL (`HOSTING_CLI_API_URL`).
+- `-o, --org <ORG>`: Organization name or ID.
+- `--json`: Output as JSON.
+- `-v, --verbose...`: Enable verbose output (`-v` debug, `-vv` trace).
+- `-h, --help`: Print help.
+
+## Examples
+
+```bash
+514 orgs list
+514 orgs switch acme
+514 --json orgs list
+```
+
+## Related
+
+- [`514 auth`](/hosting/cli/auth)
+- [`514 projects`](/hosting/cli/projects)
+- [`514 setup`](/hosting/cli/setup)
+- [`514 link`](/hosting/cli/link)

--- a/apps/framework-docs-v2/content/hosting/cli/projects.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/projects.mdx
@@ -1,0 +1,48 @@
+---
+title: projects
+description: List hosting projects in an organization.
+order: 5
+---
+
+# 514 projects
+
+Use `514 projects` to inspect projects in the current or specified organization.
+
+## Usage
+
+```bash
+514 projects [OPTIONS] <COMMAND>
+```
+
+## Subcommands
+
+### List
+
+List projects in an organization.
+
+```bash
+514 projects list
+```
+
+## Options
+
+- `--api-url <API_URL>`: Override API base URL (`HOSTING_CLI_API_URL`).
+- `-o, --org <ORG>`: Organization name or ID.
+- `--json`: Output as JSON.
+- `-v, --verbose...`: Enable verbose output (`-v` debug, `-vv` trace).
+- `-h, --help`: Print help.
+
+## Examples
+
+```bash
+514 projects list
+514 projects list --org acme
+514 --json projects list
+```
+
+## Related
+
+- [`514 auth`](/hosting/cli/auth)
+- [`514 orgs`](/hosting/cli/orgs)
+- [`514 setup`](/hosting/cli/setup)
+- [`514 link`](/hosting/cli/link)

--- a/apps/framework-docs-v2/content/hosting/cli/setup.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/setup.mdx
@@ -6,24 +6,31 @@ order: 2
 
 # 514 setup
 
-Use `514 setup <org>/<project>` to bootstrap a local workspace from an existing Fiveonefour project.
+Use `514 setup <PROJECT_REF>` to bootstrap a local workspace from an existing Fiveonefour project.
 
 This command is the main provisioning step in the CLI agent harness: it verifies cloud access, prepares local git state, and creates a runnable workspace that stays aligned with the hosted project lifecycle.
 
 ## Syntax
 
 ```bash
-514 setup <org>/<project> [options]
+514 setup [OPTIONS] <PROJECT_REF>
 ```
+
+## Arguments
+
+- `<PROJECT_REF>`: Project reference as `<org>/<project>`, project name, project ID, or Boreal URL.
 
 ## Options
 
+- `--api-url <API_URL>`: Override API base URL (`HOSTING_CLI_API_URL`).
 - `--path <dir>`: Parent directory for clone destination.
 - `--dir-name <name>`: Local directory name override.
+- `-o, --org <ORG>`: Organization name or ID.
 - `--branch <name>`: Branch name to create.
 - `--no-branch`: Skip branch creation.
 - `--push`: Push created branch.
-- `--no-push`: Do not push branch.
+- `--json`: Output as JSON.
+- `-v, --verbose...`: Enable verbose output (`-v` debug, `-vv` trace).
 - `--run <install|dev|both|skip>`: Choose local follow-up action.
 - `--yes`: Auto-confirm safe prompts.
 - `--no-input`: Disable prompts and fail fast if required input is missing.
@@ -64,5 +71,8 @@ Expected flow:
 ## Related
 
 - [`514 auth`](/hosting/cli/auth)
+- [`514 orgs`](/hosting/cli/orgs)
+- [`514 projects`](/hosting/cli/projects)
 - [`514 link`](/hosting/cli/link)
+- [`514 update`](/hosting/cli/update)
 - [Setup failures](/hosting/troubleshooting/setup-failures)

--- a/apps/framework-docs-v2/content/hosting/cli/update.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/update.mdx
@@ -1,0 +1,47 @@
+---
+title: update
+description: Update installed CLI binaries.
+order: 6
+---
+
+# 514 update
+
+Use `514 update` to update installed CLI binaries.
+
+## Usage
+
+```bash
+514 update [OPTIONS] [TARGET]
+```
+
+## Arguments
+
+- `[TARGET]`: CLI target to update. Omit to update both.
+  - `514`
+  - `moose`
+
+## Options
+
+- `--api-url <API_URL>`: Override API base URL (`HOSTING_CLI_API_URL`).
+- `-o, --org <ORG>`: Organization name or ID.
+- `--json`: Output as JSON.
+- `-v, --verbose...`: Enable verbose output (`-v` debug, `-vv` trace).
+- `-h, --help`: Print help.
+
+## Examples
+
+```bash
+# Update both CLIs
+514 update
+
+# Update only 514 CLI
+514 update 514
+
+# Update only moose CLI
+514 update moose
+```
+
+## Related
+
+- [`514 --help`](/hosting/cli)
+- [`514 auth`](/hosting/cli/auth)

--- a/apps/framework-docs-v2/content/hosting/getting-started.mdx
+++ b/apps/framework-docs-v2/content/hosting/getting-started.mdx
@@ -9,8 +9,12 @@ order: 11
 This page has moved.
 
 Use:
+- [`514 --help`](/hosting/cli)
 - [`514 auth`](/hosting/cli/auth)
-- [`514 setup`](/hosting/cli/setup)
+- [`514 orgs`](/hosting/cli/orgs)
 - [`514 link`](/hosting/cli/link)
+- [`514 projects`](/hosting/cli/projects)
+- [`514 setup`](/hosting/cli/setup)
+- [`514 update`](/hosting/cli/update)
 - [Fiveonefour hosting to local setup](/hosting/workflow/fiveonefour-to-local-setup)
 - [Setup failures](/hosting/troubleshooting/setup-failures)

--- a/apps/framework-docs-v2/content/hosting/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/index.mdx
@@ -35,9 +35,13 @@ Verify the installation:
 
 ## Start Here
 
+- [`514 --help`](/hosting/cli) - View all top-level commands and global CLI flags.
 - [`514 auth`](/hosting/cli/auth) - Establish the CLI control plane session for agent runs.
-- [`514 setup`](/hosting/cli/setup) - Bootstrap a local workspace from an existing cloud OLAP project.
+- [`514 orgs`](/hosting/cli/orgs) - List organizations and switch active org context.
 - [`514 link`](/hosting/cli/link) - Attach an existing repository to a hosted project so agents can target the right workload.
+- [`514 projects`](/hosting/cli/projects) - List projects in an organization.
+- [`514 setup`](/hosting/cli/setup) - Bootstrap a local workspace from an existing cloud OLAP project.
+- [`514 update`](/hosting/cli/update) - Update installed CLI binaries.
 
 ## Workflow
 

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -1075,8 +1075,32 @@ const hostingNavigationConfig: NavigationConfig = [
   { type: "label", title: "CLI" },
   {
     type: "page",
+    slug: "hosting/cli",
+    title: "--help",
+    languages: ["typescript", "python"],
+  },
+  {
+    type: "page",
     slug: "hosting/cli/auth",
     title: "auth",
+    languages: ["typescript", "python"],
+  },
+  {
+    type: "page",
+    slug: "hosting/cli/orgs",
+    title: "orgs",
+    languages: ["typescript", "python"],
+  },
+  {
+    type: "page",
+    slug: "hosting/cli/link",
+    title: "link",
+    languages: ["typescript", "python"],
+  },
+  {
+    type: "page",
+    slug: "hosting/cli/projects",
+    title: "projects",
     languages: ["typescript", "python"],
   },
   {
@@ -1087,8 +1111,8 @@ const hostingNavigationConfig: NavigationConfig = [
   },
   {
     type: "page",
-    slug: "hosting/cli/link",
-    title: "link",
+    slug: "hosting/cli/update",
+    title: "update",
     languages: ["typescript", "python"],
   },
   { type: "separator" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes plus navigation updates; low risk aside from potential broken links/ordering if slugs are incorrect.
> 
> **Overview**
> Expands the Hosting docs’ `514` CLI reference by adding new pages for root help (`514 --help`) and the `orgs`, `projects`, and `update` commands, plus updates cross-links from Hosting entry points.
> 
> Refines existing command docs (`auth`, `setup`, `link`) with clearer usage/syntax, argument descriptions (notably `setup <PROJECT_REF>`), and a standardized global options section (e.g., `--api-url`, `--org`, `--json`, `--verbose`). Updates the Hosting navigation config to include the new CLI pages and ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a499bb5e381af128950781663d59f10b5db6fd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->