### PR TITLE
Nicolas/fix lineage

### DIFF
--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -959,7 +959,7 @@ jobs:
         test-e2e-typescript-tests,
         test-e2e-python-default,
         test-e2e-python-tests,
-#        test-e2e-backward-compatibility-typescript,
+        test-e2e-backward-compatibility-typescript,
         test-e2e-backward-compatibility-python,
         test-e2e-cluster-typescript,
         test-e2e-cluster-python,
@@ -992,6 +992,7 @@ jobs:
              [[ "${{ needs.test-e2e-typescript-tests.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-python-default.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-python-tests.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-e2e-backward-compatibility-typescript.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-backward-compatibility-python.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-cluster-typescript.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-cluster-python.result }}" == "failure" ]] || \
@@ -1010,6 +1011,7 @@ jobs:
              [[ "${{ needs.test-e2e-typescript-tests.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-python-default.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-python-tests.result }}" == "success" ]] && \
+             [[ "${{ needs.test-e2e-backward-compatibility-typescript.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-backward-compatibility-python.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-cluster-typescript.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-cluster-python.result }}" == "success" ]] && \

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -35,7 +35,7 @@
 //! ```
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -743,6 +743,7 @@ impl PartialInfrastructureMap {
             moose_version: None,
         };
 
+        canonicalize_lineage_signatures(&mut infra_map);
         normalize_all_metadata_paths(&mut infra_map, project_root);
 
         Ok(infra_map)
@@ -1531,6 +1532,223 @@ fn normalize_all_metadata_paths(infra_map: &mut InfrastructureMap, project_root:
     }
 }
 
