### PR TITLE
docs(mcp): update config key from servers to mcpServers

### DIFF
--- a/apps/framework-docs-v2/content/shared/prerequisites/install-mcp.mdx
+++ b/apps/framework-docs-v2/content/shared/prerequisites/install-mcp.mdx
@@ -124,7 +124,7 @@ Access via: Claude > Settings > Developer > Edit Config
 
 ```json filename="claude_desktop_config.json" copy
 {
-  "servers": {
+  "mcpServers": {
     "moose-dev": {
       "command": "npx",
       "args": [


### PR DESCRIPTION
Updated configuration key from 'servers' to 'mcpServers'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update with a small JSON snippet correction and formatting fix.
> 
> **Overview**
> Updates the Claude Desktop MCP setup docs to use the correct config root key, changing the example from `servers` to `mcpServers` in `claude_desktop_config.json`.
> 
> Also fixes the missing newline at end of `install-mcp.mdx` (no behavior change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 374ff272b39c191df22947b5c3eb5bebc6823677. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->