### PR TITLE
bump clickhouse-connect from 0.7.16 to 0.11.0 in core library and CLI codegen

### DIFF
--- a/apps/framework-cli/src/project/python_project.rs
+++ b/apps/framework-cli/src/project/python_project.rs
@@ -83,7 +83,7 @@ impl Default for PythonProject {
             version: Version::from_string("0.0".to_string()),
             python_requires,
             dependencies: vec![
-                format!("clickhouse_connect==0.7.16; {python_version}").to_string(),
+                format!("clickhouse_connect==0.11.0; {python_version}").to_string(),
                 format!("requests==2.32.4; {python_version}").to_string(),
                 moose_cli_requirement,
                 moose_lib_requirement,
@@ -241,7 +241,7 @@ mod tests {
         // assert_eq!(
         //     project.dependencies,
         //     vec![
-        //         "clickhouse_connect==0.7.16; python_version >= \"3.12\"".to_string(),
+        //         "clickhouse_connect==0.11.0; python_version >= \"3.12\"".to_string(),
         //         "requests==2.32.4; python_version >= \"3.12\"".to_string(),
         //         "moose-cli; python_version >= \"3.12\"".to_string(),
         //         "moose-lib; python_version >= \"3.12\"".to_string(),

--- a/apps/framework-cli/tests/python/project/requirements.txt
+++ b/apps/framework-cli/tests/python/project/requirements.txt
@@ -1,4 +1,4 @@
-clickhouse_connect==0.7.16; python_version >= "3.12"
+clickhouse_connect==0.11.0; python_version >= "3.12"
 requests==2.32.4; python_version >= "3.12"
 moose-cli; python_version >= "3.12"
 moose-lib; python_version >= "3.12"

--- a/packages/py-moose-lib/setup.py
+++ b/packages/py-moose-lib/setup.py
@@ -30,7 +30,7 @@ setup(
         "kafka-python-ng>=2.2.2",
         "redis>=6.2.0",
         "humanfriendly>=10.0",
-        "clickhouse_connect>=0.7.16",
+        "clickhouse_connect>=0.11.0",
         "requests>=2.32.3",
         "sqlglot[rs]>=27.16.3",
         "confluent-kafka[json,schemaregistry]>=2.11.1",


### PR DESCRIPTION
Update the source-of-truth locations: py-moose-lib setup.py (>=0.11.0),
python_project.rs default dependencies (==0.11.0), and the CLI test
fixture requirements.txt.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical dependency version bump with no logic changes; main risk is runtime incompatibility if `clickhouse_connect` APIs changed between versions.
> 
> **Overview**
> Bumps the ClickHouse Python client dependency from `clickhouse_connect` `0.7.16` to `0.11.0` across the Python project generator defaults and test fixture requirements.
> 
> Updates `py-moose-lib`’s `setup.py` to require `clickhouse_connect>=0.11.0`, aligning the library’s minimum supported client version with the CLI-generated projects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbaea74b2f34841010d701747a823fd0aec213ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->