### PR TITLE
fix page scroll for chat component

### DIFF
--- a/templates/typescript-mcp/packages/web-app/src/components/layout/chat-layout-wrapper.tsx
+++ b/templates/typescript-mcp/packages/web-app/src/components/layout/chat-layout-wrapper.tsx
@@ -7,7 +7,7 @@ import { ChatButton } from "@/features/chat/chat-button";
 export function ChatLayoutWrapper({ children }: { children: React.ReactNode }) {
   return (
     <ResizableChatLayout className="h-screen">
-      <div className="flex flex-col min-h-screen">
+      <div className="flex flex-col h-full overflow-y-auto">
         <ContentHeader />
         <main className="bg-background">{children}</main>
         <ChatButton />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change adjusting layout classes to fix scrolling behavior; unlikely to affect data flow but could change page height/overflow behavior across routes using this wrapper.
> 
> **Overview**
> Fixes scrolling within the chat page layout by changing `ChatLayoutWrapper`’s inner container from `min-h-screen` to `h-full overflow-y-auto`, allowing content to scroll inside the resizable chat layout while keeping the overall layout at `h-screen`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83e1a0a4a9a0b0db7ab3a35dee60f30c20af0a88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->