### PR TITLE
docs: add WSL filesystem performance warning

### DIFF
--- a/apps/framework-docs-v2/content/shared/prerequisites/wsl-setup.mdx
+++ b/apps/framework-docs-v2/content/shared/prerequisites/wsl-setup.mdx
@@ -129,3 +129,9 @@ You need to install Node.js inside the WSL2 Ubuntu environment—not the Windows
 #### Step 5: Proceed with MooseStack installation
 
 You now have a working Ubuntu instance on your Windows machine with Docker and Node.js installed. Continue to the MooseStack CLI installation below—just make sure to run all commands in the Ubuntu terminal, not PowerShell or Command Prompt.
+
+<Callout type="warning" title="Keep your project files inside WSL, not on /mnt/c">
+  Store your MooseStack projects in your Linux home directory (e.g., `~/projects/my-moose-app`), **not** under `/mnt/c/` or any Windows-mounted path. Accessing files across the Windows/Linux boundary through `/mnt` is extremely slow—up to 30x slower than native Linux filesystem operations. This can make builds, tests, and the dev server painfully slow.
+
+  See Microsoft's [WSL filesystem documentation](https://learn.microsoft.com/en-us/windows/wsl/filesystems#file-storage-and-performance-across-file-systems) for more details on cross-filesystem performance.
+</Callout>


### PR DESCRIPTION
Add a callout warning users to keep MooseStack projects inside the WSL filesystem (e.g., ~/projects) rather than under /mnt/c, as cross-filesystem access is up to 30x slower. Links to official Microsoft WSL documentation.

Slack thread: https://fiveonefour-workspace.slack.com/archives/C06DHAPLKKP/p1771866896099629?thread_ts=1771864430.757809&cid=C06DHAPLKKP

https://claude.ai/code/session_01A2Rinyy1AUnfF8CcmrJKPX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or security.
> 
> **Overview**
> Adds a new warning callout to the WSL2 setup docs (`wsl-setup.mdx`) instructing users to keep MooseStack projects in the WSL/Linux filesystem (e.g., `~/projects`) rather than under `/mnt/c` due to major cross-filesystem performance penalties, with a link to Microsoft’s WSL filesystem guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 750aee120b9bf81c1249eed5b76640be2ed2494a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->