### PR TITLE
Fix heading hierarchy in ClickHouse reference documentation

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/reference/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/reference/index.mdx
@@ -542,7 +542,7 @@ rows = client.query.execute(query, {"min_age": min_age, "country": country, "lim
 
 <LanguageTabs>
   <LanguageTabContent value="typescript" label="TypeScript">
-#### ClickHouseEngines Enum
+### ClickHouseEngines Enum
 Available table engines:
 
 ```ts
@@ -559,7 +559,7 @@ enum ClickHouseEngines {
 }
 ```
 
-#### ReplacingMergeTreeConfig&lt;T&gt;
+### ReplacingMergeTreeConfig&lt;T&gt;
 Configuration for ReplacingMergeTree tables:
 
 ```ts
@@ -572,7 +572,7 @@ type ReplacingMergeTreeConfig<T> = {
 }
 ```
 
-#### Replicated Engine Configurations
+### Replicated Engine Configurations
 Configuration for replicated table engines:
 
 ```ts
@@ -619,7 +619,7 @@ type ReplicatedSummingMergeTreeConfig<T> = {
 **Note**: The `keeperPath` and `replicaName` parameters are optional. When omitted, Moose uses smart defaults that work in both ClickHouse Cloud and self-managed environments (default path: `/clickhouse/tables/{uuid}/{shard}` with replica `{replica}`). You can still provide both parameters explicitly if you need custom replication paths.
   </LanguageTabContent>
   <LanguageTabContent value="python" label="Python">
-#### Engine Configuration Classes
+### Engine Configuration Classes
 Type-safe configuration classes for table engines:
 
 ```python


### PR DESCRIPTION
## Summary
Updated heading levels in the ClickHouse reference documentation to maintain proper semantic hierarchy and improve document structure.

## Changes
- Changed four level 4 headings (`####`) to level 3 headings (`###`) in the TypeScript and Python sections:
  - `ClickHouseEngines Enum`
  - `ReplacingMergeTreeConfig<T>`
  - `Replicated Engine Configurations`
  - `Engine Configuration Classes`

## Details
These headings are subsections within their respective language tabs and should be at level 3 rather than level 4 to maintain consistent document hierarchy. This improves accessibility and ensures proper heading structure for documentation navigation and table of contents generation.

https://claude.ai/code/session_01XoTrrBLft574zRyW7vNv6S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only heading level changes; no runtime or API behavior impact.
> 
> **Overview**
> Fixes heading hierarchy in the ClickHouse table-engine reference docs by promoting four subheadings inside the TypeScript/Python `LanguageTabs` from `####` to `###`.
> 
> This is a documentation-only structural change to improve semantic outline/ToC generation; no API text or code examples change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7490986203f7243de5edc8527aea92d7c1d654b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->