### PR TITLE
Dave/eng 2515 add hosting docs for 514 env cli

### DIFF
--- a/apps/framework-docs-v2/content/hosting/cli/env/delete.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/env/delete.mdx
@@ -1,0 +1,40 @@
+---
+title: env delete
+description: Delete an environment variable.
+order: 4
+---
+
+# 514 env delete
+
+Use `514 env delete` to remove an environment variable from a project or branch.
+
+## Usage
+
+```bash
+514 env delete [OPTIONS] <KEY>
+```
+
+## Arguments
+
+- `<KEY>`: Environment variable key to delete.
+
+## Options
+
+- `--project <PROJECT>`: Project reference: `<org>/<project>`, project name, project ID, or 514 URL.
+- `--branch <BRANCH>`: Branch name (infers branch scope).
+
+:::include /shared/hosting/cli/global-options.mdx
+
+## Examples
+
+```bash
+514 env delete OLD_SECRET --project acme/analytics-api
+514 env delete FEATURE_FLAG --project acme/analytics-api --branch feature/new-ingest
+```
+
+## Related
+
+- [`514 env`](/hosting/cli/env)
+- [`514 env list`](/hosting/cli/env/list)
+- [`514 env get`](/hosting/cli/env/get)
+- [`514 env set`](/hosting/cli/env/set)

--- a/apps/framework-docs-v2/content/hosting/cli/env/get.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/env/get.mdx
@@ -1,0 +1,41 @@
+---
+title: env get
+description: Get the value of an environment variable.
+order: 2
+---
+
+# 514 env get
+
+Use `514 env get` to retrieve the value of a single environment variable.
+
+## Usage
+
+```bash
+514 env get [OPTIONS] <KEY>
+```
+
+## Arguments
+
+- `<KEY>`: Environment variable key.
+
+## Options
+
+- `--project <PROJECT>`: Project reference: `<org>/<project>`, project name, project ID, or 514 URL.
+- `--branch <BRANCH>`: Branch name (infers branch scope).
+
+:::include /shared/hosting/cli/global-options.mdx
+
+## Examples
+
+```bash
+514 env get DATABASE_URL --project acme/analytics-api
+514 env get API_KEY --project acme/analytics-api --branch feature/new-ingest
+514 --json env get DATABASE_URL --project acme/analytics-api
+```
+
+## Related
+
+- [`514 env`](/hosting/cli/env)
+- [`514 env list`](/hosting/cli/env/list)
+- [`514 env set`](/hosting/cli/env/set)
+- [`514 env delete`](/hosting/cli/env/delete)

--- a/apps/framework-docs-v2/content/hosting/cli/env/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/env/index.mdx
@@ -1,0 +1,81 @@
+---
+title: env
+description: Manage environment variables for a 514 hosting project.
+order: 8
+---
+
+# 514 env
+
+Use `514 env` to manage environment variables for a project. Variables can be scoped to a project or a specific branch.
+
+## Usage
+
+```bash
+514 env [OPTIONS] <COMMAND>
+```
+
+## Subcommands
+
+### List
+
+List environment variables for a project or branch.
+
+```bash
+514 env list [OPTIONS]
+```
+
+See the full command reference: [`514 env list`](/hosting/cli/env/list).
+
+### Get
+
+Get the value of a single environment variable.
+
+```bash
+514 env get [OPTIONS] <KEY>
+```
+
+See the full command reference: [`514 env get`](/hosting/cli/env/get).
+
+### Set
+
+Set one or more environment variables.
+
+```bash
+514 env set [OPTIONS] <VARS>...
+```
+
+See the full command reference: [`514 env set`](/hosting/cli/env/set).
+
+### Delete
+
+Delete an environment variable.
+
+```bash
+514 env delete [OPTIONS] <KEY>
+```
+
+See the full command reference: [`514 env delete`](/hosting/cli/env/delete).
+
+## Options
+
+:::include /shared/hosting/cli/global-options.mdx
+
+## Examples
+
+```bash
+514 env list --project acme/analytics-api
+514 env get DATABASE_URL --project acme/analytics-api
+514 env set API_KEY=sk-123 --project acme/analytics-api
+514 env set API_KEY=sk-123 BATCH_SIZE=100 --project acme/analytics-api --branch feature/new-ingest
+514 env delete OLD_SECRET --project acme/analytics-api
+```
+
+## Related
+
+- [`514 --help`](/hosting/cli)
+- [`514 env list`](/hosting/cli/env/list)
+- [`514 env get`](/hosting/cli/env/get)
+- [`514 env set`](/hosting/cli/env/set)
+- [`514 env delete`](/hosting/cli/env/delete)
+- [`514 project`](/hosting/cli/projects)
+- [`514 deployment`](/hosting/cli/deployment)