+#[derive(Debug, Default)]
+struct LineageSignatureIndex {
+    default_database_prefix: String,
+    table_ids_by_alias: HashMap<String, Vec<String>>,
+    topic_ids_by_alias: HashMap<String, Vec<String>>,
+    api_ids_by_alias: HashMap<String, Vec<String>>,
+    topic_table_sync_ids_by_alias: HashMap<String, Vec<String>>,
+    dmv1_view_ids_by_alias: HashMap<String, Vec<String>>,
+    sql_resource_ids_by_alias: HashMap<String, Vec<String>>,
+    materialized_view_ids_by_alias: HashMap<String, Vec<String>>,
+    view_ids_by_alias: HashMap<String, Vec<String>>,
+}
+
+fn reference_variants(reference: &str) -> Vec<String> {
+    let mut variants = vec![reference.to_string()];
+    let dot_normalized = reference.replace('.', "_");
+    if dot_normalized != reference {
+        variants.push(dot_normalized);
+    }
+    variants
+}
+
+fn add_alias(alias_map: &mut HashMap<String, Vec<String>>, alias: &str, id: &str) {
+    for variant in reference_variants(alias) {
+        alias_map.entry(variant).or_default().push(id.to_string());
+    }
+}
+
+fn choose_resolved_id(matches: Vec<String>, preferred_prefix: Option<&str>) -> Option<String> {
+    if matches.is_empty() {
+        return None;
+    }
+
+    let mut deduped = matches;
+    deduped.sort();
+    deduped.dedup();
+
+    if let Some(prefix) = preferred_prefix {
+        if let Some(preferred) = deduped.iter().find(|id| id.starts_with(prefix)) {
+            return Some(preferred.clone());
+        }
+    }
+
+    deduped.into_iter().next()
+}
+
+fn resolve_component_id(
+    alias_map: &HashMap<String, Vec<String>>,
+    reference: &str,
+    preferred_prefix: Option<&str>,
+) -> Option<String> {
+    let mut matches = Vec::new();
+    for variant in reference_variants(reference) {
+        if let Some(ids) = alias_map.get(&variant) {
+            matches.extend(ids.iter().cloned());
+        }
+    }
+    choose_resolved_id(matches, preferred_prefix)
+}
+
+fn build_lineage_signature_index(infra_map: &InfrastructureMap) -> LineageSignatureIndex {
+    let mut index = LineageSignatureIndex {
+        default_database_prefix: format!("{}_", infra_map.default_database),
+        ..Default::default()
+    };
+
+    for (id, table) in &infra_map.tables {
+        add_alias(&mut index.table_ids_by_alias, id, id);
+        add_alias(&mut index.table_ids_by_alias, &table.name, id);
+    }
+
+    for (id, topic) in &infra_map.topics {
+        add_alias(&mut index.topic_ids_by_alias, id, id);
+        add_alias(&mut index.topic_ids_by_alias, &topic.name, id);
+    }
+
+    for (id, api) in &infra_map.api_endpoints {
+        add_alias(&mut index.api_ids_by_alias, id, id);
+        add_alias(&mut index.api_ids_by_alias, &api.name, id);
+    }
+
+    for (id, sync) in &infra_map.topic_to_table_sync_processes {
+        add_alias(&mut index.topic_table_sync_ids_by_alias, id, id);
+        add_alias(
+            &mut index.topic_table_sync_ids_by_alias,
+            &format!("{} -> {}", sync.source_topic_id, sync.target_table_id),
+            id,
+        );
+    }
+
+    for (id, view) in &infra_map.dmv1_views {
+        add_alias(&mut index.dmv1_view_ids_by_alias, id, id);
+        add_alias(&mut index.dmv1_view_ids_by_alias, &view.name, id);
+    }
+
+    for (id, resource) in &infra_map.sql_resources {
+        add_alias(&mut index.sql_resource_ids_by_alias, id, id);
+        add_alias(&mut index.sql_resource_ids_by_alias, &resource.name, id);
+        add_alias(
+            &mut index.sql_resource_ids_by_alias,
+            &resource.id(&infra_map.default_database),
+            id,
+        );
+    }
+
+    for (id, mv) in &infra_map.materialized_views {
+        add_alias(&mut index.materialized_view_ids_by_alias, id, id);
+        add_alias(&mut index.materialized_view_ids_by_alias, &mv.name, id);
+    }
+
+    for (id, view) in &infra_map.views {
+        add_alias(&mut index.view_ids_by_alias, id, id);
+        add_alias(&mut index.view_ids_by_alias, &view.name, id);
+    }
+
+    index
+}
+
+fn canonicalize_signature(
+    signature: &InfrastructureSignature,
+    index: &LineageSignatureIndex,
+) -> InfrastructureSignature {
+    match signature {
+        InfrastructureSignature::Table { id } => InfrastructureSignature::Table {
+            id: resolve_component_id(
+                &index.table_ids_by_alias,
+                id,
+                Some(&index.default_database_prefix),
+            )
+            .unwrap_or_else(|| id.clone()),
+        },
+        InfrastructureSignature::Topic { id } => InfrastructureSignature::Topic {
+            id: resolve_component_id(&index.topic_ids_by_alias, id, None)
+                .unwrap_or_else(|| id.clone()),
+        },
+        InfrastructureSignature::ApiEndpoint { id } => InfrastructureSignature::ApiEndpoint {
+            id: resolve_component_id(&index.api_ids_by_alias, id, None)
+                .unwrap_or_else(|| id.clone()),
+        },
+        InfrastructureSignature::TopicToTableSyncProcess { id } => {
+            InfrastructureSignature::TopicToTableSyncProcess {
+                id: resolve_component_id(&index.topic_table_sync_ids_by_alias, id, None)
+                    .unwrap_or_else(|| id.clone()),
+            }
+        }
+        InfrastructureSignature::Dmv1View { id } => InfrastructureSignature::Dmv1View {
+            id: resolve_component_id(&index.dmv1_view_ids_by_alias, id, None)
+                .unwrap_or_else(|| id.clone()),
+        },
+        InfrastructureSignature::SqlResource { id } => InfrastructureSignature::SqlResource {
+            id: resolve_component_id(&index.sql_resource_ids_by_alias, id, None)
+                .unwrap_or_else(|| id.clone()),
+        },
+        InfrastructureSignature::MaterializedView { id } => {
+            InfrastructureSignature::MaterializedView {
+                id: resolve_component_id(&index.materialized_view_ids_by_alias, id, None)
+                    .unwrap_or_else(|| id.clone()),
+            }
+        }
+        InfrastructureSignature::View { id } => InfrastructureSignature::View {
+            id: resolve_component_id(&index.view_ids_by_alias, id, None)
+                .unwrap_or_else(|| id.clone()),
+        },
+    }
+}
+
+fn canonicalize_signature_vec(
+    signatures: &mut Vec<InfrastructureSignature>,
+    index: &LineageSignatureIndex,
+) {
+    let mut seen = HashSet::new();
+    let canonicalized = signatures
+        .iter()
+        .map(|signature| canonicalize_signature(signature, index))
+        .filter(|signature| seen.insert(signature.clone()))
+        .collect();
+    *signatures = canonicalized;
+}
+
+fn canonicalize_lineage_signatures(infra_map: &mut InfrastructureMap) {
+    let index = build_lineage_signature_index(infra_map);
+
+    for api in infra_map.api_endpoints.values_mut() {
+        canonicalize_signature_vec(&mut api.pulls_data_from, &index);
+        canonicalize_signature_vec(&mut api.pushes_data_to, &index);
+    }
+
+    for sql_resource in infra_map.sql_resources.values_mut() {
+        canonicalize_signature_vec(&mut sql_resource.pulls_data_from, &index);
+        canonicalize_signature_vec(&mut sql_resource.pushes_data_to, &index);
+    }
+
+    for workflow in infra_map.workflows.values_mut() {
+        let mut proto = workflow.to_proto();
+        let mut pulls = proto
+            .pulls_data_from
+            .into_iter()
+            .map(InfrastructureSignature::from_proto)
+            .collect::<Vec<_>>();
+        let mut pushes = proto
+            .pushes_data_to
+            .into_iter()
+            .map(InfrastructureSignature::from_proto)
+            .collect::<Vec<_>>();
+        canonicalize_signature_vec(&mut pulls, &index);
+        canonicalize_signature_vec(&mut pushes, &index);
+        proto.pulls_data_from = pulls.into_iter().map(|s| s.to_proto()).collect();
+        proto.pushes_data_to = pushes.into_iter().map(|s| s.to_proto()).collect();
+        *workflow = Workflow::from_proto(proto);
+    }
+
+    for web_app in infra_map.web_apps.values_mut() {
+        canonicalize_signature_vec(&mut web_app.pulls_data_from, &index);
+        canonicalize_signature_vec(&mut web_app.pushes_data_to, &index);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1709,6 +1927,98 @@ mod tests {
                 id: "OrdersEvents".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn canonicalizes_lineage_signatures_when_building_infra_map() {
+        let payload = json!({
+            "tables": {
+                "orders": {
+                    "name": "Orders",
+                    "columns": [],
+                    "orderBy": [],
+                    "version": "0.0"
+                }
+            },
+            "apis": {
+                "lineageApi": {
+                    "name": "lineageApi",
+                    "queryParams": [],
+                    "responseSchema": {},
+                    "pullsDataFrom": [{ "kind": "Table", "id": "Orders_0.0" }]
+                }
+            },
+            "sqlResources": {
+                "lineageSql": {
+                    "name": "lineageSql",
+                    "setup": [],
+                    "teardown": [],
+                    "pullsDataFrom": [{ "kind": "Table", "id": "Orders_0.0" }],
+                    "pushesDataTo": []
+                }
+            },
+            "workflows": {
+                "lineageWorkflow": {
+                    "name": "lineageWorkflow",
+                    "pullsDataFrom": [{ "kind": "Table", "id": "Orders_0.0" }],
+                    "pushesDataTo": []
+                }
+            },
+            "webApps": {
+                "lineageWebApp": {
+                    "name": "lineageWebApp",
+                    "mountPath": "/lineage",
+                    "pullsDataFrom": [{ "kind": "Table", "id": "Orders_0.0" }],
+                    "pushesDataTo": []
+                }
+            }
+        });
+
+        let partial: PartialInfrastructureMap =
+            serde_json::from_value(payload).expect("payload should deserialize");
+        let infra_map = partial
+            .into_infra_map(
+                SupportedLanguages::Typescript,
+                Path::new("app/index.ts"),
+                "local",
+                Path::new("/tmp"),
+            )
+            .expect("partial map should convert");
+
+        let expected_table_id = infra_map
+            .tables
+            .keys()
+            .find(|id| id.contains("Orders"))
+            .expect("expected Orders table to exist")
+            .clone();
+        let expected_lineage = vec![InfrastructureSignature::Table {
+            id: expected_table_id,
+        }];
+
+        let api = infra_map
+            .api_endpoints
+            .values()
+            .find(|api| api.name == "lineageApi")
+            .expect("lineageApi should exist");
+        assert_eq!(api.pulls_data_from("local"), expected_lineage);
+
+        let sql_resource = infra_map
+            .sql_resources
+            .get("lineageSql")
+            .expect("lineageSql should exist");
+        assert_eq!(sql_resource.pulls_data_from("local"), expected_lineage);
+
+        let workflow = infra_map
+            .workflows
+            .get("lineageWorkflow")
+            .expect("lineageWorkflow should exist");
+        assert_eq!(workflow.pulls_data_from(), expected_lineage);
+
+        let web_app = infra_map
+            .web_apps
+            .get("lineageWebApp")
+            .expect("lineageWebApp should exist");
+        assert_eq!(web_app.pulls_data_from, expected_lineage);
     }
 
     fn base_table_json() -> serde_json::Value {

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -35,7 +35,7 @@
 //! ```
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     path::{Path, PathBuf},
 };
 
@@ -743,7 +743,6 @@ impl PartialInfrastructureMap {
             moose_version: None,
         };
 
-        canonicalize_lineage_signatures(&mut infra_map);
         normalize_all_metadata_paths(&mut infra_map, project_root);
 
         Ok(infra_map)
@@ -1532,223 +1531,6 @@ fn normalize_all_metadata_paths(infra_map: &mut InfrastructureMap, project_root:
     }
 }
 
-#[derive(Debug, Default)]
-struct LineageSignatureIndex {
-    default_database_prefix: String,
-    table_ids_by_alias: HashMap<String, Vec<String>>,
-    topic_ids_by_alias: HashMap<String, Vec<String>>,
-    api_ids_by_alias: HashMap<String, Vec<String>>,
-    topic_table_sync_ids_by_alias: HashMap<String, Vec<String>>,
-    dmv1_view_ids_by_alias: HashMap<String, Vec<String>>,
-    sql_resource_ids_by_alias: HashMap<String, Vec<String>>,
-    materialized_view_ids_by_alias: HashMap<String, Vec<String>>,
-    view_ids_by_alias: HashMap<String, Vec<String>>,
-}
-
-fn reference_variants(reference: &str) -> Vec<String> {
-    let mut variants = vec![reference.to_string()];
-    let dot_normalized = reference.replace('.', "_");
-    if dot_normalized != reference {
-        variants.push(dot_normalized);
-    }
-    variants
-}
-
-fn add_alias(alias_map: &mut HashMap<String, Vec<String>>, alias: &str, id: &str) {
-    for variant in reference_variants(alias) {
-        alias_map.entry(variant).or_default().push(id.to_string());
-    }
-}
-
-fn choose_resolved_id(matches: Vec<String>, preferred_prefix: Option<&str>) -> Option<String> {
-    if matches.is_empty() {
-        return None;
-    }
-
-    let mut deduped = matches;
-    deduped.sort();
-    deduped.dedup();
-
-    if let Some(prefix) = preferred_prefix {
-        if let Some(preferred) = deduped.iter().find(|id| id.starts_with(prefix)) {
-            return Some(preferred.clone());
-        }
-    }
-
-    deduped.into_iter().next()
-}
-
-fn resolve_component_id(
-    alias_map: &HashMap<String, Vec<String>>,
-    reference: &str,
-    preferred_prefix: Option<&str>,
-) -> Option<String> {
-    let mut matches = Vec::new();
-    for variant in reference_variants(reference) {
-        if let Some(ids) = alias_map.get(&variant) {
-            matches.extend(ids.iter().cloned());
-        }
-    }
-    choose_resolved_id(matches, preferred_prefix)
-}
-
-fn build_lineage_signature_index(infra_map: &InfrastructureMap) -> LineageSignatureIndex {
-    let mut index = LineageSignatureIndex {
-        default_database_prefix: format!("{}_", infra_map.default_database),
-        ..Default::default()
-    };
-
-    for (id, table) in &infra_map.tables {
-        add_alias(&mut index.table_ids_by_alias, id, id);
-        add_alias(&mut index.table_ids_by_alias, &table.name, id);
-    }
-
-    for (id, topic) in &infra_map.topics {
-        add_alias(&mut index.topic_ids_by_alias, id, id);
-        add_alias(&mut index.topic_ids_by_alias, &topic.name, id);
-    }
-
-    for (id, api) in &infra_map.api_endpoints {
-        add_alias(&mut index.api_ids_by_alias, id, id);
-        add_alias(&mut index.api_ids_by_alias, &api.name, id);
-    }
-
-    for (id, sync) in &infra_map.topic_to_table_sync_processes {
-        add_alias(&mut index.topic_table_sync_ids_by_alias, id, id);
-        add_alias(
-            &mut index.topic_table_sync_ids_by_alias,
-            &format!("{} -> {}", sync.source_topic_id, sync.target_table_id),
-            id,
-        );
-    }
-
-    for (id, view) in &infra_map.dmv1_views {
-        add_alias(&mut index.dmv1_view_ids_by_alias, id, id);
-        add_alias(&mut index.dmv1_view_ids_by_alias, &view.name, id);
-    }
-
-    for (id, resource) in &infra_map.sql_resources {
-        add_alias(&mut index.sql_resource_ids_by_alias, id, id);
-        add_alias(&mut index.sql_resource_ids_by_alias, &resource.name, id);
-        add_alias(
-            &mut index.sql_resource_ids_by_alias,
-            &resource.id(&infra_map.default_database),
-            id,
-        );
-    }
-
-    for (id, mv) in &infra_map.materialized_views {
-        add_alias(&mut index.materialized_view_ids_by_alias, id, id);
-        add_alias(&mut index.materialized_view_ids_by_alias, &mv.name, id);
-    }
-
-    for (id, view) in &infra_map.views {
-        add_alias(&mut index.view_ids_by_alias, id, id);
-        add_alias(&mut index.view_ids_by_alias, &view.name, id);
-    }
-
-    index
-}
-
-fn canonicalize_signature(
-    signature: &InfrastructureSignature,
-    index: &LineageSignatureIndex,
-) -> InfrastructureSignature {
-    match signature {
-        InfrastructureSignature::Table { id } => InfrastructureSignature::Table {
-            id: resolve_component_id(
-                &index.table_ids_by_alias,
-                id,
-                Some(&index.default_database_prefix),
-            )
-            .unwrap_or_else(|| id.clone()),
-        },
-        InfrastructureSignature::Topic { id } => InfrastructureSignature::Topic {
-            id: resolve_component_id(&index.topic_ids_by_alias, id, None)
-                .unwrap_or_else(|| id.clone()),
-        },
-        InfrastructureSignature::ApiEndpoint { id } => InfrastructureSignature::ApiEndpoint {
-            id: resolve_component_id(&index.api_ids_by_alias, id, None)
-                .unwrap_or_else(|| id.clone()),
-        },
-        InfrastructureSignature::TopicToTableSyncProcess { id } => {
-            InfrastructureSignature::TopicToTableSyncProcess {
-                id: resolve_component_id(&index.topic_table_sync_ids_by_alias, id, None)
-                    .unwrap_or_else(|| id.clone()),
-            }
-        }
-        InfrastructureSignature::Dmv1View { id } => InfrastructureSignature::Dmv1View {
-            id: resolve_component_id(&index.dmv1_view_ids_by_alias, id, None)
-                .unwrap_or_else(|| id.clone()),
-        },
-        InfrastructureSignature::SqlResource { id } => InfrastructureSignature::SqlResource {
-            id: resolve_component_id(&index.sql_resource_ids_by_alias, id, None)
-                .unwrap_or_else(|| id.clone()),
-        },
-        InfrastructureSignature::MaterializedView { id } => {
-            InfrastructureSignature::MaterializedView {
-                id: resolve_component_id(&index.materialized_view_ids_by_alias, id, None)
-                    .unwrap_or_else(|| id.clone()),
-            }
-        }
-        InfrastructureSignature::View { id } => InfrastructureSignature::View {
-            id: resolve_component_id(&index.view_ids_by_alias, id, None)
-                .unwrap_or_else(|| id.clone()),
-        },
-    }
-}
-
-fn canonicalize_signature_vec(
-    signatures: &mut Vec<InfrastructureSignature>,
-    index: &LineageSignatureIndex,
-) {
-    let mut seen = HashSet::new();
-    let canonicalized = signatures
-        .iter()
-        .map(|signature| canonicalize_signature(signature, index))
-        .filter(|signature| seen.insert(signature.clone()))
-        .collect();
-    *signatures = canonicalized;
-}
-
-fn canonicalize_lineage_signatures(infra_map: &mut InfrastructureMap) {
-    let index = build_lineage_signature_index(infra_map);
-
-    for api in infra_map.api_endpoints.values_mut() {
-        canonicalize_signature_vec(&mut api.pulls_data_from, &index);
-        canonicalize_signature_vec(&mut api.pushes_data_to, &index);
-    }
-
-    for sql_resource in infra_map.sql_resources.values_mut() {
-        canonicalize_signature_vec(&mut sql_resource.pulls_data_from, &index);
-        canonicalize_signature_vec(&mut sql_resource.pushes_data_to, &index);
-    }
-
-    for workflow in infra_map.workflows.values_mut() {
-        let mut proto = workflow.to_proto();
-        let mut pulls = proto
-            .pulls_data_from
-            .into_iter()
-            .map(InfrastructureSignature::from_proto)
-            .collect::<Vec<_>>();
-        let mut pushes = proto
-            .pushes_data_to
-            .into_iter()
-            .map(InfrastructureSignature::from_proto)
-            .collect::<Vec<_>>();
-        canonicalize_signature_vec(&mut pulls, &index);
-        canonicalize_signature_vec(&mut pushes, &index);
-        proto.pulls_data_from = pulls.into_iter().map(|s| s.to_proto()).collect();
-        proto.pushes_data_to = pushes.into_iter().map(|s| s.to_proto()).collect();
-        *workflow = Workflow::from_proto(proto);
-    }
-
-    for web_app in infra_map.web_apps.values_mut() {
-        canonicalize_signature_vec(&mut web_app.pulls_data_from, &index);
-        canonicalize_signature_vec(&mut web_app.pushes_data_to, &index);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1930,7 +1712,7 @@ mod tests {
     }
 
     #[test]
-    fn canonicalizes_lineage_signatures_when_building_infra_map() {
+    fn preserves_lineage_signatures_when_building_infra_map() {
         let payload = json!({
             "tables": {
                 "orders": {
@@ -1985,14 +1767,8 @@ mod tests {
             )
             .expect("partial map should convert");
 
-        let expected_table_id = infra_map
-            .tables
-            .keys()
-            .find(|id| id.contains("Orders"))
-            .expect("expected Orders table to exist")
-            .clone();
         let expected_lineage = vec![InfrastructureSignature::Table {
-            id: expected_table_id,
+            id: "Orders_0.0".to_string(),
         }];
 
         let api = infra_map

--- a/apps/framework-cli/src/framework/typescript/bin.rs
+++ b/apps/framework-cli/src/framework/typescript/bin.rs
@@ -100,7 +100,9 @@ pub fn run(
     // This allows mooseRuntimeEnv.get() to return markers for later resolution
     // For runtime execution (functions/workflows), it will return actual env var values
     if binary_command == "dmv2-serializer" {
-        command.env("IS_LOADING_INFRA_MAP", "true");
+        command
+            .env("IS_LOADING_INFRA_MAP", "true")
+            .env("MOOSE_DEFAULT_DATABASE", &project.clickhouse_config.db_name);
     }
 
     for arg in args {

--- a/packages/ts-moose-lib/src/dmv2/dependencyAnalysis.ts
+++ b/packages/ts-moose-lib/src/dmv2/dependencyAnalysis.ts
@@ -41,7 +41,7 @@ interface RegistryLike {
 }
 
 interface RegistryIndex {
-  tableIdsByName: Map<string, string[]>;
+  tableIdsByAlias: Map<string, string[]>;
   topicIdsByName: Map<string, string[]>;
   tableIds: Set<string>;
   topicIds: Set<string>;
@@ -69,6 +69,49 @@ interface AnalysisContext {
 }
 
 const WRITE_METHODS = new Set(["insert", "send", "publish", "emit", "write"]);
+const DEFAULT_DATABASE_ENV_VAR = "MOOSE_DEFAULT_DATABASE";
+
+function resolveDefaultDatabase(): string {
+  const configured = process.env[DEFAULT_DATABASE_ENV_VAR]?.trim();
+  return configured && configured.length > 0 ? configured : "local";
+}
+
+function versionToSuffix(version: string | undefined): string | undefined {
+  return version ? version.replace(/\./g, "_") : undefined;
+}
+
+function inferVersionFromRegistryId(
+  tableName: string,
+  registryId: string,
+): string | undefined {
+  const prefix = `${tableName}_`;
+  if (!registryId.startsWith(prefix)) {
+    return undefined;
+  }
+  const suffix = registryId.slice(prefix.length);
+  return suffix.length > 0 ? suffix : undefined;
+}
+
+function buildCanonicalTableId(
+  tableName: string,
+  version: string | undefined,
+  database: string,
+): string {
+  const versionSuffix = versionToSuffix(version);
+  return versionSuffix ?
+      `${database}_${tableName}_${versionSuffix}`
+    : `${database}_${tableName}`;
+}
+
+function addAlias(
+  aliasMap: Map<string, string[]>,
+  alias: string,
+  id: string,
+): void {
+  const existing = aliasMap.get(alias) ?? [];
+  existing.push(id);
+  aliasMap.set(alias, existing);
+}
 
 function createEmptyResult(): DependencyAnalysisResult {
   return {
@@ -79,17 +122,47 @@ function createEmptyResult(): DependencyAnalysisResult {
 }
 
 function buildRegistryIndex(registry: RegistryLike): RegistryIndex {
-  const tableIdsByName = new Map<string, string[]>();
+  const tableIdsByAlias = new Map<string, string[]>();
   const topicIdsByName = new Map<string, string[]>();
   const tableIds = new Set<string>();
   const topicIds = new Set<string>();
+  const defaultDatabase = resolveDefaultDatabase();
 
   registry.tables.forEach((table: any, id: string) => {
-    tableIds.add(id);
-    const baseName = typeof table?.name === "string" ? table.name : id;
-    const existing = tableIdsByName.get(baseName) ?? [];
-    existing.push(id);
-    tableIdsByName.set(baseName, existing);
+    const tableName = typeof table?.name === "string" ? table.name : id;
+    const version =
+      typeof table?.config?.version === "string" ?
+        table.config.version
+      : inferVersionFromRegistryId(tableName, id);
+    const explicitDatabase =
+      (
+        typeof table?.config?.database === "string" &&
+        table.config.database.trim().length > 0
+      ) ?
+        table.config.database.trim()
+      : undefined;
+    const database = explicitDatabase ?? defaultDatabase;
+    const canonicalId = buildCanonicalTableId(tableName, version, database);
+
+    tableIds.add(canonicalId);
+
+    const aliases = new Set<string>([canonicalId, id, tableName]);
+    const baseId =
+      canonicalId.startsWith(`${database}_`) ?
+        canonicalId.slice(database.length + 1)
+      : canonicalId;
+    aliases.add(baseId);
+    if (version) {
+      aliases.add(`${tableName}_${version}`);
+      const versionSuffix = versionToSuffix(version);
+      if (versionSuffix) {
+        aliases.add(`${tableName}_${versionSuffix}`);
+      }
+    }
+
+    for (const alias of aliases) {
+      addAlias(tableIdsByAlias, alias, canonicalId);
+    }
   });
 
   registry.streams.forEach((stream: any, id: string) => {
@@ -101,7 +174,7 @@ function buildRegistryIndex(registry: RegistryLike): RegistryIndex {
   });
 
   return {
-    tableIdsByName,
+    tableIdsByAlias,
     topicIdsByName,
     tableIds,
     topicIds,
@@ -114,49 +187,49 @@ function resolveTableId(
   version: string | undefined,
   index: RegistryIndex,
 ): string {
+  const candidates = new Set<string>();
   if (version) {
-    const candidates = new Set<string>([`${tableName}_${version}`]);
-    if (version.includes(".")) {
-      candidates.add(`${tableName}_${version.replace(/\./g, "_")}`);
+    candidates.add(`${tableName}_${version}`);
+    const suffix = versionToSuffix(version);
+    if (suffix) {
+      candidates.add(`${tableName}_${suffix}`);
+    }
+  }
+  candidates.add(tableName);
+
+  for (const candidate of candidates) {
+    if (index.tableIds.has(candidate)) {
+      return candidate;
     }
 
-    for (const candidate of candidates) {
-      if (index.tableIds.has(candidate)) {
+    const ids = [...new Set(index.tableIdsByAlias.get(candidate) ?? [])].sort();
+    if (ids.length === 1) {
+      return ids[0];
+    }
+
+    if (ids.length > 1) {
+      const warningKey = `${candidate}:${ids.join(",")}`;
+      if (!index.warnedAmbiguousTableIds.has(warningKey)) {
+        index.warnedAmbiguousTableIds.add(warningKey);
+        compilerLog(
+          `Warning: ambiguous table lineage reference '${candidate}' resolved to '${ids[0]}' from candidates [${ids.join(", ")}]. Add an explicit version to disambiguate.`,
+        );
+      }
+      if (ids.includes(candidate)) {
         return candidate;
       }
-
-      const ids = index.tableIdsByName.get(candidate) ?? [];
-      if (ids.length === 1) {
-        return ids[0];
-      }
-      if (ids.length > 1) {
-        if (ids.includes(candidate)) {
-          return candidate;
-        }
-        return ids[0];
-      }
-    }
-
-    return `${tableName}_${version}`;
-  }
-
-  const ids = index.tableIdsByName.get(tableName) ?? [];
-  if (ids.length === 0) {
-    return tableName;
-  }
-  if (ids.includes(tableName)) {
-    return tableName;
-  }
-  if (ids.length > 1) {
-    const warningKey = `${tableName}:${ids.join(",")}`;
-    if (!index.warnedAmbiguousTableIds.has(warningKey)) {
-      index.warnedAmbiguousTableIds.add(warningKey);
-      compilerLog(
-        `Warning: ambiguous table lineage reference '${tableName}' resolved to '${ids[0]}' from candidates [${ids.join(", ")}]. Add an explicit version to disambiguate.`,
-      );
+      return ids[0];
     }
   }
-  return ids[0];
+
+  if (!version) {
+    return tableName;
+  }
+
+  const versionSuffix = versionToSuffix(version);
+  return versionSuffix ?
+      `${tableName}_${versionSuffix}`
+    : `${tableName}_${version}`;
 }
 
 function resolveTopicId(topicName: string, index: RegistryIndex): string {
@@ -193,10 +266,11 @@ function resolveResourceFromSqlIdentifier(
     if (suffix && suffix !== normalized) {
       candidates.add(suffix);
     }
+    candidates.add(normalized.replace(/\./g, "_"));
   }
 
   for (const candidate of [...candidates]) {
-    const versionedMatch = candidate.match(/^(.+)_\d+_\d+$/);
+    const versionedMatch = candidate.match(/^(.+)_\d+(?:_\d+)+$/);
     if (versionedMatch?.[1]) {
       candidates.add(versionedMatch[1]);
     }
@@ -206,7 +280,7 @@ function resolveResourceFromSqlIdentifier(
     if (index.tableIds.has(candidate)) {
       return { kind: "Table", id: candidate };
     }
-    if (index.tableIdsByName.has(candidate)) {
+    if (index.tableIdsByAlias.has(candidate)) {
       return { kind: "Table", id: resolveTableId(candidate, undefined, index) };
     }
     if (index.topicIds.has(candidate)) {
@@ -1683,7 +1757,7 @@ function createNameResolutionContext(checker: ts.TypeChecker): AnalysisContext {
   return {
     checker,
     registryIndex: {
-      tableIdsByName: new Map(),
+      tableIdsByAlias: new Map(),
       topicIdsByName: new Map(),
       tableIds: new Set(),
       topicIds: new Set(),

--- a/packages/ts-moose-lib/src/dmv2/dependencyAnalysis.ts
+++ b/packages/ts-moose-lib/src/dmv2/dependencyAnalysis.ts
@@ -1,10 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
-import process from "node:process";
 import ts from "typescript";
 
 import { getSourceDir } from "../compiler-config";
 import { compilerLog } from "../commons";
+import {
+  buildCanonicalLineageTableId,
+  inferVersionFromRegistryId,
+  normalizeLineageVersion,
+  resolveDefaultLineageDatabase,
+  resolveLineageDatabase,
+} from "./lineageTableId";
 import { findSourceFiles, isSourceFilePath } from "./utils";
 
 type SignatureKind =
@@ -69,39 +75,6 @@ interface AnalysisContext {
 }
 
 const WRITE_METHODS = new Set(["insert", "send", "publish", "emit", "write"]);
-const DEFAULT_DATABASE_ENV_VAR = "MOOSE_DEFAULT_DATABASE";
-
-function resolveDefaultDatabase(): string {
-  const configured = process.env[DEFAULT_DATABASE_ENV_VAR]?.trim();
-  return configured && configured.length > 0 ? configured : "local";
-}
-
-function versionToSuffix(version: string | undefined): string | undefined {
-  return version ? version.replace(/\./g, "_") : undefined;
-}
-
-function inferVersionFromRegistryId(
-  tableName: string,
-  registryId: string,
-): string | undefined {
-  const prefix = `${tableName}_`;
-  if (!registryId.startsWith(prefix)) {
-    return undefined;
-  }
-  const suffix = registryId.slice(prefix.length);
-  return suffix.length > 0 ? suffix : undefined;
-}
-
-function buildCanonicalTableId(
-  tableName: string,
-  version: string | undefined,
-  database: string,
-): string {
-  const versionSuffix = versionToSuffix(version);
-  return versionSuffix ?
-      `${database}_${tableName}_${versionSuffix}`
-    : `${database}_${tableName}`;
-}
 
 function addAlias(
   aliasMap: Map<string, string[]>,
@@ -126,7 +99,7 @@ function buildRegistryIndex(registry: RegistryLike): RegistryIndex {
   const topicIdsByName = new Map<string, string[]>();
   const tableIds = new Set<string>();
   const topicIds = new Set<string>();
-  const defaultDatabase = resolveDefaultDatabase();
+  const defaultDatabase = resolveDefaultLineageDatabase();
 
   registry.tables.forEach((table: any, id: string) => {
     const tableName = typeof table?.name === "string" ? table.name : id;
@@ -135,14 +108,15 @@ function buildRegistryIndex(registry: RegistryLike): RegistryIndex {
         table.config.version
       : inferVersionFromRegistryId(tableName, id);
     const explicitDatabase =
-      (
-        typeof table?.config?.database === "string" &&
-        table.config.database.trim().length > 0
-      ) ?
-        table.config.database.trim()
+      typeof table?.config?.database === "string" ?
+        table.config.database
       : undefined;
-    const database = explicitDatabase ?? defaultDatabase;
-    const canonicalId = buildCanonicalTableId(tableName, version, database);
+    const database = resolveLineageDatabase(explicitDatabase, defaultDatabase);
+    const canonicalId = buildCanonicalLineageTableId(
+      tableName,
+      version,
+      database,
+    );
 
     tableIds.add(canonicalId);
 
@@ -154,7 +128,7 @@ function buildRegistryIndex(registry: RegistryLike): RegistryIndex {
     aliases.add(baseId);
     if (version) {
       aliases.add(`${tableName}_${version}`);
-      const versionSuffix = versionToSuffix(version);
+      const versionSuffix = normalizeLineageVersion(version);
       if (versionSuffix) {
         aliases.add(`${tableName}_${versionSuffix}`);
       }
@@ -190,7 +164,7 @@ function resolveTableId(
   const candidates = new Set<string>();
   if (version) {
     candidates.add(`${tableName}_${version}`);
-    const suffix = versionToSuffix(version);
+    const suffix = normalizeLineageVersion(version);
     if (suffix) {
       candidates.add(`${tableName}_${suffix}`);
     }
@@ -208,17 +182,15 @@ function resolveTableId(
     }
 
     if (ids.length > 1) {
+      const resolvedId = ids.includes(candidate) ? candidate : ids[0];
       const warningKey = `${candidate}:${ids.join(",")}`;
       if (!index.warnedAmbiguousTableIds.has(warningKey)) {
         index.warnedAmbiguousTableIds.add(warningKey);
         compilerLog(
-          `Warning: ambiguous table lineage reference '${candidate}' resolved to '${ids[0]}' from candidates [${ids.join(", ")}]. Add an explicit version to disambiguate.`,
+          `Warning: ambiguous table lineage reference '${candidate}' resolved to '${resolvedId}' from candidates [${ids.join(", ")}]. Add an explicit version to disambiguate.`,
         );
       }
-      if (ids.includes(candidate)) {
-        return candidate;
-      }
-      return ids[0];
+      return resolvedId;
     }
   }
 
@@ -226,7 +198,7 @@ function resolveTableId(
     return tableName;
   }
 
-  const versionSuffix = versionToSuffix(version);
+  const versionSuffix = normalizeLineageVersion(version);
   return versionSuffix ?
       `${tableName}_${versionSuffix}`
     : `${tableName}_${version}`;

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -53,6 +53,11 @@ import {
   type DependencyAnalysisResult,
   type InfrastructureSignatureJson,
 } from "./dependencyAnalysis";
+import {
+  buildCanonicalLineageTableId,
+  resolveDefaultLineageDatabase,
+  resolveLineageDatabase,
+} from "./lineageTableId";
 import { findSourceFiles } from "./utils";
 
 /**
@@ -1062,28 +1067,19 @@ function convertTableConfigToEngineConfig(
   return undefined;
 }
 
-const DEFAULT_DATABASE_ENV_VAR = "MOOSE_DEFAULT_DATABASE";
-
-function resolveDefaultDatabaseForLineage(): string {
-  const configured = process.env[DEFAULT_DATABASE_ENV_VAR]?.trim();
-  return configured && configured.length > 0 ? configured : "local";
-}
-
 function buildCanonicalTableLineageId(
   table: OlapTable<any>,
   defaultDatabase: string,
 ): string {
-  const database =
-    (
-      typeof table.config.database === "string" &&
-      table.config.database.trim().length > 0
-    ) ?
-      table.config.database.trim()
-    : defaultDatabase;
-  const versionSuffix = table.config.version?.replace(/\./g, "_");
-  return versionSuffix ?
-      `${database}_${table.name}_${versionSuffix}`
-    : `${database}_${table.name}`;
+  const database = resolveLineageDatabase(
+    table.config.database,
+    defaultDatabase,
+  );
+  return buildCanonicalLineageTableId(
+    table.name,
+    table.config.version,
+    database,
+  );
 }
 
 export const toInfraMap = (registry: MooseInternalRegistry) => {
@@ -1097,7 +1093,7 @@ export const toInfraMap = (registry: MooseInternalRegistry) => {
   const materializedViews: { [key: string]: MaterializedViewJson } = {};
   const views: { [key: string]: ViewJson } = {};
   const lineage = getCachedLineage(registry);
-  const defaultDatabaseForLineage = resolveDefaultDatabaseForLineage();
+  const defaultDatabaseForLineage = resolveDefaultLineageDatabase();
 
   registry.tables.forEach((table) => {
     const id =

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -1062,6 +1062,30 @@ function convertTableConfigToEngineConfig(
   return undefined;
 }
 
+const DEFAULT_DATABASE_ENV_VAR = "MOOSE_DEFAULT_DATABASE";
+
+function resolveDefaultDatabaseForLineage(): string {
+  const configured = process.env[DEFAULT_DATABASE_ENV_VAR]?.trim();
+  return configured && configured.length > 0 ? configured : "local";
+}
+
+function buildCanonicalTableLineageId(
+  table: OlapTable<any>,
+  defaultDatabase: string,
+): string {
+  const database =
+    (
+      typeof table.config.database === "string" &&
+      table.config.database.trim().length > 0
+    ) ?
+      table.config.database.trim()
+    : defaultDatabase;
+  const versionSuffix = table.config.version?.replace(/\./g, "_");
+  return versionSuffix ?
+      `${database}_${table.name}_${versionSuffix}`
+    : `${database}_${table.name}`;
+}
+
 export const toInfraMap = (registry: MooseInternalRegistry) => {
   const tables: { [key: string]: TableJson } = {};
   const topics: { [key: string]: StreamJson } = {};
@@ -1073,6 +1097,7 @@ export const toInfraMap = (registry: MooseInternalRegistry) => {
   const materializedViews: { [key: string]: MaterializedViewJson } = {};
   const views: { [key: string]: ViewJson } = {};
   const lineage = getCachedLineage(registry);
+  const defaultDatabaseForLineage = resolveDefaultDatabaseForLineage();
 
   registry.tables.forEach((table) => {
     const id =
@@ -1270,12 +1295,8 @@ export const toInfraMap = (registry: MooseInternalRegistry) => {
       pullsDataFrom: sqlResource.pullsDataFrom.map((r) => {
         if (r.kind === "OlapTable") {
           const table = r as OlapTable<any>;
-          const id =
-            table.config.version ?
-              `${table.name}_${table.config.version}`
-            : table.name;
           return {
-            id,
+            id: buildCanonicalTableLineageId(table, defaultDatabaseForLineage),
             kind: "Table",
           };
         } else if (r.kind === "SqlResource") {
@@ -1303,12 +1324,8 @@ export const toInfraMap = (registry: MooseInternalRegistry) => {
       pushesDataTo: sqlResource.pushesDataTo.map((r) => {
         if (r.kind === "OlapTable") {
           const table = r as OlapTable<any>;
-          const id =
-            table.config.version ?
-              `${table.name}_${table.config.version}`
-            : table.name;
           return {
-            id,
+            id: buildCanonicalTableLineageId(table, defaultDatabaseForLineage),
             kind: "Table",
           };
         } else if (r.kind === "SqlResource") {

--- a/packages/ts-moose-lib/src/dmv2/lineageTableId.ts
+++ b/packages/ts-moose-lib/src/dmv2/lineageTableId.ts
@@ -1,0 +1,45 @@
+import process from "node:process";
+
+export const DEFAULT_DATABASE_ENV_VAR = "MOOSE_DEFAULT_DATABASE";
+
+export function resolveDefaultLineageDatabase(): string {
+  const configured = process.env[DEFAULT_DATABASE_ENV_VAR]?.trim();
+  return configured && configured.length > 0 ? configured : "local";
+}
+
+export function resolveLineageDatabase(
+  explicitDatabase: string | undefined,
+  defaultDatabase: string,
+): string {
+  const configured = explicitDatabase?.trim();
+  return configured && configured.length > 0 ? configured : defaultDatabase;
+}
+
+export function normalizeLineageVersion(
+  version: string | undefined,
+): string | undefined {
+  return version ? version.replace(/\./g, "_") : undefined;
+}
+
+export function inferVersionFromRegistryId(
+  tableName: string,
+  registryId: string,
+): string | undefined {
+  const prefix = `${tableName}_`;
+  if (!registryId.startsWith(prefix)) {
+    return undefined;
+  }
+  const suffix = registryId.slice(prefix.length);
+  return suffix.length > 0 ? suffix : undefined;
+}
+
+export function buildCanonicalLineageTableId(
+  tableName: string,
+  version: string | undefined,
+  database: string,
+): string {
+  const versionSuffix = normalizeLineageVersion(version);
+  return versionSuffix ?
+      `${database}_${tableName}_${versionSuffix}`
+    : `${database}_${tableName}`;
+}

--- a/packages/ts-moose-lib/tests/lineage-analysis.test.ts
+++ b/packages/ts-moose-lib/tests/lineage-analysis.test.ts
@@ -9,6 +9,7 @@ import {
   WebApp,
   Workflow,
   IngestPipeline,
+  SqlResource,
 } from "../src/dmv2/index";
 import { getMooseInternal, toInfraMap } from "../src/dmv2/internal";
 import { ApiHelpers, sql } from "../src/index";
@@ -56,7 +57,7 @@ describe("Lineage Analysis", function () {
 
     const infra = toInfraMap(getMooseInternal());
     expect(infra.apis.lineageApi.pullsDataFrom).to.deep.include({
-      id: "LineageApiTable",
+      id: "local_LineageApiTable",
       kind: "Table",
     });
   });
@@ -93,7 +94,7 @@ describe("Lineage Analysis", function () {
 
     const infra = toInfraMap(getMooseInternal());
     expect(infra.apis.lineageApiHelpers.pullsDataFrom).to.deep.include({
-      id: "LineageApiHelpersTable",
+      id: "local_LineageApiHelpersTable",
       kind: "Table",
     });
   });
@@ -134,7 +135,7 @@ describe("Lineage Analysis", function () {
 
     const infra = toInfraMap(getMooseInternal());
     expect(infra.apis.lineageCommaCallApi.pullsDataFrom).to.deep.include({
-      id: "LineageCommaCallTable",
+      id: "local_LineageCommaCallTable",
       kind: "Table",
     });
   });
@@ -164,7 +165,7 @@ describe("Lineage Analysis", function () {
 
     const infra = toInfraMap(getMooseInternal());
     expect(infra.apis.lineageSqlCallApi.pullsDataFrom).to.deep.include({
-      id: "LineageSqlCallTable",
+      id: "local_LineageSqlCallTable",
       kind: "Table",
     });
   });
@@ -199,7 +200,69 @@ describe("Lineage Analysis", function () {
 
     const infra = toInfraMap(getMooseInternal());
     expect(infra.apis.lineageSqlFragmentApi.pullsDataFrom).to.deep.include({
-      id: "LineageSqlFragmentTable",
+      id: "local_LineageSqlFragmentTable",
+      kind: "Table",
+    });
+  });
+
+  it("uses explicit table database in canonical lineage ids", () => {
+    interface QueryParams {}
+    interface ApiResponse {
+      id: string;
+    }
+    interface TableRow {
+      id: string;
+    }
+
+    const table = new OlapTable<TableRow>("LineageExplicitDbTable", {
+      database: "analytics",
+    });
+
+    const handler = async (
+      _params: QueryParams,
+      { client }: any,
+    ): Promise<ApiResponse[]> => {
+      await client.query.execute(sql`SELECT ${table.columns.id} FROM ${table}`);
+      return [];
+    };
+
+    new Api<QueryParams, ApiResponse[]>("lineageExplicitDbApi", handler);
+
+    const infra = toInfraMap(getMooseInternal());
+    expect(infra.apis.lineageExplicitDbApi.pullsDataFrom).to.deep.include({
+      id: "analytics_LineageExplicitDbTable",
+      kind: "Table",
+    });
+  });
+
+  it("emits canonical table lineage for SqlResource dependencies", () => {
+    interface TableRow {
+      id: string;
+    }
+
+    const table = new OlapTable<TableRow>("LineageSqlResourceTable", {
+      version: "1.0",
+    });
+
+    new SqlResource(
+      "lineageSqlResource",
+      ["CREATE VIEW lineage AS SELECT * FROM LineageSqlResourceTable"],
+      ["DROP VIEW lineage"],
+      {
+        pullsDataFrom: [table],
+        pushesDataTo: [table],
+      },
+    );
+
+    const infra = toInfraMap(getMooseInternal());
+    expect(infra.sqlResources.lineageSqlResource.pullsDataFrom).to.deep.include(
+      {
+        id: "local_LineageSqlResourceTable_1_0",
+        kind: "Table",
+      },
+    );
+    expect(infra.sqlResources.lineageSqlResource.pushesDataTo).to.deep.include({
+      id: "local_LineageSqlResourceTable_1_0",
       kind: "Table",
     });
   });
@@ -232,9 +295,9 @@ describe("Lineage Analysis", function () {
 
     const infra = toInfraMap(getMooseInternal());
     const candidateTableIds = new Set(
-      [...getMooseInternal().tables.keys()].filter((id) =>
-        id.includes("LineagePipelineSqlAlias"),
-      ),
+      [...getMooseInternal().tables.keys()]
+        .filter((id) => id.includes("LineagePipelineSqlAlias"))
+        .map((id) => `local_${id.replace(/\./g, "_")}`),
     );
     expect(candidateTableIds.size).to.be.greaterThan(0);
 
@@ -295,7 +358,7 @@ exports.LineageCommonJsApi = new Api(
       const commonJsApi =
         infra.apis.lineageCommonJsApi ?? infra.apis["lineageCommonJsApi:0.0"];
       expect(commonJsApi?.pullsDataFrom).to.deep.include({
-        id: "LineageCommonJsTable",
+        id: "local_LineageCommonJsTable",
         kind: "Table",
       });
     } finally {
@@ -372,7 +435,7 @@ new Api(
         infra.apis.lineageCompiledTemplateObjectApi ??
         infra.apis["lineageCompiledTemplateObjectApi:0.0"];
       expect(api?.pullsDataFrom).to.deep.include({
-        id: "LineageCompiledTemplateObjectTable",
+        id: "local_LineageCompiledTemplateObjectTable",
         kind: "Table",
       });
     } finally {
@@ -409,7 +472,7 @@ new Api(
 
     const firstInfra = toInfraMap(getMooseInternal());
     expect(firstInfra.apis.lineageCacheApiA.pullsDataFrom).to.deep.include({
-      id: "LineageCacheTableA",
+      id: "local_LineageCacheTableA",
       kind: "Table",
     });
 
@@ -425,12 +488,12 @@ new Api(
 
     const secondInfra = toInfraMap(getMooseInternal());
     expect(secondInfra.apis.lineageCacheApiB.pullsDataFrom).to.deep.include({
-      id: "LineageCacheTableB",
+      id: "local_LineageCacheTableB",
       kind: "Table",
     });
     expect(secondInfra.apis.lineageCacheApiB.pullsDataFrom).to.not.deep.include(
       {
-        id: "LineageCacheTableA",
+        id: "local_LineageCacheTableA",
         kind: "Table",
       },
     );
@@ -468,7 +531,7 @@ new Api(
       kind: "Topic",
     });
     expect(infra.workflows.lineageWorkflow.pushesDataTo).to.deep.include({
-      id: "LineageWorkflowTable",
+      id: "local_LineageWorkflowTable",
       kind: "Table",
     });
   });
@@ -500,7 +563,7 @@ new Api(
 
     const infra = toInfraMap(getMooseInternal());
     expect(infra.webApps.lineageWebApp.pullsDataFrom).to.deep.include({
-      id: "LineageWebAppTable",
+      id: "local_LineageWebAppTable",
       kind: "Table",
     });
     expect(infra.webApps.lineageWebApp.pushesDataTo).to.deep.include({
@@ -508,7 +571,7 @@ new Api(
       kind: "Topic",
     });
     expect(infra.webApps.lineageWebApp.pushesDataTo).to.deep.include({
-      id: "LineageWebAppTable",
+      id: "local_LineageWebAppTable",
       kind: "Table",
     });
   });

--- a/packages/ts-moose-lib/tests/lineage-analysis.test.ts
+++ b/packages/ts-moose-lib/tests/lineage-analysis.test.ts
@@ -141,7 +141,7 @@ describe("Lineage Analysis", function () {
   });
 
   it("infers pulls_data_from for compiled-style sql(...) calls", () => {
-    interface QueryParams {}
+    type QueryParams = { _unused?: string };
 
     interface ApiResponse {
       id: string;
@@ -171,7 +171,7 @@ describe("Lineage Analysis", function () {
   });
 
   it("infers pulls_data_from from sql table-name fragments", () => {
-    interface QueryParams {}
+    type QueryParams = { _unused?: string };
 
     interface ApiResponse {
       id: string;
@@ -206,7 +206,7 @@ describe("Lineage Analysis", function () {
   });
 
   it("uses explicit table database in canonical lineage ids", () => {
-    interface QueryParams {}
+    type QueryParams = { _unused?: string };
     interface ApiResponse {
       id: string;
     }
@@ -283,7 +283,7 @@ describe("Lineage Analysis", function () {
       version: "0.0",
     });
 
-    interface QueryParams {}
+    type QueryParams = { _unused?: string };
 
     const handler = async (_params: QueryParams, { client }: any) => {
       const tableName = sql`LineagePipelineSqlAlias_0_0`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the generated lineage table IDs (adds database prefix and normalizes version formatting) and expands alias/ambiguity resolution, which could affect any consumers that expect the previous ID format.
> 
> **Overview**
> **Lineage table identifiers are now canonicalized** across the TypeScript tooling to include a database prefix (defaulting to `local`) and normalized version suffixes (dots replaced with underscores), via new helpers in `dmv2/lineageTableId.ts`.
> 
> Dependency/SQL lineage analysis now indexes tables by multiple aliases and resolves ambiguous references with a warning, and `toInfraMap` emits canonical table lineage IDs for `SqlResource` dependencies. The CLI sets `MOOSE_DEFAULT_DATABASE` when running `dmv2-serializer` so the TS library can compute consistent canonical IDs.
> 
> CI now re-enables the TypeScript backward-compatibility E2E job and treats its result as required, and tests were updated/added to assert canonical IDs and preservation of provided lineage signatures when building the infra map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e91472c2dd0120e2a2ab9801b9338711aa3bea3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->