### PR TITLE
update templates

### DIFF
--- a/templates/ads-b-frontend/moose/package.json
+++ b/templates/ads-b-frontend/moose/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/ads-b/package.json
+++ b/templates/ads-b/package.json
@@ -12,11 +12,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.19.33"
   },
   "pnpm": {

--- a/templates/brainwaves/apps/brainmoose/package.json
+++ b/templates/brainwaves/apps/brainmoose/package.json
@@ -7,14 +7,14 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "axios": "^1.7.9",
     "dotenv": "^16.4.5",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/github-dev-trends/apps/moose-backend/package.json
+++ b/templates/github-dev-trends/apps/moose-backend/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "@octokit/rest": "^21.1.1",
     "axios": "^1.7.7",
     "dotenv": "^16.4.7",
@@ -16,7 +16,7 @@
     "moose-objects": "workspace:*"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.19.33",
     "@octokit/types": "^14.1.0"
   },

--- a/templates/github-dev-trends/packages/moose-objects/package.json
+++ b/templates/github-dev-trends/packages/moose-objects/package.json
@@ -13,7 +13,7 @@
     "ts-patch": "^3.3.0"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "typia": "^9.6.1"
   }
 }

--- a/templates/live-heartrate-leaderboard/requirements.txt
+++ b/templates/live-heartrate-leaderboard/requirements.txt
@@ -5,5 +5,5 @@ python-dateutil>=2.8.2
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests>=2.31.0
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402

--- a/templates/live-heartrate-leaderboard/setup.py
+++ b/templates/live-heartrate-leaderboard/setup.py
@@ -7,8 +7,8 @@ setup(
         "kafka-python-ng==2.2.2",
         "clickhouse_connect==0.7.16",
         "requests==2.32.4",
-        "moose-cli==0.6.309",
-        "moose-lib==0.6.309",
+        "moose-cli==0.6.402",
+        "moose-lib==0.6.402",
         "streamlit>=1.32.0",
     ],
 )

--- a/templates/next-app-empty/moose/package-lock.json
+++ b/templates/next-app-empty/moose/package-lock.json
@@ -8,12 +8,12 @@
       "name": "moose",
       "version": "0.0",
       "dependencies": {
-        "@514labs/moose-lib": "0.6.309",
+        "@514labs/moose-lib": "0.6.402",
         "ts-patch": "^3.3.0",
         "typia": "^9.6.1"
       },
       "devDependencies": {
-        "@514labs/moose-cli": "0.6.309",
+        "@514labs/moose-cli": "0.6.402",
         "@types/node": "^20.12.12"
       }
     },
