### PR TITLE
Clarify pipeline olaptable conflict

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/olap/model-table.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/model-table.mdx
@@ -142,7 +142,7 @@ example_table = OlapTable[ExampleSchema]("example_table", OlapConfig(
 
 ### Creating Tables in Ingestion Pipelines
 
-For end-to-end data flows, create tables as part of an ingestion pipeline. When you set `table: true`, the pipeline creates the table automatically — don't declare a separate `OlapTable` with the same name or you'll get a conflict error at startup.
+For end-to-end data flows, create tables as part of an ingestion pipeline. Setting `table` creates it automatically — a separate `OlapTable` with the same name will cause a conflict.
 
 <LanguageTabs>
   <LanguageTabContent value="typescript">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies expected table creation behavior in ingestion pipelines; no runtime code or schemas are modified.
> 
> **Overview**
> Clarifies the `Creating Tables in Ingestion Pipelines` docs to explicitly state that setting `table` on an `IngestPipeline` *auto-creates* the underlying table and that defining a separate `OlapTable` with the same name will conflict.
> 
> Also normalizes minor formatting in the TypeScript example (comment alignment).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f09089cd8751a72037e098e45798d9043bca574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->