### PR TITLE
docs: replace Boreal references with Fiveonefour in hosting CLI docs

### DIFF
--- a/apps/framework-docs-v2/content/hosting/cli/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/index.mdx
@@ -18,7 +18,7 @@ Use `514 --help` to view the complete top-level command surface and global flags
 
 - `auth`: Manage authentication.
 - `orgs`: Manage organizations.
-- `link`: Link local repository to an existing Boreal project.
+- `link`: Link local repository to an existing Fiveonefour project.
 - `projects`: Manage projects.
 - `setup`: Set up a hosting project locally (clone, branch, dev environment).
 - `update`: Update installed CLIs (`514` and/or `moose`).

--- a/apps/framework-docs-v2/content/hosting/cli/setup.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/setup.mdx
@@ -18,7 +18,7 @@ This command is the main provisioning step in the CLI agent harness: it verifies
 
 ## Arguments
 
-- `<PROJECT_REF>`: Project reference as `<org>/<project>`, project name, project ID, or Boreal URL.
+- `<PROJECT_REF>`: Project reference as `<org>/<project>`, project name, project ID, or Fiveonefour URL.
 
 ## Options
 


### PR DESCRIPTION
Slack thread: https://fiveonefour-workspace.slack.com/archives/C06UGJHPNQ1/p1772123249256349

https://claude.ai/code/session_01R4YqUvPuh4SMUyyuaq5c1g

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating product naming; no runtime or behavioral impact.
> 
> **Overview**
> Updates the hosting CLI documentation to replace remaining *Boreal* references with **Fiveonefour**, specifically in the `514 --help` command list (`link`) and the `514 setup` `<PROJECT_REF>` argument description (URL reference).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec6a141cabc5d1148c5067bc010d349f71343584. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->