### PR TITLE
fix: copy .npmrc to deploy stage for modern pnpm deploy in Docker

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -556,6 +556,7 @@ USER root:root
 WORKDIR /temp-monorepo
 COPY --from=monorepo-base /monorepo/pnpm-workspace.yaml ./
 {}
+COPY --from=monorepo-base /monorepo/.npmr[c] ./
 COPY --from=monorepo-base /monorepo/{} ./{}
 # Copy all workspace directories that exist
 {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to Dockerfile generation for monorepo TypeScript builds; it only adds copying `.npmrc` into the deploy workspace to keep `pnpm deploy` behavior consistent.
> 
> **Overview**
> Ensures the generated monorepo Dockerfile copies `.npmrc` into the temporary workspace context used for `pnpm deploy`, so deploy-time dependency resolution uses the same npm/pnpm configuration as the root monorepo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f668a954f182a931ca8484d4a3c2435c93189e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->