@@ -33,25 +33,25 @@
       }
     },
     "node_modules/@514labs/moose-cli": {
-      "version": "0.6.309",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.309.tgz",
-      "integrity": "sha512-0OkRXBeCrzljNkDBSeTigb2lCFl1F36UHTUoR3m6kj0p4fq7QQFzI7fvbDAHX+fCwWKRYq/1EHxCEaZutvHHFQ==",
+      "version": "0.6.402",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.402.tgz",
+      "integrity": "sha512-SppTwUKdpN9GVJP5p/kLopRWod8ioUVSSfo77NGjW+NBavdQsfB70LYj47nc5aJzvL1GsIE82k57c5r4ydOY9Q==",
       "dev": true,
       "bin": {
         "moose": "dist/index.js",
         "moose-cli": "dist/index.js"
       },
       "optionalDependencies": {
-        "@514labs/moose-cli-darwin-arm64": "0.6.309",
-        "@514labs/moose-cli-darwin-x64": "0.6.309",
-        "@514labs/moose-cli-linux-arm64": "0.6.309",
-        "@514labs/moose-cli-linux-x64": "0.6.309"
+        "@514labs/moose-cli-darwin-arm64": "0.6.402",
+        "@514labs/moose-cli-darwin-x64": "0.6.402",
+        "@514labs/moose-cli-linux-arm64": "0.6.402",
+        "@514labs/moose-cli-linux-x64": "0.6.402"
       }
     },
     "node_modules/@514labs/moose-cli-darwin-arm64": {
-      "version": "0.6.309",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-darwin-arm64/-/moose-cli-darwin-arm64-0.6.309.tgz",
-      "integrity": "sha512-JQgD+Nv1iMasJUU/MSN8cbMgPGTs3k8kglCN/QK92GZJARUFxGmKDZKel8XoNEoTMl3GYnZe1qyMAshaFrYGVw==",
+      "version": "0.6.402",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-darwin-arm64/-/moose-cli-darwin-arm64-0.6.402.tgz",
+      "integrity": "sha512-i+/I7FxkakFh7D8cQpNB8wiHluAFMMgEoFJW1e892giCAbhwdvHAPLq1TK6wPy/l+iukyG1jfFp0Uqmelak+eA==",
       "cpu": [
         "arm64"
       ],
@@ -62,9 +62,9 @@
       ]
     },
     "node_modules/@514labs/moose-cli-linux-arm64": {
-      "version": "0.6.309",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-arm64/-/moose-cli-linux-arm64-0.6.309.tgz",
-      "integrity": "sha512-tpftU0oRopmSVP4Bkai5Bj0eu+BJSzERpVfoqritflPMR8Rjxy2+gThi70MyPJb18dkQk1gWD8Fs+Wl5Yz4qAQ==",
+      "version": "0.6.402",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-arm64/-/moose-cli-linux-arm64-0.6.402.tgz",
+      "integrity": "sha512-4K0QsIiXJfMJKAYonCJBNHFEkQXqcf+WF05kNFF69s6hDrSh2m0DxY+xeB9hclhu2QMTskNN9jWPo8p+n1AteA==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +75,9 @@
       ]
     },
     "node_modules/@514labs/moose-cli-linux-x64": {
-      "version": "0.6.309",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-x64/-/moose-cli-linux-x64-0.6.309.tgz",
-      "integrity": "sha512-9HSdZnyFatd6E1uvhlf080ILICDS6vTaRhvH+OPZJ20T5L2mzOPATU6C8CBNfpQtFoTmrVhJ1xqhLWga0unSuQ==",
+      "version": "0.6.402",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-x64/-/moose-cli-linux-x64-0.6.402.tgz",
+      "integrity": "sha512-Q/tkb+ojTekqU/Yp7S8k+JIHEMA3XihZ7OC06OFM3OV4F3gvqrTHdPJcGkSl5iZEESoXPkAaXFkhSlaZuSdJJA==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       "optional": true
     },
     "node_modules/@514labs/moose-lib": {
-      "version": "0.6.309",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.309.tgz",
-      "integrity": "sha512-Ush3W+/ic8WobfbkhgwRC/ztsJGQXMmv4lwS0rVHQZ4V73ytvPQgu/aiL0H1jnfRJgE7Mp/Z+qgo+nWZXq93Zw==",
+      "version": "0.6.402",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.402.tgz",
+      "integrity": "sha512-2wE1+mwU2MBrVfph8/0jJ9E7C8xqyODvGvO13xnxWxb3g1bPK9xeHxsiG65MYctmUjtupvPG3N8KCrGCMgVbTw==",
       "dependencies": {
         "@514labs/kafka-javascript": "1.7.1-patch",
         "@clickhouse/client": "1.8.1",
@@ -111,11 +111,14 @@
         "jose": "5.9.2",
         "redis": "^4.6.13",
         "toml": "3.0.0",
-        "ts-node": "^10.9.1",
         "typescript": "~5.9.2"
       },
       "bin": {
-        "moose-runner": "dist/moose-runner.js"
+        "moose-runner": "dist/moose-runner.js",
+        "moose-tspc": "dist/moose-tspc.js"
+      },
+      "engines": {
+        "node": ">=20 <25"
       },
       "peerDependencies": {
         "ts-patch": "^3.3.0",
@@ -175,18 +178,6 @@
       "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.5.0.tgz",
       "integrity": "sha512-U3vDp+PDnNVEv6kia+Mq5ygnlMZzsYU+3TX+0da3XvL926jzYLMBlIvFUxe2+/5k47ySvnINRC/2QxVK7PC2/A==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.13.1",
@@ -307,16 +298,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -874,30 +855,6 @@
         "@temporalio/proto": "1.11.7"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "license": "MIT"
-    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -1122,18 +1079,6 @@
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
       },
       "engines": {
         "node": ">=0.4.0"
@@ -1627,12 +1572,6 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "license": "MIT"
-    },
     "node_modules/csv-parse": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
@@ -1687,15 +1626,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/drange": {
@@ -2341,12 +2271,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "license": "ISC"
     },
     "node_modules/mappersmith": {
       "version": "2.46.1",
@@ -3231,55 +3155,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "license": "MIT"
-    },
     "node_modules/ts-patch": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.3.0.tgz",
