### PR TITLE
fix: deployment failure logs show as info in hosting UI

### DIFF
--- a/apps/framework-cli/src/cli/display/message_display.rs
+++ b/apps/framework-cli/src/cli/display/message_display.rs
@@ -252,6 +252,20 @@ mod tests {
     }
 
     #[test]
+    fn test_show_message_impl_with_logging_error() {
+        let message = Message::new("Error".to_string(), "This should log as error".to_string());
+        let result = show_message_impl(MessageType::Error, message, true, false, false, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_show_message_impl_with_logging_warning() {
+        let message = Message::new("Warning".to_string(), "This should log as warn".to_string());
+        let result = show_message_impl(MessageType::Warning, message, true, false, false, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_show_message_impl_multiline() {
         let message = Message::new(
             "Multi\nLine".to_string(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to log severity selection with added tests; minimal behavioral impact beyond how logs are classified downstream.
> 
> **Overview**
> CLI message logging now uses the appropriate `tracing` level: `MessageType::Error` logs via `error!`, `MessageType::Warning` via `warn!`, and everything else remains `info!`, instead of always emitting `info!`.
> 
> Adds focused unit tests covering the new error and warning logging paths in `show_message_impl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be28ed87a00e8fb1f2b05fdb34b801c6c63cfc4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->