### PR TITLE
Fix moose with read only config

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -1295,6 +1295,12 @@ pub async fn top_command_handler(
                 .to_string();
 
             let log_file_path = user_directory()
+                .map_err(|e| {
+                    RoutineFailure::new(
+                        Message::new("Failed".to_string(), "to resolve log directory".to_string()),
+                        e,
+                    )
+                })?
                 .join(log_file_path)
                 .to_str()
                 .unwrap()

--- a/apps/framework-cli/src/cli/logger.rs
+++ b/apps/framework-cli/src/cli/logger.rs
@@ -356,7 +356,11 @@ impl Default for LoggerSettings {
 fn clean_old_logs() {
     let cut_off = SystemTime::now() - Duration::from_secs(7 * 24 * 60 * 60);
 
-    if let Ok(dir) = user_directory().read_dir() {
+    let dir_path = match user_directory() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    if let Ok(dir) = dir_path.read_dir() {
         for entry in dir.flatten() {
             if entry.path().extension().is_some_and(|ext| ext == "log") {
                 match entry.metadata().and_then(|md| md.modified()) {
@@ -405,7 +409,10 @@ impl<'a> MakeWriter<'a> for DateBasedWriter {
 
     fn make_writer(&'a self) -> Self::Writer {
         let formatted_name = chrono::Local::now().format(&self.date_format).to_string();
-        let file_path = user_directory().join(&formatted_name);
+        // HOME was already validated during CLI startup in setup_user_directory()
+        let file_path = user_directory()
+            .expect("HOME was validated at startup")
+            .join(&formatted_name);
 
         std::fs::OpenOptions::new()
             .create(true)

--- a/apps/framework-cli/src/cli/routines/feedback.rs
+++ b/apps/framework-cli/src/cli/routines/feedback.rs
@@ -7,7 +7,7 @@ use crate::utilities::capture::{
     capture_usage, identify_user_with_email, wait_for_usage_capture, ActivityType,
 };
 use crate::utilities::constants::{
-    CLI_VERSION, GITHUB_ISSUES_URL, SLACK_COMMUNITY_URL, SUPPORT_EMAIL,
+    CLI_USER_DIRECTORY, CLI_VERSION, GITHUB_ISSUES_URL, SLACK_COMMUNITY_URL, SUPPORT_EMAIL,
 };
 use std::collections::HashMap;
 
@@ -18,7 +18,9 @@ fn build_issue_url(description: Option<&str>) -> String {
         None => "<!-- Describe the issue -->".to_string(),
     };
 
-    let log_path = user_directory().to_string_lossy().to_string();
+    let log_path = user_directory()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| format!("~/{CLI_USER_DIRECTORY}"));
 
     let body = format!(
         "## Description\n\n{}\n\n## Environment\n- CLI Version: {}\n- OS: {}\n- Architecture: {}\n\n## Logs\nLog files are located at: `{}`\n\nPlease attach relevant log files if applicable.",
@@ -220,7 +222,9 @@ pub async fn report_bug(
     );
     wait_for_usage_capture(handle).await;
 
-    let path = user_directory().to_string_lossy().to_string();
+    let path = user_directory()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| format!("~/{CLI_USER_DIRECTORY}"));
     Ok(RoutineSuccess::success(Message::new(
         "Bug report".to_string(),
         format!("Opening GitHub Issues. Log files are at: {}", path),

--- a/apps/framework-cli/src/cli/routines/templates.rs
+++ b/apps/framework-cli/src/cli/routines/templates.rs
@@ -48,17 +48,20 @@ impl TemplateConfig {
 }
 
 // TODO - no need to download every time, once cached once, use the cached version
-fn templates_download_dir() -> PathBuf {
-    let mut path = user_directory();
+fn templates_download_dir() -> std::io::Result<PathBuf> {
+    let mut path = user_directory()?;
     path.push(DOWNLOAD_DIR);
-    path
+    Ok(path)
 }
 
-pub(crate) fn template_file_archive(template_name: &str, template_version: &str) -> PathBuf {
-    let mut path = templates_download_dir();
+pub(crate) fn template_file_archive(
+    template_name: &str,
+    template_version: &str,
+) -> std::io::Result<PathBuf> {
+    let mut path = templates_download_dir()?;
     path.push(template_version);
     path.push(format!("{template_name}.tgz"));
-    path
+    Ok(path)
 }
 
 async fn download_from_local(template_name: &str) -> anyhow::Result<()> {
@@ -77,7 +80,7 @@ async fn download_from_local(template_name: &str) -> anyhow::Result<()> {
         anyhow::bail!("Local template not found. Did you run scripts/package-templates.js?")
     }
 
-    let mut dest: PathBuf = templates_download_dir();
+    let mut dest: PathBuf = templates_download_dir()?;
     dest.push("0.0.1"); // In local mode, we always use "latest"
 
     // Create the directory if it doesn't exist
@@ -108,7 +111,7 @@ pub(crate) async fn download(template_name: &str, template_version: &str) -> any
 
     res.error_for_status_ref()?;
 
-    let mut dest = templates_download_dir();
+    let mut dest = templates_download_dir()?;
     dest.push(template_version);
 
     // Create the directory if it doesn't exist
@@ -129,7 +132,7 @@ pub(crate) async fn download(template_name: &str, template_version: &str) -> any
 }
 
 fn unpack(template_name: &str, template_version: &str, target_dir: &PathBuf) -> anyhow::Result<()> {
-    let template_archive = template_file_archive(template_name, template_version);
+    let template_archive = template_file_archive(template_name, template_version)?;
     let tar_gz = File::open(template_archive)?;
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);

--- a/apps/framework-cli/src/cli/settings.rs
+++ b/apps/framework-cli/src/cli/settings.rs
@@ -192,23 +192,28 @@ fn default_release_channel() -> String {
 }
 
 /// Returns the path to the config file in the user's home directory
-fn config_path() -> PathBuf {
-    let mut path: PathBuf = user_directory();
+fn config_path() -> Result<PathBuf, std::io::Error> {
+    let mut path: PathBuf = user_directory()?;
     path.push(CLI_CONFIG_FILE);
-    path
+    Ok(path)
 }
 
 /// Returns the path to the Moose user directory
-pub fn user_directory() -> PathBuf {
-    let mut path: PathBuf = home_dir().unwrap();
+pub fn user_directory() -> Result<PathBuf, std::io::Error> {
+    let mut path: PathBuf = home_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not determine home directory. Ensure HOME is set.",
+        )
+    })?;
     path.push(CLI_USER_DIRECTORY);
-    path
+    Ok(path)
 }
 
 /// Creates the Moose user directory if it doesn't exist
 pub fn setup_user_directory() -> Result<(), std::io::Error> {
-    let path = user_directory();
-    std::fs::create_dir_all(path.clone())?;
+    let path = user_directory()?;
+    std::fs::create_dir_all(path)?;
     Ok(())
 }
 
@@ -222,7 +227,8 @@ pub fn setup_user_directory() -> Result<(), std::io::Error> {
 ///
 /// Returns a Result containing the parsed Settings or a ConfigError
 pub fn read_settings() -> Result<Settings, ConfigError> {
-    let config_file_location: PathBuf = config_path();
+    let config_file_location: PathBuf =
+        config_path().map_err(|e| ConfigError::Message(e.to_string()))?;
 
     let s = Config::builder()
         .add_source(File::from(config_file_location).required(false))
@@ -263,7 +269,7 @@ pub fn read_settings() -> Result<Settings, ConfigError> {
 ///
 /// Returns a Result indicating success or an IO error
 pub fn init_config_file() -> Result<(), std::io::Error> {
-    let path = config_path();
+    let path = config_path()?;
     if !path.exists() {
         let contents_toml = r#"
 # Helps gather insights, identify issues, & improve the user experience
@@ -273,7 +279,16 @@ pub fn init_config_file() -> Result<(), std::io::Error> {
 enabled=true
 is_moose_developer=false
 "#;
-        std::fs::write(path, contents_toml)?;
+        if let Err(e) = std::fs::write(&path, contents_toml) {
+            if e.kind() == std::io::ErrorKind::PermissionDenied {
+                eprintln!(
+                    "Config file {} could not be created (read-only or externally managed); using defaults",
+                    path.display()
+                );
+                return Ok(());
+            }
+            return Err(e);
+        }
     } else {
         let data = std::fs::read_to_string(&path)?;
         match data.parse::<DocumentMut>() {
@@ -420,7 +435,7 @@ pub fn set_suppress_dev_setup_prompt(value_to_set: bool) -> Result<(), std::io::
     //     .entry("suppress_dev_setup_prompt")
     //     .or_insert(value(false));
 
-    let path = config_path();
+    let path = config_path()?;
     let contents = std::fs::read_to_string(&path)?;
     let mut doc: DocumentMut = contents
         .parse()
@@ -461,7 +476,7 @@ pub fn set_suppress_dev_setup_prompt(value_to_set: bool) -> Result<(), std::io::
 /// docs.default_language value using toml_edit. Creates the
 /// [docs] table if missing.
 pub fn set_docs_default_language(language: &str) -> Result<(), std::io::Error> {
-    let path = config_path();
+    let path = config_path()?;
     let contents = std::fs::read_to_string(&path)?;
     let mut doc: DocumentMut = contents
         .parse()

--- a/apps/framework-cli/src/main.rs
+++ b/apps/framework-cli/src/main.rs
@@ -53,8 +53,32 @@ fn main() -> ExitCode {
         std::process::exit(1);
     }
 
-    cli::settings::init_config_file().expect("Failed to init config file");
-    let config = cli::settings::read_settings().expect("Failed to read settings");
+    if let Err(e) = cli::settings::init_config_file() {
+        show_message!(
+            MessageType::Error,
+            Message {
+                action: "Init".to_string(),
+                details: format!("Failed to initialize config file (~/.moose/config.toml): {e:?}"),
+            }
+        );
+        ensure_terminal_cleanup();
+        return ExitCode::from(1);
+    }
+
+    let config = match cli::settings::read_settings() {
+        Ok(config) => config,
+        Err(e) => {
+            show_message!(
+                MessageType::Error,
+                Message {
+                    action: "Init".to_string(),
+                    details: format!("Failed to read settings: {e:?}"),
+                }
+            );
+            ensure_terminal_cleanup();
+            return ExitCode::from(1);
+        }
+    };
 
     // Parse CLI arguments
     let cli_result = match cli::Cli::try_parse() {

--- a/apps/framework-cli/src/mcp/tools/logs.rs
+++ b/apps/framework-cli/src/mcp/tools/logs.rs
@@ -77,11 +77,11 @@ struct GetLogsParams {
 }
 
 /// Gets the path to the current day's log file using the shared format from logger module
-fn get_log_file_path() -> PathBuf {
+fn get_log_file_path() -> std::io::Result<PathBuf> {
     let formatted_date = Local::now().format(DEFAULT_LOG_FILE_FORMAT).to_string();
-    let mut path = user_directory();
+    let mut path = user_directory()?;
     path.push(formatted_date);
-    path
+    Ok(path)
 }
 
 /// Helper to check if a log level string is valid
@@ -284,7 +284,7 @@ pub fn handle_call(arguments: Option<&Map<String, Value>>) -> CallToolResult {
 
 /// Main function to retrieve and filter logs
 fn execute_get_logs(params: GetLogsParams) -> Result<String, LogError> {
-    let log_file_path = get_log_file_path();
+    let log_file_path = get_log_file_path()?;
 
     // Check if log file exists
     if !log_file_path.exists() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches CLI startup/config loading and filesystem path resolution across multiple commands, which can affect whether the CLI exits vs. continues and where it reads/writes files, but changes are mostly defensive error handling.
> 
> **Overview**
> Hardens CLI startup and path handling by making `user_directory()` (and derived helpers like `config_path`) return `Result`, then plumbing failures into user-facing errors instead of panics.
> 
> Config initialization is updated to tolerate *read-only or externally managed* `~/.moose/config.toml` by warning/printing and continuing with defaults on `PermissionDenied`, while `main.rs` now surfaces init/read failures cleanly and ensures terminal cleanup before exiting.
> 
> Call sites that rely on the Moose user directory (logs command/MCP log tool, template downloads/unpack, feedback bug report URLs, and log cleanup/writer) are updated to handle the new fallible API, including sensible fallbacks for displaying log paths when the directory can’t be resolved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 991cc52cef103ef61165f475b091552c66edcd05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->