@@ -3436,12 +3311,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.4.2",
@@ -3620,15 +3489,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     }
   }

--- a/templates/next-app-empty/moose/package.json
+++ b/templates/next-app-empty/moose/package.json
@@ -7,13 +7,13 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "@514labs/moose-cli": "0.6.309"
+    "@514labs/moose-cli": "0.6.402"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/python-cluster/requirements.txt
+++ b/templates/python-cluster/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402
 faker
 sqlglot[rs]>=27.16.3

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,5 +1,5 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402

--- a/templates/python-experimental/requirements.txt
+++ b/templates/python-experimental/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402
 faker
 sqlglot[rs]>=27.16.3

--- a/templates/python-fastapi-client-only/requirements.txt
+++ b/templates/python-fastapi-client-only/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402
 faker
 fastapi[standard]

--- a/templates/python-fastapi/requirements.txt
+++ b/templates/python-fastapi/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402
 faker
 fastapi[standard]

--- a/templates/python-tests/requirements.txt
+++ b/templates/python-tests/requirements.txt
@@ -1,8 +1,8 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402
 faker
 sqlglot[rs]>=27.16.3
 fastapi[standard]

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.7.16
 requests==2.32.4
-moose-cli==0.6.309
-moose-lib==0.6.309
+moose-cli==0.6.402
+moose-lib==0.6.402
 faker
 sqlglot[rs]>=27.16.3

--- a/templates/typescript-cluster/package.json
+++ b/templates/typescript-cluster/package.json
@@ -11,7 +11,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"

--- a/templates/typescript-empty/package.json
+++ b/templates/typescript-empty/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "axios": "^1.7.7",
     "express": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/express": "^5.0.3",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"

--- a/templates/typescript-fastify/package.json
+++ b/templates/typescript-fastify/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "axios": "^1.7.7",
     "fastify": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },

--- a/templates/typescript-mcp/packages/moosestack-service/package.json
+++ b/templates/typescript-mcp/packages/moosestack-service/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.383",
+    "@514labs/moose-lib": "0.6.402",
     "@514labs/express-pbkdf2-api-key-auth": "^1.0.4",
     "@cfworker/json-schema": "4.1.1",
     "@modelcontextprotocol/sdk": "1.26.0",
@@ -18,7 +18,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.383",
+    "@514labs/moose-cli": "0.6.402",
     "@types/express": "^5.0.3",
     "@types/node": "^20.12.12"
   }

--- a/templates/typescript-mcp/pnpm-lock.yaml
+++ b/templates/typescript-mcp/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4(express@5.2.1)
       '@514labs/moose-lib':
