### PR TITLE
respect tsconfig outDir everywhere

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -142,9 +142,7 @@ RUN npx moose check
 
 # Pre-compile TypeScript with moose plugins (typia, compilerPlugin)
 # This eliminates ts-node overhead at runtime for faster worker startup
-# Explicitly pass .moose/compiled as outDir to ensure a consistent path
-# in the Docker image, regardless of any outDir in the user's tsconfig.json
-RUN MOOSE_SOURCE_DIR='{}' npx moose-tspc .moose/compiled
+RUN MOOSE_SOURCE_DIR='{}' npx moose-tspc
 
 # Set environment variable to use pre-compiled JavaScript at runtime
 ENV MOOSE_USE_COMPILED=true"#,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Docker build-time TypeScript compilation output location, which can break container startup if runtime code assumes the previous `.moose/compiled` path.
> 
> **Overview**
> Generated Dockerfiles for TypeScript builds no longer pass an explicit `.moose/compiled` argument to `npx moose-tspc`, allowing compilation output to follow the user’s `tsconfig.json` `outDir` (or the tool default) consistently with non-Docker production compilation.
> 
> This removes the prior guarantee of a fixed compiled output path inside the image, so reviewers should confirm runtime still locates the compiled artifacts under the configured `outDir`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 260aa1a7104fc4000c0501f4975c25039a42d2e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->