### PR TITLE
ci: add validation workflow for examples

### DIFF
--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -54,23 +54,55 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Find project roots
+        id: roots
+        working-directory: examples/${{ matrix.example }}
+        run: |
+          # Collect directories that contain a buildable manifest.
+          # Start with the example root itself, then fall back to subdirectories.
+          roots=""
+          if [ -f "package.json" ] || [ -f "pnpm-workspace.yaml" ] || [ -f "pnpm-lock.yaml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ]; then
+            roots="."
+          else
+            # Monorepo-style example: find subdirectories with manifests (up to 3 levels)
+            roots=$(find . -mindepth 1 -maxdepth 3 \( -name package.json -o -name requirements.txt -o -name setup.py -o -name pnpm-workspace.yaml \) -exec dirname {} \; | sort -u)
+          fi
+          if [ -z "$roots" ]; then
+            echo "::error::No manifest found for ${{ matrix.example }} at any depth — nothing to validate"
+            exit 1
+          fi
+          echo "roots<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$roots" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "Project roots: $roots"
+
       - name: Install dependencies
         working-directory: examples/${{ matrix.example }}
         run: |
-          if [ -f "pnpm-workspace.yaml" ] || [ -f "pnpm-lock.yaml" ]; then
-            corepack enable
-            pnpm install --frozen-lockfile
-          elif [ -f "package-lock.json" ]; then
-            npm ci
-          elif [ -f "package.json" ]; then
-            npm install
-          fi
-          if [ -f "requirements.txt" ]; then
-            pip install -r requirements.txt
-          fi
-          if [ -f "setup.py" ]; then
-            pip install -e .
-          fi
+          while IFS= read -r root; do
+            [ -z "$root" ] && continue
+            echo "::group::Install deps in $root"
+            pushd "$root" > /dev/null
+            if [ -f "pnpm-lock.yaml" ]; then
+              corepack enable
+              pnpm install --frozen-lockfile
+            elif [ -f "pnpm-workspace.yaml" ]; then
+              corepack enable
+              pnpm install
+            elif [ -f "package-lock.json" ]; then
+              npm ci
+            elif [ -f "package.json" ]; then
+              npm install
+            fi
+            if [ -f "requirements.txt" ]; then
+              pip install -r requirements.txt
+            fi
+            if [ -f "setup.py" ]; then
+              pip install -e .
+            fi
+            popd > /dev/null
+            echo "::endgroup::"
+          done <<< "${{ steps.roots.outputs.roots }}"
 
       # Note: ideally we'd run `moose build` here per the design spec,
       # but that requires ClickHouse and other infrastructure.
@@ -79,30 +111,37 @@ jobs:
         working-directory: examples/${{ matrix.example }}
         run: |
           validated=false
-          if [ -f "pnpm-workspace.yaml" ] || [ -f "pnpm-lock.yaml" ]; then
-            pnpm run build --if-present
-            pnpm run typecheck --if-present
-            validated=true
-          elif [ -f "package.json" ]; then
-            ran_any=false
-            if node -e "const p=require('./package.json'); process.exit(p.scripts?.build ? 0 : 1)" 2>/dev/null; then
-              npm run build
-              ran_any=true
+          while IFS= read -r root; do
+            [ -z "$root" ] && continue
+            echo "::group::Validate $root"
+            pushd "$root" > /dev/null
+            if [ -f "pnpm-workspace.yaml" ] || [ -f "pnpm-lock.yaml" ]; then
+              pnpm run --if-present build
+              pnpm run --if-present typecheck
+              validated=true
+            elif [ -f "package.json" ]; then
+              ran_any=false
+              if node -e "const p=require('./package.json'); process.exit(p.scripts?.build ? 0 : 1)" 2>/dev/null; then
+                npm run build
+                ran_any=true
+              fi
+              if node -e "const p=require('./package.json'); process.exit(p.scripts?.typecheck ? 0 : 1)" 2>/dev/null; then
+                npm run typecheck
+                ran_any=true
+              fi
+              if [ "$ran_any" = false ]; then
+                echo "No build/typecheck script found, deps install verified"
+              fi
+              validated=true
             fi
-            if node -e "const p=require('./package.json'); process.exit(p.scripts?.typecheck ? 0 : 1)" 2>/dev/null; then
-              npm run typecheck
-              ran_any=true
+            if python -m pip show moose-lib >/dev/null 2>&1; then
+              python -c "import moose_lib; print('moose_lib imported successfully')"
+              validated=true
             fi
-            if [ "$ran_any" = false ]; then
-              echo "No build/typecheck script found, deps install verified"
-            fi
-            validated=true
-          fi
-          if python -m pip show moose-lib >/dev/null 2>&1; then
-            python -c "import moose_lib; print('moose_lib imported successfully')"
-            validated=true
-          fi
+            popd > /dev/null
+            echo "::endgroup::"
+          done <<< "${{ steps.roots.outputs.roots }}"
           if [ "$validated" = false ]; then
-            echo "::error::No root-level manifest found for ${{ matrix.example }} — nothing was validated"
+            echo "::error::No manifest validated for ${{ matrix.example }} — nothing was validated"
             exit 1
           fi

--- a/scripts/package-templates.js
+++ b/scripts/package-templates.js
@@ -164,7 +164,12 @@ function verifyVersions(stagingDir, versions, templateName) {
           ["@514labs/moose-lib", versions["moose-lib"]],
           ["@514labs/moose-cli", versions["moose-cli"]],
         ]) {
-          if (deps[name] && deps[name] !== ver && deps[name] !== "latest") {
+          if (
+            ver &&
+            deps[name] &&
+            deps[name] !== ver &&
+            deps[name] !== "latest"
+          ) {
             throw new Error(
               `${templateName} ${filePath} has ${name}@${deps[name]}, expected ${ver}`,
             );
@@ -177,7 +182,7 @@ function verifyVersions(stagingDir, versions, templateName) {
         ["moose-cli", versions["moose-cli"]],
       ]) {
         const match = content.match(new RegExp(`${pkg}==([\\w.\\-]+)`));
-        if (match && match[1] !== ver) {
+        if (ver && match && match[1] !== ver) {
           throw new Error(
             `${templateName} ${filePath} has ${pkg}==${match[1]}, expected ${ver}`,
           );


### PR DESCRIPTION
Runs on PRs touching examples/, after successful CLI releases,
and on manual dispatch. Discovers buildable examples automatically
and validates each one can install dependencies and build/typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI workflow that will run installs/build steps across many example projects, which could introduce flaky or unexpectedly long CI runs and new failures on PRs/releases. Template version verification is slightly relaxed when version pins are missing, reducing false failures but potentially masking mispinned deps.
> 
> **Overview**
> Adds a new `Validate Examples` GitHub Actions workflow that triggers on PRs touching `examples/**`, after successful `Release CLI` runs on `main`, and via manual dispatch.
> 
> The workflow auto-discovers buildable example directories, fans out per example in a matrix, then installs Node/Python dependencies and runs build/typecheck where available (including basic `moose_lib` import validation).
> 
> Updates `scripts/package-templates.js` so `verifyVersions` only enforces `package.json`/`requirements.txt` version matches when the expected version is present in `_versions.toml`, avoiding failures when a version isn’t defined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84d7bc954852807d69d141ace9009e9b275355aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->