### PR TITLE
fix -Merge suffix position

### DIFF
--- a/packages/ts-moose-lib/src/sqlHelpers.ts
+++ b/packages/ts-moose-lib/src/sqlHelpers.ts
@@ -159,8 +159,14 @@ export class Sql {
           ([k, _]) => k === "aggregationFunction",
         );
         if (aggregationFunction !== undefined) {
-          this.strings[pos] +=
-            `${(aggregationFunction[1] as AggregationFunction).functionName}Merge(\`${child.name}\`)`;
+          const funcName = (aggregationFunction[1] as AggregationFunction)
+            .functionName;
+          const parenIdx = funcName.indexOf("(");
+          const mergedName =
+            parenIdx !== -1 ?
+              `${funcName.slice(0, parenIdx)}Merge${funcName.slice(parenIdx)}`
+            : `${funcName}Merge`;
+          this.strings[pos] += `${mergedName}(\`${child.name}\`)`;
         } else {
           this.strings[pos] += `\`${child.name}\``;
         }


### PR DESCRIPTION
no relevant bug fix in py-moose-lib because no relevant funcationality there

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk, localized change to SQL string generation for aggregated columns; main risk is altering generated ClickHouse function names for any existing `aggregationFunction` annotations that include parentheses.
> 
> **Overview**
> Fixes how `Sql` renders aggregated `Column`s by placing the `Merge` suffix **before** any existing parameter list in the annotated aggregation function name (e.g. `foo(…)` -> `fooMerge(…)`), instead of always appending `Merge` at the end.
> 
> This corrects generated ClickHouse SQL for *parametric* aggregate functions while preserving the previous behavior for non-parametric function names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6077c44aca9c29db05f897d5f8de33b11261753. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->