--- a/apps/framework-docs-v2/content/hosting/cli/env/list.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/env/list.mdx
@@ -1,0 +1,37 @@
+---
+title: env list
+description: List environment variables for a project or branch.
+order: 1
+---
+
+# 514 env list
+
+Use `514 env list` to list environment variables for a project. Optionally scope to a specific branch.
+
+## Usage
+
+```bash
+514 env list [OPTIONS]
+```
+
+## Options
+
+- `--project <PROJECT>`: Project reference: `<org>/<project>`, project name, project ID, or 514 URL.
+- `--branch <BRANCH>`: Branch name (infers branch scope).
+
+:::include /shared/hosting/cli/global-options.mdx
+
+## Examples
+
+```bash
+514 env list --project acme/analytics-api
+514 env list --project acme/analytics-api --branch feature/new-ingest
+514 --json env list --project acme/analytics-api
+```
+
+## Related
+
+- [`514 env`](/hosting/cli/env)
+- [`514 env get`](/hosting/cli/env/get)
+- [`514 env set`](/hosting/cli/env/set)
+- [`514 env delete`](/hosting/cli/env/delete)

--- a/apps/framework-docs-v2/content/hosting/cli/env/set.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/env/set.mdx
@@ -1,0 +1,41 @@
+---
+title: env set
+description: Set one or more environment variables.
+order: 3
+---
+
+# 514 env set
+
+Use `514 env set` to set one or more environment variables as `KEY=VALUE` pairs.
+
+## Usage
+
+```bash
+514 env set [OPTIONS] <VARS>...
+```
+
+## Arguments
+
+- `<VARS>...`: One or more `KEY=VALUE` pairs.
+
+## Options
+
+- `--project <PROJECT>`: Project reference: `<org>/<project>`, project name, project ID, or 514 URL.
+- `--branch <BRANCH>`: Branch name (infers branch scope).
+
+:::include /shared/hosting/cli/global-options.mdx
+
+## Examples
+
+```bash
+514 env set API_KEY=sk-123 --project acme/analytics-api
+514 env set API_KEY=sk-123 BATCH_SIZE=100 --project acme/analytics-api
+514 env set API_KEY=sk-branch-456 --project acme/analytics-api --branch feature/new-ingest
+```
+
+## Related
+
+- [`514 env`](/hosting/cli/env)
+- [`514 env list`](/hosting/cli/env/list)
+- [`514 env get`](/hosting/cli/env/get)
+- [`514 env delete`](/hosting/cli/env/delete)

--- a/apps/framework-docs-v2/content/hosting/cli/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/index.mdx
@@ -26,6 +26,7 @@ Argument convention:
 - `deployment`: Manage deployments (`list`).
 - `doc`: Browse and search documentation (`list`, `show`, `search`, `browse`).
 - `cli`: Manage installed CLIs (`update`).
+- `env`: Manage environment variables (`list`, `get`, `set`, `delete`).
 - `agent`: Agent-focused read-only command surface.
 - `api-endpoint`: Manage API endpoint resources for a deployment.
 - `stream`: Manage stream resources for a deployment.
@@ -85,6 +86,8 @@ Resources following this pattern:
 514 stream list dep_abc123 --project my-org/my-project
 514 api-endpoints list dep_abc123 --project my-org/my-project
 514 agent deployment list --project my-org/my-project
+514 env list --project my-org/my-project
+514 env set API_KEY=sk-123 --project my-org/my-project
 514 doc search "deployment"
 514 cli update moose
 ```
@@ -96,4 +99,5 @@ Resources following this pattern:
 - [`514 project`](/hosting/cli/projects)
 - [`514 project link`](/hosting/cli/projects/link)
 - [`514 project setup`](/hosting/cli/projects/setup)
+- [`514 env`](/hosting/cli/env)
 - [`514 cli update`](/hosting/cli/cli/update)

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -1245,6 +1245,38 @@ const hostingNavigationConfig: NavigationConfig = [
   },
   {
     type: "page",
+    slug: "hosting/cli/env",
+    title: "env",
+    languages: ["typescript", "python"],
+    children: [
+      {
+        type: "page",
+        slug: "hosting/cli/env/list",
+        title: "list",
+        languages: ["typescript", "python"],
+      },
+      {
+        type: "page",
+        slug: "hosting/cli/env/get",
+        title: "get",
+        languages: ["typescript", "python"],
+      },
+      {
+        type: "page",
+        slug: "hosting/cli/env/set",
+        title: "set",
+        languages: ["typescript", "python"],
+      },
+      {
+        type: "page",
+        slug: "hosting/cli/env/delete",
+        title: "delete",
+        languages: ["typescript", "python"],
+      },
+    ],
+  },
+  {
+    type: "page",
     slug: "hosting/cli/agent",
     title: "agent",
     languages: ["typescript", "python"],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only additions plus a navigation entry; no runtime logic or backend behavior changes.
> 
> **Overview**
> Adds a new **`514 env` CLI documentation section** covering `list`, `get`, `set`, and `delete`, including usage, arguments/options, examples, and cross-links between commands.
> 
> Updates the hosting CLI root docs and `navigation.ts` to surface `env` in the top-level command list, examples, and sidebar navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3cfd5ef4cf4f1dad77a092755ccb85819221f32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->