### PR TITLE
remove setting for init from remote and db pull

### DIFF
--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -901,6 +901,59 @@ jobs:
         run: |
           cat ~/.moose/*-cli.log
 
+  test-e2e-init-from-remote-and-seed:
+    needs:
+      [detect-changes, check, test-cli, test-ts-moose-lib, test-py-moose-lib]
+    if: needs.detect-changes.outputs.should_run == 'true'
+    name: Test E2E Init From Remote & Seed
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    env:
+      RUST_BACKTRACE: full
+    steps:
+      - name: Install Protoc (Needed for Temporal)
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "23.x"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+          cache-shared-key: ${{ runner.os }}-${{ runner.arch }}-rust
+          cache-on-failure: true
+          cache-all-crates: true
+          cache-workspace-crates: true
+
+      - name: Run Init From Remote & Seed E2E Tests
+        run: pnpm install --frozen-lockfile && pnpm --filter=framework-cli-e2e run test -- --grep "moose seed clickhouse with seedFilter"
+
+      - name: Inspect Logs
+        if: always()
+        run: |
+          cat ~/.moose/*-cli.log
+
   lints:
     needs: detect-changes
     if: needs.detect-changes.outputs.should_run == 'true'
@@ -964,6 +1017,7 @@ jobs:
         test-e2e-cluster-typescript,
         test-e2e-cluster-python,
         test-e2e-otlp-export,
+        test-e2e-init-from-remote-and-seed,
         lints,
       ]
     if: always()
@@ -996,6 +1050,7 @@ jobs:
              [[ "${{ needs.test-e2e-cluster-typescript.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-cluster-python.result }}" == "failure" ]] || \
              [[ "${{ needs.test-e2e-otlp-export.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-e2e-init-from-remote-and-seed.result }}" == "failure" ]] || \
              [[ "${{ needs.lints.result }}" == "failure" ]]; then
             echo "One or more required jobs failed"
             exit 1
@@ -1014,6 +1069,7 @@ jobs:
              [[ "${{ needs.test-e2e-cluster-typescript.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-cluster-python.result }}" == "success" ]] && \
              [[ "${{ needs.test-e2e-otlp-export.result }}" == "success" ]] && \
+             [[ "${{ needs.test-e2e-init-from-remote-and-seed.result }}" == "success" ]] && \
              [[ "${{ needs.lints.result }}" == "success" ]]; then
             echo "All required jobs succeeded"
             exit 0

--- a/apps/framework-cli/src/cli/routines/code_generation.rs
+++ b/apps/framework-cli/src/cli/routines/code_generation.rs
@@ -8,7 +8,7 @@ use crate::framework::languages::SupportedLanguages;
 use crate::framework::python::generate::tables_to_python;
 use crate::framework::typescript::generate::tables_to_typescript;
 use crate::infrastructure::olap::clickhouse::remote::ClickHouseRemote;
-use crate::infrastructure::olap::clickhouse::{create_client, ConfiguredDBClient};
+use crate::infrastructure::olap::clickhouse::{create_readonly_client, ConfiguredDBClient};
 use crate::infrastructure::olap::OlapOperations;
 use crate::project::Project;
 use crate::utilities::constants::{
@@ -123,7 +123,7 @@ pub async fn create_client_and_db(
         config.db_name = db_name.clone();
     }
 
-    Ok((create_client(config), db_name))
+    Ok((create_readonly_client(config), db_name))
 }
 
 fn write_external_models_file(

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -1884,24 +1884,39 @@ pub struct ConfiguredDBClient {
 /// });
 /// ```
 pub fn create_client(clickhouse_config: ClickHouseConfig) -> ConfiguredDBClient {
+    let mut client = create_base_client(&clickhouse_config);
+    client = client
+        .with_option("enable_json_type", "1")
+        .with_option("flatten_nested", "0");
+    ConfiguredDBClient {
+        client,
+        config: clickhouse_config,
+    }
+}
+
+/// Creates a client without setting session-level options like `flatten_nested`.
+/// Use this for connecting to remote/read-only ClickHouse servers (e.g. `init --from-remote`, `db pull`).
+pub fn create_readonly_client(clickhouse_config: ClickHouseConfig) -> ConfiguredDBClient {
+    ConfiguredDBClient {
+        client: create_base_client(&clickhouse_config),
+        config: clickhouse_config,
+    }
+}
+
+fn create_base_client(clickhouse_config: &ClickHouseConfig) -> Client {
     let protocol = if clickhouse_config.use_ssl {
         "https"
     } else {
         "http"
     };
-    ConfiguredDBClient {
-        client: Client::default()
-            .with_url(format!(
-                "{}://{}:{}",
-                protocol, clickhouse_config.host, clickhouse_config.host_port
-            ))
-            .with_user(clickhouse_config.user.to_string())
-            .with_password(clickhouse_config.password.to_string())
-            .with_database(clickhouse_config.db_name.to_string())
-            .with_option("enable_json_type", "1")
-            .with_option("flatten_nested", "0"),
-        config: clickhouse_config,
-    }
+    Client::default()
+        .with_url(format!(
+            "{}://{}:{}",
+            protocol, clickhouse_config.host, clickhouse_config.host_port
+        ))
+        .with_user(clickhouse_config.user.to_string())
+        .with_password(clickhouse_config.password.to_string())
+        .with_database(clickhouse_config.db_name.to_string())
 }
 
 /// Executes a SQL query against the ClickHouse database

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/remote.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/remote.rs
@@ -23,7 +23,7 @@
 use std::fmt;
 
 use super::config::ClickHouseConfig;
-use super::{create_client, ConfiguredDBClient};
+use super::{create_readonly_client, ConfiguredDBClient};
 use urlencoding::encode;
 
 /// Escapes a string for use in a SQL string literal.
@@ -178,7 +178,7 @@ impl ClickHouseRemote {
             clusters: None,
         };
 
-        let client = create_client(config);
+        let client = create_readonly_client(config);
         (client, self.database.clone())
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ClickHouse client construction and which connection options are applied, which can subtly change query/serialization behavior for remote init and schema pulls; CI coverage is added but production behavior may differ across ClickHouse versions.
> 
> **Overview**
> Stops setting session-level ClickHouse options (notably `flatten_nested`) for remote/read-only connections by introducing `create_readonly_client` and refactoring `create_client` to build from a shared base client.
> 
> Updates remote schema/codegen paths (`init --from-remote`, `db pull`, and `ClickHouseRemote::build_client`) to use the new read-only client.
> 
> Extends the `test-framework-cli` GitHub Actions workflow with a new E2E job (`Test E2E Init From Remote & Seed`) and includes it in the final required status aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d36af5c3efb996610067ee0edbf6195293b30411. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->