-        specifier: 0.6.383
-        version: 0.6.383(@swc/core@1.15.11)(@types/node@20.19.30)(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
+        specifier: 0.6.402
+        version: 0.6.402(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 4.1.1
         version: 4.1.1
@@ -42,8 +42,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@514labs/moose-cli':
-        specifier: 0.6.383
-        version: 0.6.383
+        specifier: 0.6.402
+        version: 0.6.402
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
@@ -253,27 +253,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.383':
-    resolution: {integrity: sha512-LRuvzXJLvZrTKHTtfN5CBf6rYJAhmhAy9NRxlwi45c4/ByRTEPBWUeGbO84BkavwZ6fASdpvrgTPEePg2asnsw==}
+  '@514labs/moose-cli-darwin-arm64@0.6.402':
+    resolution: {integrity: sha512-i+/I7FxkakFh7D8cQpNB8wiHluAFMMgEoFJW1e892giCAbhwdvHAPLq1TK6wPy/l+iukyG1jfFp0Uqmelak+eA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.383':
-    resolution: {integrity: sha512-n9DQIsO0pF3kG2uoTQQYS2dw3bMewsK/mDFtmO02O/u8/ALvkqUAX8mqLAaVXDuDBTBadPLLsXpmvQLCiTuKfw==}
+  '@514labs/moose-cli-linux-arm64@0.6.402':
+    resolution: {integrity: sha512-4K0QsIiXJfMJKAYonCJBNHFEkQXqcf+WF05kNFF69s6hDrSh2m0DxY+xeB9hclhu2QMTskNN9jWPo8p+n1AteA==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.383':
-    resolution: {integrity: sha512-CkRyX9b21hXzWS+NsM/S5zWTDJwZgqciqr28xaMQmHF/9dyWnTf8k2dn5qRqU1etitjqueqm6Kfns3lkWW1z5Q==}
+  '@514labs/moose-cli-linux-x64@0.6.402':
+    resolution: {integrity: sha512-Q/tkb+ojTekqU/Yp7S8k+JIHEMA3XihZ7OC06OFM3OV4F3gvqrTHdPJcGkSl5iZEESoXPkAaXFkhSlaZuSdJJA==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.383':
-    resolution: {integrity: sha512-q/aBDCvYy8/VZerEFJNf6XXEqfKp7jQhfYhXEl25kDdDFHkom5TkzwqWgbVWG1AkHuIoHsBwJ8uY6UQ/v7eWtg==}
+  '@514labs/moose-cli@0.6.402':
+    resolution: {integrity: sha512-SppTwUKdpN9GVJP5p/kLopRWod8ioUVSSfo77NGjW+NBavdQsfB70LYj47nc5aJzvL1GsIE82k57c5r4ydOY9Q==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.383':
-    resolution: {integrity: sha512-Se7Sq1soyk9JebmnSK2v9YfTFHHMAJsjVMORR6jhBdhER1wtyZ0Cb/738jZ7VzTK9f0c1R3b0a0ipI0bV31/zw==}
+  '@514labs/moose-lib@0.6.402':
+    resolution: {integrity: sha512-2wE1+mwU2MBrVfph8/0jJ9E7C8xqyODvGvO13xnxWxb3g1bPK9xeHxsiG65MYctmUjtupvPG3N8KCrGCMgVbTw==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -415,10 +415,6 @@ packages:
   '@clickhouse/client@1.8.1':
     resolution: {integrity: sha512-Ec0pCdwftIPD7hCxhOukHS0Zxr2tDc5mNAHBqkT3c0c6GO2WQdZkME9+EcfGcoF7+foUp82F5a0bPfSDDjfWmg==}
     engines: {node: '>=16'}
-
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -706,9 +702,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
@@ -875,28 +868,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -1667,28 +1656,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.11':
     resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.11':
     resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.11':
     resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.11':
     resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
@@ -1764,28 +1749,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1849,18 +1830,6 @@ packages:
   '@temporalio/workflow@1.14.1':
     resolution: {integrity: sha512-MzshcoRo8zjQYa9WHrv3XC8LVvpRNSVaW3kOSTmHuTYDh/7be48WODOgs5yUpbnkpsw6rjVCDCgtB/K02cQwDg==}
     engines: {node: '>= 18.0.0'}
-
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2067,49 +2036,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2208,10 +2169,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -2276,9 +2233,6 @@ packages:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2547,9 +2501,6 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2682,10 +2633,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3527,28 +3474,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3611,9 +3554,6 @@ packages:
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   mappersmith@2.46.1:
     resolution: {integrity: sha512-Ac9UGnHmf5rNtbOxe/SmEwtFPmb2/ronEwQbWcS6uA6nXxGPyr+dhPpTmzCTmZosdc8reFdeSqOy+khEkCFogA==}
@@ -4483,6 +4423,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -4556,20 +4497,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
 
   ts-patch@3.3.0:
     resolution: {integrity: sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==}
@@ -4710,9 +4637,6 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -4825,10 +4749,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4868,22 +4788,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.383':
+  '@514labs/moose-cli-darwin-arm64@0.6.402':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.383':
+  '@514labs/moose-cli-linux-arm64@0.6.402':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.383':
+  '@514labs/moose-cli-linux-x64@0.6.402':
     optional: true
 
-  '@514labs/moose-cli@0.6.383':
+  '@514labs/moose-cli@0.6.402':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.383
-      '@514labs/moose-cli-linux-arm64': 0.6.383
-      '@514labs/moose-cli-linux-x64': 0.6.383
+      '@514labs/moose-cli-darwin-arm64': 0.6.402
+      '@514labs/moose-cli-linux-arm64': 0.6.402
+      '@514labs/moose-cli-linux-x64': 0.6.402
 
-  '@514labs/moose-lib@0.6.383(@swc/core@1.15.11)(@types/node@20.19.30)(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.402(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1
@@ -4900,16 +4820,12 @@ snapshots:
       jose: 5.9.2
       redis: 4.7.1
       toml: 3.0.0
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.19.30)(typescript@5.9.3)
       ts-patch: 3.3.0
       tsconfig-paths: 4.2.0
       typescript: 5.9.3
       typia: 9.7.2(@types/node@20.19.30)(typescript@5.9.3)
     transitivePeerDependencies:
-      - '@swc/core'
       - '@swc/helpers'
-      - '@swc/wasm'
-      - '@types/node'
       - encoding
       - esbuild
       - supports-color
@@ -5082,10 +4998,6 @@ snapshots:
   '@clickhouse/client@1.8.1':
     dependencies:
       '@clickhouse/client-common': 1.8.1
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@date-fns/tz@1.4.1': {}
 
@@ -5328,11 +5240,6 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6500,14 +6407,6 @@ snapshots:
       '@temporalio/proto': 1.14.1
       nexus-rpc: 0.0.1
 
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -6877,10 +6776,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.3.4:
-    dependencies:
-      acorn: 8.15.0
-
   acorn@8.15.0: {}
 
   agent-base@6.0.2:
@@ -6947,8 +6842,6 @@ snapshots:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
-
-  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -7226,8 +7119,6 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-require@1.1.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -7345,8 +7236,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  diff@4.0.4: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -8404,8 +8293,6 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
-
-  make-error@1.3.6: {}
 
   mappersmith@2.46.1: {}
 
@@ -9687,26 +9574,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.30)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.30
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.11
-
   ts-patch@3.3.0:
     dependencies:
       chalk: 4.1.2
@@ -9909,8 +9776,6 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  v8-compile-cache-lib@3.0.1: {}
-
   vary@1.1.2: {}
 
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
@@ -10087,8 +9952,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/templates/typescript-migrate-test/migration/package.json
+++ b/templates/typescript-migrate-test/migration/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-migrate-test/package.json
+++ b/templates/typescript-migrate-test/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -13,14 +13,14 @@
     "generate-runtime": "tspc app/index.ts"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.309",
+    "@514labs/moose-lib": "0.6.402",
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.309",
+    "@514labs/moose-cli": "0.6.402",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily dependency/version bumps in template scaffolding with no functional app code changes; risk is limited to potential template build/runtime regressions due to the upstream Moose update.
> 
> **Overview**
> Updates all shipped templates to use `@514labs/moose-lib`/`@514labs/moose-cli` (and Python `moose-lib`/`moose-cli`) version **0.6.402** (from **0.6.309** / **0.6.383**).
> 
> Refreshes template lockfiles accordingly (notably `next-app-empty` and `typescript-mcp`), including new `@514labs/moose-lib` metadata (Node engine range and additional `moose-tspc` bin) and removal of transitive deps no longer required by the updated packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a82976ddc3791f533fb8e1f48df29c75e302abd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->