### PR TITLE
Add olap = true feature flag to all templates

### DIFF
--- a/templates/ads-b-frontend/moose/moose.config.toml
+++ b/templates/ads-b-frontend/moose/moose.config.toml
@@ -47,6 +47,7 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/ads-b/moose.config.toml
+++ b/templates/ads-b/moose.config.toml
@@ -52,6 +52,7 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/brainwaves/apps/brainmoose/moose.config.toml
+++ b/templates/brainwaves/apps/brainmoose/moose.config.toml
@@ -34,6 +34,7 @@ main_branch_name = "main"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/github-dev-trends/apps/moose-backend/moose.config.toml
+++ b/templates/github-dev-trends/apps/moose-backend/moose.config.toml
@@ -47,6 +47,7 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/live-heartrate-leaderboard/moose.config.toml
+++ b/templates/live-heartrate-leaderboard/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 scripts = true

--- a/templates/next-app-empty/moose/moose.config.toml
+++ b/templates/next-app-empty/moose/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/python-empty/moose.config.toml
+++ b/templates/python-empty/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/python-experimental/moose.config.toml
+++ b/templates/python-experimental/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/python-fastapi-client-only/moose.config.toml
+++ b/templates/python-fastapi-client-only/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = false
 workflows = false
 apis = true

--- a/templates/python-fastapi/moose.config.toml
+++ b/templates/python-fastapi/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = false
 workflows = false
 apis = true

--- a/templates/python-tests/moose.config.toml
+++ b/templates/python-tests/moose.config.toml
@@ -55,6 +55,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/python/moose.config.toml
+++ b/templates/python/moose.config.toml
@@ -54,6 +54,7 @@ api_key = ""
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/typescript-empty/moose.config.toml
+++ b/templates/typescript-empty/moose.config.toml
@@ -52,6 +52,7 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/typescript-express/moose.config.toml
+++ b/templates/typescript-express/moose.config.toml
@@ -54,5 +54,6 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true

--- a/templates/typescript-fastify/moose.config.toml
+++ b/templates/typescript-fastify/moose.config.toml
@@ -54,5 +54,6 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true

--- a/templates/typescript-mcp/packages/moosestack-service/moose.config.toml
+++ b/templates/typescript-mcp/packages/moosestack-service/moose.config.toml
@@ -51,5 +51,6 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true

--- a/templates/typescript-tests/moose.config.toml
+++ b/templates/typescript-tests/moose.config.toml
@@ -60,6 +60,7 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true

--- a/templates/typescript/moose.config.toml
+++ b/templates/typescript/moose.config.toml
@@ -54,6 +54,7 @@ postgresql_version = "13"
 ignore_patterns = []
 
 [features]
+olap = true
 streaming_engine = true
 workflows = true
 apis = true


### PR DESCRIPTION
Ensures all templates have the OLAP feature enabled by default in their moose.config.toml files. Previously only 4 templates (cluster and migrate-test) had this flag set.

Slack thread: https://fiveonefour-workspace.slack.com/archives/C08BYKG5P7C/p1772751492901909?thread_ts=1757097492.948059&cid=C08BYKG5P7C

https://claude.ai/code/session_01GmLxpJeq1H4Gh2ij9XZYYi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to template defaults; no runtime logic changes, with limited impact to newly generated projects.
> 
> **Overview**
> All template `moose.config.toml` files now set **`[features].olap = true`**, aligning default template behavior with existing OLAP-enabled templates.
> 
> No functional code changes; this is a template configuration-only update affecting newly generated projects (Typescript and Python templates, including app-specific template variants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f153d8e29b91f3cb9fe727859f1dfbb8cd3a6a1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->