### PR TITLE
feat: add k8s lease integration in moose to gate migration changes

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -123,6 +123,7 @@ use crate::framework::core::plan::InfraPlan;
 use crate::framework::core::plan::ReconciliationFilter;
 use crate::framework::core::state_storage::StateStorageBuilder;
 use crate::framework::languages::SupportedLanguages;
+use crate::infrastructure::kubernetes::lease_gate::maybe_acquire_dynamic_migration_lease;
 use crate::infrastructure::olap::clickhouse::diff_strategy::ClickHouseTableDiffStrategy;
 use crate::infrastructure::olap::clickhouse::remote::{ClickHouseRemote, Protocol};
 use crate::infrastructure::olap::clickhouse::{check_ready, create_client};
@@ -131,6 +132,7 @@ use crate::infrastructure::orchestration::temporal_client::{
     manager_from_project_if_enabled, probe_temporal,
 };
 use crate::infrastructure::stream::kafka::client::fetch_topics;
+use crate::infrastructure::{olap as olap_infra, stream as stream_infra};
 use crate::utilities::constants::{KEY_REMOTE_CLICKHOUSE_URL, MIGRATION_FILE, STORE_CRED_PROMPT};
 use crate::utilities::keyring::{KeyringSecretRepository, SecretRepository};
 
@@ -159,6 +161,30 @@ async fn maybe_warmup_connections(project: &Project, redis_client: &Arc<RedisCli
             let _ = probe_temporal(&manager, namespace, "warmup").await;
         }
     }
+}
+
+async fn execute_dynamic_mutation_phase(
+    project: &Project,
+    settings: &Settings,
+    plan: &InfraPlan,
+    skip_olap: bool,
+) -> anyhow::Result<()> {
+    if settings.should_bypass_infrastructure_execution() {
+        info!(
+            "Bypassing OLAP and streaming infrastructure execution (bypass_infrastructure_execution is enabled)"
+        );
+        return Ok(());
+    }
+
+    if project.features.olap && !skip_olap {
+        olap_infra::execute_changes(project, &plan.changes.olap_changes).await?;
+    }
+
+    if project.features.streaming_engine {
+        stream_infra::execute_changes(project, &plan.changes.streaming_engine_changes).await?;
+    }
+
+    Ok(())
 }
 
 pub mod auth;
