### PR TITLE
update chat in your app guide

### DIFF
--- a/apps/framework-docs-v2/content/guides/chat-in-your-app/tutorial.mdx
+++ b/apps/framework-docs-v2/content/guides/chat-in-your-app/tutorial.mdx
@@ -562,7 +562,7 @@ From your monorepo root, run:
 moose add mcp-server --dir packages/moosestack-service
 ```
 
-This adds the MCP server (with `query_clickhouse` and `get_data_catalog` tools), adds the required npm dependencies, adds `MCP_API_KEY` to `.env.local`, and exports the MCP server from your project's entry file.
+This adds the MCP server (with `query_clickhouse` and `get_data_catalog` tools), adds the required npm dependencies, creates an `MCP_API_KEY` placeholder in `.env.local`, and exports the MCP server from your project's entry file.
 
 Add `--yes` to skip confirmation prompts, or `--overwrite` to replace existing files if re-running.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that change no runtime code. Main risk is user confusion if the new `moose` CLI steps or output wording diverge from current tooling.
> 
> **Overview**
> Updates the **Chat in your app** tutorial to replace long manual backend/frontend setup instructions with streamlined Moose CLI workflows.
> 
> The guide now directs readers to use `moose add mcp-server` (and `moose generate hash-token`) for backend MCP setup, and `moose add chat` for frontend chat/UI/API/env-var installation, including clearer “next steps” for wiring `MCP_API_TOKEN`, `ANTHROPIC_API_KEY`, and `ChatLayoutWrapper` into the root layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a5997272cd248b55c19c9744ff171ac6a265dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->