### PR TITLE
ENG-2230: add scaffold for build-template-images workflow

### DIFF
--- a/.github/workflows/build-template-images.yaml
+++ b/.github/workflows/build-template-images.yaml
@@ -1,0 +1,32 @@
+name: Build Template Docker Images
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - "templates/**"
+
+  workflow_dispatch:
+    inputs:
+      template:
+        type: string
+        description: "Specific template to rebuild (e.g. 'python-fastapi'), or 'all' to rebuild everything. Leave empty to auto-detect from latest commit."
+        required: false
+        default: ""
+      build_all:
+        type: boolean
+        description: "Build all templates"
+        required: false
+        default: false
+
+jobs:
+  build:
+    name: Build Template Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Placeholder
+        run: echo "TODO: Implement template image building"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds an inert CI workflow with only a checkout and placeholder step; no production code or deployment behavior changes yet.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `build-template-images.yaml`, that triggers on changes under `templates/**` (and via manual dispatch) with inputs to target a specific template or build all.
> 
> The job currently only checks out the repo and runs a placeholder command, scaffolding future template Docker image builds without implementing them yet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c73847347ac1e6562874b4f228dfc627a9f2dae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->