### PR TITLE
Use latest for E2E tests

### DIFF
--- a/templates/typescript-tests/package.json
+++ b/templates/typescript-tests/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.338",
+    "@514labs/moose-lib": "latest",
     "@koa/router": "^13.1.0",
     "@modelcontextprotocol/sdk": "1.26.0",
     "axios": "^1.7.7",
@@ -25,7 +25,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.338",
+    "@514labs/moose-cli": "latest",
     "@faker-js/faker": "^9.7.0",
     "@types/express": "^5.0.3",
     "@types/koa": "^2.15.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency version bump only, limited to the TypeScript test template; primary risk is CI/E2E flakiness from pulling new upstream releases.
> 
> **Overview**
> Updates the `templates/typescript-tests` E2E test template to use `latest` for `@514labs/moose-lib` and `@514labs/moose-cli` instead of a pinned `0.6.338` version, so tests track the newest Moose releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e20eaefb93658975cfa3ac9621847661a0c7399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->