@@ -953,23 +979,8 @@ pub async fn start_production_mode(
         .build()
         .await?;
 
-    let (current_state, plan) = plan_changes(&*state_storage, &project).await?;
-    maybe_warmup_connections(&project, &redis_client).await;
-
     let execute_migration_yaml = project.features.ddl_plan && std::fs::exists(MIGRATION_FILE)?;
-
-    if execute_migration_yaml {
-        migrate::execute_migration_plan(
-            &project,
-            &project.clickhouse_config,
-            &current_state.tables,
-            &plan.target_infra_map,
-            &*state_storage,
-        )
-        .await?;
-    };
-
-    plan_validator::validate(&project, &plan)?;
+    let lease_guard = maybe_acquire_dynamic_migration_lease(&project).await?;
 
     let api_changes_channel = web_server
         .spawn_api_update_listener(project.clone(), route_table, consumption_apis)
@@ -977,22 +988,107 @@ pub async fn start_production_mode(
 
     let webapp_update_channel = web_server.spawn_webapp_update_listener(web_apps).await;
 
+    let is_dynamic_lease_mode = lease_guard.is_some();
+    let is_lease_leader = lease_guard.as_ref().is_some_and(|guard| guard.is_leader());
+
+    let (current_state, plan) = if is_dynamic_lease_mode && !is_lease_leader {
+        // Followers should not compute runtime diffs from persisted state.
+        // They only need their local runtime graph to boot request handling.
+        let target_infra_map = InfrastructureMap::load_from_user_code(&project, true).await?;
+        (
+            InfrastructureMap::empty_from_project(&project),
+            InfraPlan {
+                target_infra_map,
+                changes: Default::default(),
+            },
+        )
+    } else {
+        plan_changes(&*state_storage, &project).await?
+    };
+    maybe_warmup_connections(&project, &redis_client).await;
+
+    if execute_migration_yaml && (!is_dynamic_lease_mode || is_lease_leader) {
+        if let Err(e) = migrate::execute_migration_plan(
+            &project,
+            &project.clickhouse_config,
+            &current_state.tables,
+            &plan.target_infra_map,
+            &*state_storage,
+        )
+        .await
+        {
+            if is_dynamic_lease_mode && is_lease_leader {
+                if let Some(guard) = &lease_guard {
+                    if let Err(status_err) = guard.mark_failed(&format!("{:#}", e)).await {
+                        warn!("Failed to mark migration lease as failed: {}", status_err);
+                    }
+                }
+            }
+            return Err(e);
+        }
+    }
+
+    plan_validator::validate(&project, &plan)?;
+
+    if is_dynamic_lease_mode && is_lease_leader {
+        let migration_result = async {
+            execute_dynamic_mutation_phase(&project, settings, &plan, execute_migration_yaml)
+                .await?;
+            state_storage
+                .store_infrastructure_map(&plan.target_infra_map)
+                .await?;
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+
+        match migration_result {
+            Ok(_) => {
+                if let Some(guard) = &lease_guard {
+                    if let Err(e) = guard.mark_completed().await {
+                        warn!(
+                            "Migration completed but failed to mark Kubernetes lease as completed: {}",
+                            e
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                if let Some(guard) = &lease_guard {
+                    if let Err(status_err) = guard.mark_failed(&format!("{:#}", e)).await {
+                        warn!("Failed to mark migration lease as failed: {}", status_err);
+                    }
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    let mut execution_settings = settings.clone();
+    if is_dynamic_lease_mode {
+        // Lease-following pods must not run dynamic OLAP/streaming mutations.
+        execution_settings.dev.bypass_infrastructure_execution = true;
+    }
+
     let process_registry = execute_initial_infra_change(ExecutionContext {
         project: &project,
-        settings,
+        settings: &execution_settings,
         plan: &plan,
-        skip_olap: execute_migration_yaml,
+        skip_olap: execute_migration_yaml || is_dynamic_lease_mode,
         api_changes_channel,
         webapp_changes_channel: webapp_update_channel,
         metrics: metrics.clone(),
     })
     .await?;
 
-    state_storage
-        .store_infrastructure_map(&plan.target_infra_map)
-        .await?;
+    if !is_dynamic_lease_mode {
+        state_storage
+            .store_infrastructure_map(&plan.target_infra_map)
+            .await?;
+    }
 
-    let infra_map: &'static InfrastructureMap = Box::leak(Box::new(plan.target_infra_map));
+    let target_infra_map = plan.target_infra_map;
+
+    let infra_map: &'static InfrastructureMap = Box::leak(Box::new(target_infra_map));
 
     // Create processing coordinator (unused in production but required for API consistency)
     use crate::cli::processing_coordinator::ProcessingCoordinator;

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -892,6 +892,7 @@ mod tests {
                 crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
             state_config: crate::project::StateConfig::default(),
             migration_config: crate::project::MigrationConfig::default(),
+            migration_coordinator: crate::project::MigrationCoordinatorConfig::default(),
             language_project_config: crate::project::LanguageProjectConfig::default(),
             project_location: std::path::PathBuf::new(),
             is_production: false,

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -890,6 +890,7 @@ mod tests {
                 crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
             state_config: crate::project::StateConfig::default(),
             migration_config: crate::project::MigrationConfig::default(),
+            migration_coordinator: crate::project::MigrationCoordinatorConfig::default(),
             language_project_config: crate::project::LanguageProjectConfig::default(),
             project_location: std::path::PathBuf::new(),
             is_production: false,

--- a/apps/framework-cli/src/framework/core/plan_validator.rs
+++ b/apps/framework-cli/src/framework/core/plan_validator.rs
@@ -123,6 +123,7 @@ mod tests {
                 crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
             state_config: crate::project::StateConfig::default(),
             migration_config: crate::project::MigrationConfig::default(),
+            migration_coordinator: crate::project::MigrationCoordinatorConfig::default(),
             language_project_config: crate::project::LanguageProjectConfig::default(),
             project_location: PathBuf::from("/test"),
             is_production: false,

--- a/apps/framework-cli/src/infrastructure.rs
+++ b/apps/framework-cli/src/infrastructure.rs
@@ -15,6 +15,7 @@
 //!
 
 pub mod api;
+pub mod kubernetes;
 pub mod olap;
 pub mod orchestration;
 pub mod processes;

--- a/apps/framework-cli/src/infrastructure/kubernetes/lease_gate.rs
+++ b/apps/framework-cli/src/infrastructure/kubernetes/lease_gate.rs
@@ -1,0 +1,705 @@
+use crate::project::Project;
+use anyhow::{Context, Result};
+use chrono::{SecondsFormat, Utc};
+use reqwest::{Certificate, StatusCode};
+use serde_json::{Map, Value};
+use std::fs;
+use std::time::Duration;
+use tokio::time::{sleep, Instant};
+use tracing::{debug, info, warn};
+
+const DEFAULT_API_SERVER: &str = "https://kubernetes.default.svc";
+const SERVICEACCOUNT_TOKEN_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+const SERVICEACCOUNT_CA_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+const SERVICEACCOUNT_NAMESPACE_PATH: &str =
+    "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+const STATUS_ANNOTATION: &str = "moose.sh/migration-status";
+const APPLIED_BY_ANNOTATION: &str = "moose.sh/applied-by";
+const COMPLETED_AT_ANNOTATION: &str = "moose.sh/completed-at";
+const ERROR_ANNOTATION: &str = "moose.sh/error-summary";
+const STARTED_AT_ANNOTATION: &str = "moose.sh/started-at";
+const LEASE_POLL_INTERVAL_SECS: u64 = 2;
+const TERMINAL_STATUS_UPDATE_RETRIES: usize = 5;
+const ERROR_SUMMARY_MAX_LEN: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LeaseRole {
+    Leader,
+    Follower,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LeaseStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicMigrationLeaseGuard {
+    role: LeaseRole,
+    holder_id: String,
+    lease_name: String,
+    client: KubernetesLeaseClient,
+}
+
+impl DynamicMigrationLeaseGuard {
+    fn new(
+        role: LeaseRole,
+        holder_id: String,
+        lease_name: String,
+        client: KubernetesLeaseClient,
+    ) -> Self {
+        Self {
+            role,
+            holder_id,
+            lease_name,
+            client,
+        }
+    }
+
+    pub fn is_leader(&self) -> bool {
+        self.role == LeaseRole::Leader
+    }
+
+    pub async fn mark_completed(&self) -> Result<()> {
+        if self.role != LeaseRole::Leader {
+            return Ok(());
+        }
+
+        self.update_terminal_status("completed", None).await
+    }
+
+    pub async fn mark_failed(&self, error_summary: &str) -> Result<()> {
+        if self.role != LeaseRole::Leader {
+            return Ok(());
+        }
+
+        self.update_terminal_status("failed", Some(error_summary))
+            .await
+    }
+
+    async fn update_terminal_status(
+        &self,
+        status: &str,
+        error_summary: Option<&str>,
+    ) -> Result<()> {
+        for attempt in 1..=TERMINAL_STATUS_UPDATE_RETRIES {
+            let mut lease = self.client.get_lease(&self.lease_name).await?;
+            set_status(&mut lease, status)?;
+            set_annotation(&mut lease, APPLIED_BY_ANNOTATION, &self.holder_id)?;
+            set_annotation(&mut lease, COMPLETED_AT_ANNOTATION, &now_rfc3339())?;
+            set_spec_string_field(&mut lease, "holderIdentity", &self.holder_id)?;
+
+            if let Some(summary) = error_summary {
+                let truncated = truncate_error_summary(summary);
+                set_annotation(&mut lease, ERROR_ANNOTATION, &truncated)?;
+            } else {
+                remove_annotation(&mut lease, ERROR_ANNOTATION)?;
+            }
+
+            match self.client.update_lease(&self.lease_name, &lease).await {
+                Ok(_) => {
+                    info!(
+                        "Updated Kubernetes migration lease '{}' to terminal status '{}'",
+                        self.lease_name, status
+                    );
+                    return Ok(());
+                }
+                Err(LeaseClientError::Conflict) if attempt < TERMINAL_STATUS_UPDATE_RETRIES => {
+                    debug!(
+                        "Lease '{}' conflict while setting status '{}', retrying (attempt {}/{})",
+                        self.lease_name, status, attempt, TERMINAL_STATUS_UPDATE_RETRIES
+                    );
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to update lease '{}' to status '{}': {}",
+                        self.lease_name,
+                        status,
+                        e
+                    ));
+                }
+            }
+        }
+
+        anyhow::bail!(
+            "Failed to update lease '{}' to terminal status '{}' after {} retries",
+            self.lease_name,
+            status,
+            TERMINAL_STATUS_UPDATE_RETRIES
+        );
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum LeaseClientError {
+    #[error("Lease not found")]
+    NotFound,
+    #[error("Lease update conflict")]
+    Conflict,
+    #[error("Lease API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("Lease transport error: {0}")]
+    Transport(String),
+    #[error("Lease parse error: {0}")]
+    Parse(String),
+}
+
+#[derive(Debug, Clone)]
+struct KubernetesLeaseClient {
+    http_client: reqwest::Client,
+    api_server: String,
+    namespace: String,
+    token: String,
+}
+
+impl KubernetesLeaseClient {
+    fn in_cluster(namespace: String) -> Result<Self> {
+        let token = fs::read_to_string(SERVICEACCOUNT_TOKEN_PATH)
+            .with_context(|| format!("Failed to read {}", SERVICEACCOUNT_TOKEN_PATH))?
+            .trim()
+            .to_string();
+        if token.is_empty() {
+            anyhow::bail!("Kubernetes service account token is empty");
+        }
+
+        let ca_pem = fs::read(SERVICEACCOUNT_CA_PATH)
+            .with_context(|| format!("Failed to read {}", SERVICEACCOUNT_CA_PATH))?;
+        let cert = Certificate::from_pem(&ca_pem)
+            .context("Failed to parse Kubernetes service account CA certificate")?;
+
+        let http_client = reqwest::Client::builder()
+            .add_root_certificate(cert)
+            .build()
+            .context("Failed to build Kubernetes Lease HTTP client")?;
+
+        Ok(Self {
+            http_client,
+            api_server: kubernetes_api_server(),
+            namespace,
+            token,
+        })
+    }
+
+    async fn get_lease(&self, lease_name: &str) -> Result<Value, LeaseClientError> {
+        let response = self
+            .http_client
+            .get(self.lease_url(lease_name))
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| LeaseClientError::Transport(e.to_string()))?;
+
+        self.parse_json_response(response).await
+    }
+
+    async fn update_lease(
+        &self,
+        lease_name: &str,
+        lease: &Value,
+    ) -> Result<Value, LeaseClientError> {
+        let response = self
+            .http_client
+            .put(self.lease_url(lease_name))
+            .bearer_auth(&self.token)
+            .json(lease)
+            .send()
+            .await
+            .map_err(|e| LeaseClientError::Transport(e.to_string()))?;
+
+        self.parse_json_response(response).await
+    }
+
+    fn lease_url(&self, lease_name: &str) -> String {
+        format!(
+            "{}/apis/coordination.k8s.io/v1/namespaces/{}/leases/{}",
+            self.api_server, self.namespace, lease_name
+        )
+    }
+
+    async fn parse_json_response(
+        &self,
+        response: reqwest::Response,
+    ) -> Result<Value, LeaseClientError> {
+        let status = response.status();
+        let body_text = response
+            .text()
+            .await
+            .map_err(|e| LeaseClientError::Transport(e.to_string()))?;
+
+        match status {
+            StatusCode::NOT_FOUND => Err(LeaseClientError::NotFound),
+            StatusCode::CONFLICT => Err(LeaseClientError::Conflict),
+            s if !s.is_success() => Err(LeaseClientError::Api {
+                status: s.as_u16(),
+                message: body_text,
+            }),
+            _ => {
+                serde_json::from_str(&body_text).map_err(|e| LeaseClientError::Parse(e.to_string()))
+            }
+        }
+    }
+}
+
+pub async fn maybe_acquire_dynamic_migration_lease(
+    project: &Project,
+) -> Result<Option<DynamicMigrationLeaseGuard>> {
+    if !project.migration_coordinator.is_kubernetes_lease_mode() {
+        return Ok(None);
+    }
+
+    let kube_cfg = &project.migration_coordinator.kubernetes;
+
+    let namespace = resolve_namespace(kube_cfg.namespace.as_deref())
+        .context("Failed to resolve Kubernetes namespace for lease coordination")?;
+
+    let deployment_id = kube_cfg
+        .deployment_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Kubernetes lease mode requires migration_coordinator.kubernetes.deployment_id"
+            )
+        })?;
+
+    let holder_id = kube_cfg
+        .pod_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| std::env::var("HOSTNAME").ok())
+        .unwrap_or_else(|| "unknown-pod".to_string());
+
+    let lease_name = build_lease_name(&kube_cfg.lease_name_prefix, deployment_id)?;
+    let fail_closed = kube_cfg.fail_closed || project.is_production;
+
+    let client = match KubernetesLeaseClient::in_cluster(namespace.clone()) {
+        Ok(client) => client,
+        Err(e) => {
+            if fail_closed {
+                return Err(e).context(
+                    "Kubernetes lease mode is enabled but in-cluster client initialization failed",
+                );
+            }
+            warn!("Kubernetes lease client initialization failed (fail_closed=false): {e}");
+            return Ok(None);
+        }
+    };
+
+    info!(
+        "Kubernetes lease coordination enabled for deployment '{}' (lease='{}', namespace='{}')",
+        deployment_id, lease_name, namespace
+    );
+
+    match wait_for_or_claim_lease(
+        &client,
+        &lease_name,
+        &holder_id,
+        kube_cfg.wait_timeout_seconds,
+    )
+    .await
+    {
+        Ok(role) => Ok(Some(DynamicMigrationLeaseGuard::new(
+            role, holder_id, lease_name, client,
+        ))),
+        Err(e) => {
+            if fail_closed {
+                Err(e)
+            } else {
+                warn!("Lease gating failed with fail_closed=false; continuing without lease gate: {e}");
+                Ok(None)
+            }
+        }
+    }
+}
+
+async fn wait_for_or_claim_lease(
+    client: &KubernetesLeaseClient,
+    lease_name: &str,
+    holder_id: &str,
+    wait_timeout_seconds: u64,
+) -> Result<LeaseRole> {
+    let timeout = Duration::from_secs(wait_timeout_seconds.max(1));
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if Instant::now() > deadline {
+            anyhow::bail!(
+                "Timed out waiting for migration lease '{}' to become completed",
+                lease_name
+            );
+        }
+
+        let lease = match client.get_lease(lease_name).await {
+            Ok(lease) => lease,
+            Err(LeaseClientError::NotFound) => {
+                anyhow::bail!(
+                    "No Kubernetes migration lease '{}' found while lease mode is enabled",
+                    lease_name
+                );
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to fetch lease '{}': {}",
+                    lease_name,
+                    e
+                ))
+            }
+        };
+
+        match lease_status(&lease) {
+            LeaseStatus::Completed => {
+                info!(
+                    "Migration lease '{}' is already completed; skipping migration execution",
+                    lease_name
+                );
+                return Ok(LeaseRole::Follower);
+            }
+            LeaseStatus::Failed => {
+                anyhow::bail!(
+                    "Migration lease '{}' is marked failed: {}",
+                    lease_name,
+                    lease_error_summary(&lease)
+                        .unwrap_or_else(|| "no error summary provided".to_string())
+                );
+            }
+            LeaseStatus::Pending => {
+                match try_claim_lease(client, lease_name, lease, holder_id).await {
+                    Ok(true) => {
+                        info!(
+                            "Claimed migration lease '{}' as holder '{}'",
+                            lease_name, holder_id
+                        );
+                        return Ok(LeaseRole::Leader);
+                    }
+                    Ok(false) => {}
+                    Err(LeaseClientError::Conflict) => {
+                        debug!("Lease '{}' claim conflict; retrying", lease_name);
+                    }
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed claiming migration lease '{}': {}",
+                            lease_name,
+                            e
+                        ));
+                    }
+                }
+            }
+            LeaseStatus::InProgress => {
+                let Some(current_holder) = lease_holder(&lease) else {
+                    anyhow::bail!(
+                        "Lease '{}' is in_progress but missing spec.holderIdentity",
+                        lease_name
+                    );
+                };
+
+                if current_holder == holder_id {
+                    info!(
+                        "Lease '{}' already held by current holder '{}' (resuming as leader)",
+                        lease_name, holder_id
+                    );
+                    return Ok(LeaseRole::Leader);
+                }
+                debug!(
+                    "Lease '{}' is in progress by '{}'; waiting for completion",
+                    lease_name, current_holder
+                );
+            }
+            LeaseStatus::Unknown => {
+                anyhow::bail!(
+                    "Lease '{}' has unknown migration status annotation",
+                    lease_name
+                );
+            }
+        }
+
+        sleep(Duration::from_secs(LEASE_POLL_INTERVAL_SECS)).await;
+    }
+}
+
+async fn try_claim_lease(
+    client: &KubernetesLeaseClient,
+    lease_name: &str,
+    mut lease: Value,
+    holder_id: &str,
+) -> Result<bool, LeaseClientError> {
+    if lease_status(&lease) != LeaseStatus::Pending {
+        return Ok(false);
+    }
+
+    set_status(&mut lease, "in_progress").map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    set_annotation(&mut lease, APPLIED_BY_ANNOTATION, holder_id)
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    set_annotation(&mut lease, STARTED_AT_ANNOTATION, &now_rfc3339())
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    remove_annotation(&mut lease, COMPLETED_AT_ANNOTATION)
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    remove_annotation(&mut lease, ERROR_ANNOTATION)
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    set_spec_string_field(&mut lease, "holderIdentity", holder_id)
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    set_spec_string_field(&mut lease, "acquireTime", &now_rfc3339())
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+    set_spec_string_field(&mut lease, "renewTime", &now_rfc3339())
+        .map_err(|e| LeaseClientError::Parse(e.to_string()))?;
+
+    client.update_lease(lease_name, &lease).await?;
+    Ok(true)
+}
+
+fn lease_status(lease: &Value) -> LeaseStatus {
+    match lease_annotation(lease, STATUS_ANNOTATION)
+        .unwrap_or_else(|| "pending".to_string())
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "pending" => LeaseStatus::Pending,
+        "in_progress" => LeaseStatus::InProgress,
+        "completed" => LeaseStatus::Completed,
+        "failed" => LeaseStatus::Failed,
+        _ => LeaseStatus::Unknown,
+    }
+}
+
+fn lease_holder(lease: &Value) -> Option<String> {
+    lease
+        .get("spec")
+        .and_then(Value::as_object)
+        .and_then(|spec| spec.get("holderIdentity"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn lease_annotation(lease: &Value, key: &str) -> Option<String> {
+    lease
+        .get("metadata")
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("annotations"))
+        .and_then(Value::as_object)
+        .and_then(|annotations| annotations.get(key))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn lease_error_summary(lease: &Value) -> Option<String> {
+    lease_annotation(lease, ERROR_ANNOTATION)
+}
+
+fn set_status(lease: &mut Value, status: &str) -> Result<()> {
+    set_annotation(lease, STATUS_ANNOTATION, status)
+}
+
+fn set_annotation(lease: &mut Value, key: &str, value: &str) -> Result<()> {
+    let annotations = annotations_mut(lease)?;
+    annotations.insert(key.to_string(), Value::String(value.to_string()));
+    Ok(())
+}
+
+fn remove_annotation(lease: &mut Value, key: &str) -> Result<()> {
+    let annotations = annotations_mut(lease)?;
+    annotations.remove(key);
+    Ok(())
+}
+
+fn set_spec_string_field(lease: &mut Value, key: &str, value: &str) -> Result<()> {
+    let spec = spec_mut(lease)?;
+    spec.insert(key.to_string(), Value::String(value.to_string()));
+    Ok(())
+}
+
+fn annotations_mut(lease: &mut Value) -> Result<&mut Map<String, Value>> {
+    let metadata = metadata_mut(lease)?;
+    let annotations = metadata
+        .entry("annotations")
+        .or_insert_with(|| Value::Object(Map::new()));
+    annotations
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Lease metadata.annotations is not an object"))
+}
+
+fn metadata_mut(lease: &mut Value) -> Result<&mut Map<String, Value>> {
+    let root = lease
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Lease payload is not an object"))?;
+    let metadata = root
+        .entry("metadata")
+        .or_insert_with(|| Value::Object(Map::new()));
+    metadata
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Lease metadata is not an object"))
+}
+
+fn spec_mut(lease: &mut Value) -> Result<&mut Map<String, Value>> {
+    let root = lease
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Lease payload is not an object"))?;
+    let spec = root
+        .entry("spec")
+        .or_insert_with(|| Value::Object(Map::new()));
+    spec.as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Lease spec is not an object"))
+}
+
+fn resolve_namespace(explicit_namespace: Option<&str>) -> Result<String> {
+    if let Some(ns) = explicit_namespace.map(str::trim).filter(|s| !s.is_empty()) {
+        return Ok(ns.to_string());
+    }
+
+    let from_file = fs::read_to_string(SERVICEACCOUNT_NAMESPACE_PATH)
+        .with_context(|| format!("Failed to read {}", SERVICEACCOUNT_NAMESPACE_PATH))?;
+    let namespace = from_file.trim();
+    if namespace.is_empty() {
+        anyhow::bail!("Kubernetes namespace file is empty");
+    }
+    Ok(namespace.to_string())
+}
+
+fn build_lease_name(prefix: &str, deployment_id: &str) -> Result<String> {
+    let prefix = sanitize_lease_token(prefix).unwrap_or_default();
+    let deployment = sanitize_lease_token(deployment_id).ok_or_else(|| {
+        anyhow::anyhow!("deployment_id is invalid after Kubernetes name sanitization")
+    })?;
+
+    let mut lease_name = if prefix.is_empty() {
+        deployment
+    } else {
+        format!("{prefix}-{deployment}")
+    };
+
+    if lease_name.len() > 253 {
+        lease_name.truncate(253);
+        lease_name = trim_non_alnum_edges(&lease_name).to_string();
+    }
+
+    if lease_name.is_empty() {
+        anyhow::bail!("constructed lease name is empty after sanitization");
+    }
+
+    Ok(lease_name)
+}
+
+fn sanitize_lease_token(input: &str) -> Option<String> {
+    let mut out = String::with_capacity(input.len());
+    let mut last_was_sep = false;
+
+    for c in input.trim().chars() {
+        let mapped = if c.is_ascii_lowercase() || c.is_ascii_digit() {
+            c
+        } else if c.is_ascii_uppercase() {
+            c.to_ascii_lowercase()
+        } else if c == '-' || c == '.' || c == '_' || c.is_whitespace() {
+            '-'
+        } else {
+            '-'
+        };
+
+        if mapped == '-' || mapped == '.' {
+            if last_was_sep {
+                continue;
+            }
+            last_was_sep = true;
+        } else {
+            last_was_sep = false;
+        }
+
+        out.push(mapped);
+    }
+
+    let trimmed = trim_non_alnum_edges(&out).to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn trim_non_alnum_edges(input: &str) -> &str {
+    input.trim_matches(|c: char| !c.is_ascii_lowercase() && !c.is_ascii_digit())
+}
+
+fn kubernetes_api_server() -> String {
+    match (
+        std::env::var("KUBERNETES_SERVICE_HOST"),
+        std::env::var("KUBERNETES_SERVICE_PORT_HTTPS")
+            .or_else(|_| std::env::var("KUBERNETES_SERVICE_PORT")),
+    ) {
+        (Ok(host), Ok(port)) if !host.is_empty() && !port.is_empty() => {
+            format!("https://{host}:{port}")
+        }
+        _ => DEFAULT_API_SERVER.to_string(),
+    }
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn truncate_error_summary(summary: &str) -> String {
+    let mut truncated = summary.trim().to_string();
+    if truncated.len() > ERROR_SUMMARY_MAX_LEN {
+        truncated.truncate(ERROR_SUMMARY_MAX_LEN);
+    }
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_build_lease_name() {
+        assert_eq!(
+            build_lease_name("moose-migration", "abc123").unwrap(),
+            "moose-migration-abc123"
+        );
+        assert_eq!(
+            build_lease_name("moose-migration-", "abc123").unwrap(),
+            "moose-migration-abc123"
+        );
+        assert_eq!(build_lease_name("", "abc123").unwrap(), "abc123");
+    }
+
+    #[test]
+    fn test_build_lease_name_sanitizes_input() {
+        assert_eq!(
+            build_lease_name("Moose_Migration", "Deploy/ABC 123").unwrap(),
+            "moose-migration-deploy-abc-123"
+        );
+    }
+
+    #[test]
+    fn test_lease_status_defaults_to_pending() {
+        let lease = json!({
+            "metadata": {
+                "annotations": {}
+            }
+        });
+        assert_eq!(lease_status(&lease), LeaseStatus::Pending);
+    }
+
+    #[test]
+    fn test_set_and_remove_annotation() {
+        let mut lease = json!({
+            "metadata": {
+                "annotations": {}
+            }
+        });
+
+        set_annotation(&mut lease, STATUS_ANNOTATION, "in_progress").unwrap();
+        assert_eq!(
+            lease_annotation(&lease, STATUS_ANNOTATION).unwrap(),
+            "in_progress"
+        );
+
+        remove_annotation(&mut lease, STATUS_ANNOTATION).unwrap();
+        assert!(lease_annotation(&lease, STATUS_ANNOTATION).is_none());
+    }
+}

--- a/apps/framework-cli/src/infrastructure/kubernetes/mod.rs
+++ b/apps/framework-cli/src/infrastructure/kubernetes/mod.rs
@@ -1,0 +1,1 @@
+pub mod lease_gate;

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -165,6 +165,18 @@ fn default_state_storage() -> String {
     "redis".to_string()
 }
 
+fn default_migration_coordinator_mode() -> String {
+    "state_storage".to_string()
+}
+
+fn default_kubernetes_wait_timeout_seconds() -> u64 {
+    900
+}
+
+fn default_kubernetes_lease_name_prefix() -> String {
+    "moose-migration".to_string()
+}
+
 fn default_dockerfile_path() -> String {
     "./Dockerfile".to_string()
 }
@@ -204,6 +216,74 @@ impl Default for StateConfig {
     fn default() -> Self {
         StateConfig {
             storage: default_state_storage(),
+        }
+    }
+}
+
+/// Migration coordinator configuration
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MigrationCoordinatorConfig {
+    /// Coordination backend mode:
+    /// - "state_storage": Existing Redis/ClickHouse lock-based behavior
+    /// - "kubernetes_lease": Kubernetes Lease-based coordination (MDS-managed leases)
+    #[serde(default = "default_migration_coordinator_mode")]
+    pub mode: String,
+    /// Kubernetes-specific coordination settings
+    #[serde(default)]
+    pub kubernetes: KubernetesMigrationCoordinatorConfig,
+}
+
+impl MigrationCoordinatorConfig {
+    pub fn is_kubernetes_lease_mode(&self) -> bool {
+        self.mode.eq_ignore_ascii_case("kubernetes_lease") || self.kubernetes.enabled
+    }
+}
+
+impl Default for MigrationCoordinatorConfig {
+    fn default() -> Self {
+        Self {
+            mode: default_migration_coordinator_mode(),
+            kubernetes: KubernetesMigrationCoordinatorConfig::default(),
+        }
+    }
+}
+
+/// Kubernetes lease coordination settings.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct KubernetesMigrationCoordinatorConfig {
+    /// Explicitly enable Kubernetes lease gating
+    #[serde(default)]
+    pub enabled: bool,
+    /// Namespace containing the lease object
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Deployment identifier used to locate the lease
+    #[serde(default)]
+    pub deployment_id: Option<String>,
+    /// Optional pod identifier used as lease holder identity
+    #[serde(default)]
+    pub pod_id: Option<String>,
+    /// Time to wait for in-progress leases before failing startup
+    #[serde(default = "default_kubernetes_wait_timeout_seconds")]
+    pub wait_timeout_seconds: u64,
+    /// Fail startup if lease checks fail (recommended in production)
+    #[serde(default = "_true")]
+    pub fail_closed: bool,
+    /// Lease name prefix. Full lease name is "<prefix>-<deployment_id>"
+    #[serde(default = "default_kubernetes_lease_name_prefix")]
+    pub lease_name_prefix: String,
+}
+
+impl Default for KubernetesMigrationCoordinatorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            namespace: None,
+            deployment_id: None,
+            pod_id: None,
+            wait_timeout_seconds: default_kubernetes_wait_timeout_seconds(),
+            fail_closed: true,
+            lease_name_prefix: default_kubernetes_lease_name_prefix(),
         }
     }
 }
@@ -370,6 +450,9 @@ pub struct Project {
     /// Migration configuration
     #[serde(default)]
     pub migration_config: MigrationConfig,
+    /// Migration coordination backend and runtime gating settings
+    #[serde(default)]
+    pub migration_coordinator: MigrationCoordinatorConfig,
     /// Language-specific project configuration (not serialized)
     #[serde(skip)]
     pub language_project_config: LanguageProjectConfig,
@@ -473,6 +556,7 @@ impl Project {
             temporal_config: TemporalConfig::default(),
             state_config: StateConfig::default(),
             migration_config: MigrationConfig::default(),
+            migration_coordinator: MigrationCoordinatorConfig::default(),
             language_project_config,
             supported_old_versions: HashMap::new(),
             git_config: GitConfig::default(),


### PR DESCRIPTION
### TL;DR

Added Kubernetes lease-based migration coordination to enable safe multi-pod deployments with dynamic schema migrations.

### What changed?

- Added `MigrationCoordinatorConfig` and `KubernetesMigrationCoordinatorConfig` to project configuration with support for Kubernetes lease coordination mode
- Implemented `KubernetesLeaseClient` for managing Kubernetes lease objects with in-cluster authentication
- Created `DynamicMigrationLeaseGuard` to handle lease acquisition, status updates, and coordination between leader/follower pods
- Modified production startup flow to acquire leases before executing migrations, with leader pods performing migrations and followers waiting for completion
- Added lease status tracking through annotations (`moose.sh/migration-status`, `moose.sh/applied-by`, etc.) with support for pending, in-progress, completed, and failed states
- Implemented lease name sanitization and namespace resolution for Kubernetes environments
- Added `execute_dynamic_mutation_phase` function to separate OLAP and streaming infrastructure changes from other startup tasks

### How to test?

1. Configure a project with `migration_coordinator.mode = "kubernetes_lease"` and set `deployment_id`
2. Deploy multiple pods in a Kubernetes cluster with the same deployment ID
3. Create a Kubernetes lease object in the same namespace
4. Verify that only one pod becomes the leader and executes migrations while others wait as followers
5. Test failure scenarios by simulating migration errors and confirming lease status updates
6. Test timeout behavior when migrations exceed the configured wait timeout

### Why make this change?

This enables safe deployment of multiple application pods that need to perform dynamic schema migrations without conflicts. Previously, all pods would attempt migrations simultaneously, potentially causing race conditions or inconsistent state. The Kubernetes lease coordination ensures only one pod (the leader) executes migrations while others wait for completion, providing a robust solution for production multi-replica deployments.