### PR TITLE
Nico/fix telemetry reporting

### DIFF
--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -7,6 +7,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  MOOSE_TELEMETRY__ENABLED: false
+  MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
+
 defaults:
   run:
     working-directory: ./apps/framework-cli
@@ -183,9 +187,6 @@ jobs:
 
       - name: Run CLI Tests
         run: cargo test
-        env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
 
       - name: Inspect Logs
         if: always()
@@ -296,9 +297,6 @@ jobs:
 
       - name: Run Module Compilation E2E Tests
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "Module Compilation"
-        env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
 
       - name: Inspect Logs
         if: always()
@@ -384,8 +382,6 @@ jobs:
       - name: Run TypeScript E2E Tests (Default Template)
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "typescript template default"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           TEST_PACKAGE_MANAGER: ${{ matrix.pm-name }}
 
       - name: Inspect Logs
@@ -454,8 +450,6 @@ jobs:
       - name: Run TypeScript E2E Tests (Tests Template)
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "typescript template tests"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           TEST_PACKAGE_MANAGER: ${{ matrix.pm-name }}
 
       - name: Inspect Logs
@@ -527,8 +521,6 @@ jobs:
       - name: Run Python E2E Tests (Default Template)
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "python template default"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           TEST_PACKAGE_MANAGER: pip
 
       - name: Inspect Logs
@@ -600,8 +592,6 @@ jobs:
       - name: Run Python E2E Tests (Tests Template)
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "python template tests"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           TEST_PACKAGE_MANAGER: pip
 
       - name: Inspect Logs
@@ -660,8 +650,6 @@ jobs:
       - name: Run TypeScript Backward Compatibility Test
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "TypeScript Tests Template - Upgrade"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           # Add test credentials for S3Queue tests
           TEST_AWS_ACCESS_KEY_ID: "test-access-key-id"
           TEST_AWS_SECRET_ACCESS_KEY: "test-secret-access-key"
@@ -730,8 +718,6 @@ jobs:
       - name: Run Python Backward Compatibility Test
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "Python Tests Template - Upgrade"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           # Add test credentials for S3Queue tests
           TEST_AWS_ACCESS_KEY_ID: "test-access-key-id"
           TEST_AWS_SECRET_ACCESS_KEY: "test-secret-access-key"
@@ -791,9 +777,6 @@ jobs:
 
       - name: Run TypeScript Cluster E2E Tests
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "TypeScript Cluster Template"
-        env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
 
       - name: Inspect Logs
         if: always()
@@ -858,9 +841,6 @@ jobs:
 
       - name: Run Python Cluster E2E Tests
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "Python Cluster Template"
-        env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
 
       - name: Inspect Logs
         if: always()
@@ -915,9 +895,6 @@ jobs:
 
       - name: Run OTLP Export E2E Tests
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "OTLP"
-        env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
 
       - name: Inspect Logs
         if: always()

--- a/.github/workflows/test-llm-docs-automation.yaml
+++ b/.github/workflows/test-llm-docs-automation.yaml
@@ -6,6 +6,10 @@ on:
     # Monday and Thursday at 6am PST
     - cron: '0 14 * * 1,4'
 
+env:
+  MOOSE_TELEMETRY__ENABLED: false
+  MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
+
 jobs:
   test-llm-docs:
     name: LLM Docs (${{ matrix.language }})
@@ -47,8 +51,6 @@ jobs:
       - name: Run LLM Docs Automation Test (${{ matrix.language }})
         run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test:llm-docs -- --grep "LLM Documentation Automation"
         env:
-          MOOSE_TELEMETRY__ENABLED: false
-          MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER: true
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only environment variable changes; main risk is misnaming the telemetry flags and unintentionally re-enabling telemetry or affecting test behavior.
> 
> **Overview**
> CI workflows now disable Moose telemetry globally by adding workflow-level `env` (`MOOSE_TELEMETRY__ENABLED=false` and `MOOSE_TELEMETRY__IS_MOOSE_DEVELOPER=true`) in `test-framework-cli` and `test-llm-docs-automation`.
> 
> Per-step `MOOSE_TELEMETRY_ENABLED=false` overrides were removed from multiple test steps so all jobs consistently inherit the same telemetry configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 319a31d26bd0fc4e3d3f181f6df4c3c577a5f3d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->