### PR TITLE
docs: add commit boundaries to Feb 28 release notes frontmatter

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/release-notes/2026-02-28.mdx
+++ b/apps/framework-docs-v2/content/moosestack/release-notes/2026-02-28.mdx
@@ -1,6 +1,10 @@
 ---
 title: February 28, 2026
 description: Release notes for February 28, 2026
+commits:
+  moosestack: 9fc70ea6029365c471c8af694112630298843417
+  commercial: b0ce6200d06e98a8c6442cb77e281e163c7d55ac
+  registry: b617893ae7b34b0b6d88ebeb4dc1a78813037213
 ---
 
 import { Callout } from "@/components/mdx";


### PR DESCRIPTION
adds commit markers to the release notes frontmatter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata change with no runtime or behavioral impact; risk is limited to potential formatting/frontmatter parsing issues.
> 
> **Overview**
> Adds a new `commits` block to the frontmatter of `2026-02-28.mdx`, recording the `moosestack`, `commercial`, and `registry` git SHAs associated with the release notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9574d4cccb306c7a58d3b117570a56284f9e55ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->