### PR TITLE
fix(docs): use H2/H3 headings in API reference docs for TOC visibility

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/apis/analytics-api.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/analytics-api.mdx
@@ -564,7 +564,7 @@ def run(client: MooseClient, params: QueryParams):
   </LanguageTabContent>
 </LanguageTabs>
 
-#### Basic Query Parameter Interpolation
+### Basic Query Parameter Interpolation
 
 <LanguageTabs>
   <LanguageTabContent value="typescript">
@@ -653,7 +653,7 @@ UserTable = OlapTable[UserSchema]("users")
   </LanguageTabContent>
 </LanguageTabs>
 
-#### Table and Column References
+### Table and Column References
 
 <LanguageTabs>
   <LanguageTabContent value="typescript">
@@ -694,14 +694,14 @@ Static type checking ensures you only reference columns that actually exist.
 
 ### Advanced Query Patterns
 
-#### SQL Template Helpers
+### SQL Template Helpers
 
 The `sql` template tag provides helper methods for building dynamic queries safely:
 
 <LanguageTabs>
   <LanguageTabContent value="typescript">
 
-##### Combine SQL Fragments
+### Combine SQL Fragments
 
 Join an array of `Sql` fragments with a separator. Spaces are automatically added around separators that don't include them:
 
@@ -727,7 +727,7 @@ const whereClause = sql.join(conditions, "AND");
 // Result: `age` >= 18 AND `status` = 'active'
 ```
 
-##### Insert Raw SQL
+### Insert Raw SQL
 
 Insert raw SQL strings without parameterization. Use for SQL keywords, functions, or static values that can't be parameterized:
 
@@ -747,7 +747,7 @@ const sortedQuery = sql`SELECT * FROM ${UserTable} ORDER BY created_at ${directi
 Only use `sql.raw()` with trusted, static values. Never pass user input directly to `sql.raw()` as it bypasses SQL injection protection.
 </Callout>
 
-##### Build Queries Incrementally
+### Build Queries Incrementally
 
 Chain SQL fragments together to build queries step by step:
 
@@ -794,7 +794,7 @@ Python APIs use parameter binding with the `execute` method. See the examples be
   </LanguageTabContent>
 </LanguageTabs>
 
-#### Dynamic Column & Table Selection
+### Dynamic Column & Table Selection
 
 <LanguageTabs>
   <LanguageTabContent value="typescript">
@@ -886,7 +886,7 @@ UserTable = OlapTable[UserSchema]("users")
   </LanguageTabContent>
 </LanguageTabs>
 
-#### Conditional `WHERE` Clauses
+### Conditional `WHERE` Clauses
 
 Build `WHERE` clauses based on provided parameters using `sql.join()` and `Sql.append()`:
 

--- a/apps/framework-docs-v2/content/moosestack/apis/auth.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/auth.mdx
@@ -102,7 +102,7 @@ Moose validates JWT tokens using RS256 algorithm with your identity provider's p
 
 ### Step 1: Configure JWT Settings
 
-#### Option A: Configure in `moose.config.toml`
+### Option A: Configure in `moose.config.toml`
 
 ```toml filename=moose.config.toml
 [jwt]
@@ -122,7 +122,7 @@ audience = "my-moose-app"
   The `secret` field should contain your JWT **public key** used to verify signatures using RS256 algorithm.
 </Callout>
 
-#### Option B: Configure with Environment Variables
+### Option B: Configure with Environment Variables
 
 You can also set these values as environment variables:
 
@@ -155,7 +155,7 @@ You can configure both JWT and API Key authentication simultaneously. When both 
 
 ### Understanding Authentication Priority
 
-#### Default Behavior (No Enforcement)
+### Default Behavior (No Enforcement)
 
 By default, when both JWT and API Keys are configured, Moose tries JWT validation first, then falls back to API Key validation:
 
@@ -185,7 +185,7 @@ MOOSE_CONSUMPTION_API_KEY='your_pbkdf2_hmac_sha256_hashed_key'
 
 This allows you to use either authentication method for your clients.
 
-#### Enforcing JWT Only
+### Enforcing JWT Only
 
 If you want to **only** accept JWT tokens (no API key fallback), set the enforcement flags:
 
@@ -203,7 +203,7 @@ enforce_on_all_consumptions_apis = true
 
 ### Common Use Cases
 
-#### Use Case 1: Different Auth for Different Endpoints
+### Use Case 1: Different Auth for Different Endpoints
 
 Configure JWT for user-facing analytics endpoints, API keys for internal ingestion:
 
@@ -220,7 +220,7 @@ enforce_on_all_ingest_apis = false        # Allow fallback for /ingest/*
 MOOSE_INGEST_API_KEY='hashed_key_for_internal_services'
 ```
 
-#### Use Case 2: Migration from API Keys to JWT
+### Use Case 2: Migration from API Keys to JWT
 
 Start with both configured, no enforcement. Gradually migrate clients to JWT. Once complete, enable enforcement:
 


### PR DESCRIPTION
Convert H4 and H5 headings to H3 in analytics-api.mdx and auth.mdx so they appear in the Table of Contents. The TOC extraction regex only captures H2 and H3 headings.

Fixes: ENG-2353
Slack: https://fiveonefour-workspace.slack.com/archives/C08BYKG5P7C/p1771885448761529?thread_ts=1771885385.549939&cid=C08BYKG5P7C

https://claude.ai/code/session_01Cy9yHJFtTJftjKHDgYVBig

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only heading level changes to improve TOC extraction; no runtime or behavior impact.
> 
> **Overview**
> Promotes several sub-section headings in the API reference docs from H4/H5 to H3 so they are picked up by the Table of Contents extraction.
> 
> This update is applied across `analytics-api.mdx` (SQL/query-building sections) and `auth.mdx` (JWT configuration and auth-behavior sections), without changing the underlying examples or guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22051b795274b267890eb5428247af4d7804b755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->