### PR TITLE
fix: respect clickhouse native_port in docker compose host binding

### DIFF
--- a/apps/framework-cli/src/utilities/docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/docker-compose.yml.hbs
@@ -154,7 +154,7 @@ services:
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
     ports:
       - "${CLICKHOUSE_HOST_PORT:-18123}:8123"
-      - "9000:9000"
+      - "${CLICKHOUSE_NATIVE_PORT:-9000}:9000"
     networks:
       - clickhouse-network
     healthcheck:

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -252,6 +252,10 @@ impl DockerClient {
                 project.clickhouse_config.host_port.to_string(),
             )
             .env(
+                "CLICKHOUSE_NATIVE_PORT",
+                project.clickhouse_config.native_port.to_string(),
+            )
+            .env(
                 "REDIS_PORT",
                 project.redis_config.effective_port().to_string(),
             );

--- a/apps/framework-cli/src/utilities/prod-docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/prod-docker-compose.yml.hbs
@@ -167,7 +167,7 @@ services:
       - clickhouse-network
     ports:
       - "${CLICKHOUSE_HOST_PORT:-18123}:8123"
-      - "9000:9000"
+      - "${CLICKHOUSE_NATIVE_PORT:-9000}:9000"
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary

- Pass `CLICKHOUSE_NATIVE_PORT` env var from `ClickHouseConfig.native_port` in `start_containers()` (`docker.rs`)
- Use `${CLICKHOUSE_NATIVE_PORT:-9000}:9000` in both `docker-compose.yml.hbs` and `prod-docker-compose.yml.hbs`

Same class of bug as the Redis port fix (#3616). The `native_port` field (default 9000) was never forwarded to the compose templates — the mapping was hardcoded as `9000:9000`. The HTTP port (`host_port`) was already correctly parameterized via `CLICKHOUSE_HOST_PORT`.

## Test plan

- [ ] `cargo clippy --package moose-cli -- -D warnings` — clean
- [ ] `cargo test --package moose-cli` — all pass
- [ ] Manual: set `native_port = 9100` in `moose.config.toml`, run `moose dev`, verify `.moose/docker-compose.yml` shows `9100:9000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to container startup env wiring and compose port mapping; risk is limited to ClickHouse connectivity if a port is misconfigured.
> 
> **Overview**
> Fixes ClickHouse native (TCP) port binding in generated compose files by replacing the hardcoded `9000:9000` mapping with `${CLICKHOUSE_NATIVE_PORT:-9000}:9000` in both dev and prod templates.
> 
> Updates `DockerClient::start_containers()` to export `CLICKHOUSE_NATIVE_PORT` from `ClickHouseConfig.native_port`, ensuring user config is reflected in the rendered compose and runtime environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2305e9a330962c2753b63760ae7537fe7a2614c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->