### PR TITLE
bump moose version in python to avoid sqlglotrs in templates

### DIFF
--- a/templates/live-heartrate-leaderboard/requirements.txt
+++ b/templates/live-heartrate-leaderboard/requirements.txt
@@ -5,5 +5,5 @@ python-dateutil>=2.8.2
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests>=2.31.0
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420

--- a/templates/python-cluster/requirements.txt
+++ b/templates/python-cluster/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420
 faker
 sqlglot[c]>=29.0.1

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,5 +1,5 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420

--- a/templates/python-experimental/requirements.txt
+++ b/templates/python-experimental/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420
 faker
 sqlglot[c]>=29.0.1

--- a/templates/python-fastapi-client-only/requirements.txt
+++ b/templates/python-fastapi-client-only/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420
 faker
 fastapi[standard]

--- a/templates/python-fastapi/requirements.txt
+++ b/templates/python-fastapi/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420
 faker
 fastapi[standard]

--- a/templates/python-tests/requirements.txt
+++ b/templates/python-tests/requirements.txt
@@ -1,8 +1,8 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420
 faker
 sqlglot[c]>=29.0.1
 fastapi[standard]

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.402
-moose-lib==0.6.402
+moose-cli==0.6.420
+moose-lib==0.6.420
 faker
 sqlglot[c]>=29.0.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates dependency pins in template `requirements.txt` files; no runtime code changes in this repo.
> 
> **Overview**
> Bumps the pinned `moose-cli` and `moose-lib` versions from `0.6.402` to `0.6.420` across all Python templates’ `requirements.txt` files (including the Streamlit live heartrate leaderboard template).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3efaa933c8f3d4e42a85888ebd410cc85f909a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->