### PR TITLE
Add VS Code onboarding extension

### DIFF
--- a/apps/vscode-extension/.gitignore
+++ b/apps/vscode-extension/.gitignore
@@ -1,0 +1,2 @@
+dist-test/
+*.vsix

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -1,0 +1,41 @@
+# Fiveonefour
+
+Fiveonefour is a narrow VS Code workspace extension for keeping the Moose and `514` CLIs installed and current, then pointing you at the next step for creating a Moose Harness project.
+
+## What the extension does
+
+- Runs the Fiveonefour installer on every activation to keep `moose` and `514` current.
+- Detects the installed CLI versions and records the latest install state.
+- Opens a Harness splash page after the first successful install or update in a session.
+- Exposes one manual command: `Fiveonefour: Check Install State`.
+
+## Create a Moose Harness project
+
+When the installer run succeeds, Fiveonefour opens a splash page with the current Harness init command:
+
+```bash
+moose init
+```
+
+Use that command from a terminal in the parent directory where you want the new project to be created.
+
+## Platform support
+
+- Supported: macOS, Linux, VS Code Remote - WSL
+- Unsupported: native Windows
+
+On Windows, Fiveonefour does not attempt to run the installer. It shows a message telling you to reopen the project in WSL instead.
+
+## Check install state
+
+Run `Fiveonefour: Check Install State` from the Command Palette to open the extension output and review:
+
+- the last installer result
+- the last attempt / success / failure timestamps
+- detected `moose` and `514` versions
+- the current Harness init command
+
+## Links
+
+- Docs: https://docs.fiveonefour.com/moosestack
+- Support: http://slack.moosestack.com/

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "fiveonefour",
+  "displayName": "Fiveonefour",
+  "description": "Install the Moose and 514 CLIs, keep them current, and show Moose Harness getting-started guidance for VS Code-family editors.",
+  "version": "0.0.0",
+  "publisher": "514-labs",
+  "homepage": "https://docs.fiveonefour.com/moosestack",
+  "bugs": {
+    "url": "https://github.com/514-labs/moosestack/issues"
+  },
+  "qna": "http://slack.moosestack.com/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/514-labs/moosestack",
+    "directory": "apps/vscode-extension"
+  },
+  "license": "MIT",
+  "markdown": "github",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "fiveonefour",
+    "moose",
+    "moosestack",
+    "harness",
+    "cli",
+    "installer",
+    "wsl",
+    "vscode"
+  ],
+  "extensionKind": [
+    "workspace"
+  ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true,
+      "description": "Fiveonefour can install and update the Moose and 514 CLIs, show install state, and open the Moose Harness guide without requiring a trusted workspace."
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:fiveonefour.checkInstallState"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "fiveonefour.checkInstallState",
+        "title": "Fiveonefour: Check Install State"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "test": "pnpm run build && node -e \"require('node:fs').rmSync('dist-test', { recursive: true, force: true })\" && tsc -p tsconfig.test.json && node --test dist-test/test/*.test.js",
+    "package:vsix": "pnpm run build && npx @vscode/vsce package",
+    "publish:vscode": "pnpm run build && npx @vscode/vsce publish",
+    "publish:openvsx": "pnpm run build && npx ovsx publish"
+  },
+  "devDependencies": {
+    "@repo/ts-config": "workspace:^",
+    "@types/node": "catalog:",
+    "@types/vscode": "^1.90.0",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "escape-goat": "^4.0.0"
+  }
+}

--- a/apps/vscode-extension/scripts/build.mjs
+++ b/apps/vscode-extension/scripts/build.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(__dirname, "..");
+const distDir = path.join(extensionRoot, "dist");
+
+rmSync(distDir, { force: true, recursive: true });
+execFileSync("tsc", ["-p", "tsconfig.json"], {
+  cwd: extensionRoot,
+  stdio: "inherit",
+});

--- a/apps/vscode-extension/src/activityController.ts
+++ b/apps/vscode-extension/src/activityController.ts
@@ -1,0 +1,126 @@
+import type * as vscode from "vscode";
+
+import { EXTENSION_BRAND } from "./constants";
+
+export interface ActivityReporter {
+  step(message: string): void;
+}
+
+export interface ActivityHandle extends ActivityReporter {
+  complete(): void;
+  fail(message: string): void;
+}
+
+export interface ActivityController {
+  begin(title: string): ActivityHandle;
+  dispose(): void;
+}
+
+interface PendingActivity {
+  id: number;
+  message: string;
+  title: string;
+}
+
+export function createActivityController(
+  statusBarItem: vscode.StatusBarItem,
+  outputChannel: vscode.OutputChannel,
+): ActivityController {
+  let nextId = 0;
+  let resetTimer: ReturnType<typeof setTimeout> | undefined;
+  const pendingActivities: PendingActivity[] = [];
+
+  function clearResetTimer(): void {
+    if (resetTimer) {
+      clearTimeout(resetTimer);
+      resetTimer = undefined;
+    }
+  }
+
+  function showTransientStatus(text: string, tooltip: string): void {
+    clearResetTimer();
+    statusBarItem.text = text;
+    statusBarItem.tooltip = tooltip;
+    statusBarItem.show();
+    resetTimer = setTimeout(() => {
+      statusBarItem.hide();
+      resetTimer = undefined;
+    }, 4000);
+  }
+
+  function render(): void {
+    clearResetTimer();
+    const currentActivity = pendingActivities[pendingActivities.length - 1];
+    if (!currentActivity) {
+      statusBarItem.hide();
+      return;
+    }
+
+    statusBarItem.text = `$(sync~spin) ${currentActivity.message}`;
+    statusBarItem.tooltip = currentActivity.title;
+    statusBarItem.show();
+  }
+
+  function removeActivity(id: number): PendingActivity | undefined {
+    const index = pendingActivities.findIndex((activity) => activity.id === id);
+    if (index === -1) {
+      return undefined;
+    }
+
+    return pendingActivities.splice(index, 1)[0];
+  }
+
+  return {
+    begin(title: string): ActivityHandle {
+      const pendingActivity: PendingActivity = {
+        id: nextId++,
+        message: title,
+        title,
+      };
+      pendingActivities.push(pendingActivity);
+      outputChannel.appendLine(`${title} started.`);
+      render();
+
+      return {
+        step(message: string): void {
+          pendingActivity.message = message;
+          outputChannel.appendLine(message);
+          render();
+        },
+        complete(): void {
+          const completedActivity = removeActivity(pendingActivity.id);
+          if (!completedActivity) {
+            return;
+          }
+
+          outputChannel.appendLine(`${completedActivity.title} completed.`);
+          render();
+          if (pendingActivities.length === 0) {
+            showTransientStatus(
+              `$(check) ${EXTENSION_BRAND} ready`,
+              `${EXTENSION_BRAND} is idle.`,
+            );
+          }
+        },
+        fail(message: string): void {
+          const failedActivity = removeActivity(pendingActivity.id);
+          if (!failedActivity) {
+            return;
+          }
+
+          outputChannel.show(true);
+          outputChannel.appendLine(
+            `${failedActivity.title} failed: ${message}`,
+          );
+          render();
+          if (pendingActivities.length === 0) {
+            showTransientStatus(`$(error) ${EXTENSION_BRAND} failed`, message);
+          }
+        },
+      };
+    },
+    dispose(): void {
+      clearResetTimer();
+    },
+  };
+}

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -1,0 +1,17 @@
+export const EXTENSION_BRAND = "Fiveonefour";
+export const OUTPUT_CHANNEL_NAME = EXTENSION_BRAND;
+export const INSTALL_STATE_KEY = "fiveonefour.installState";
+
+export const COMMANDS = {
+  checkInstallState: "fiveonefour.checkInstallState",
+} as const;
+
+export const INSTALLER_SCRIPT_URL = "https://fiveonefour.com/install.sh";
+export const INSTALLER_TARGETS = ["moose", "514"] as const;
+export const HARNESS_INIT_COMMAND = "moose init";
+
+export const MOOSESTACK_DOCS_URL = "https://docs.fiveonefour.com/moosestack";
+export const SUPPORT_URL = "http://slack.moosestack.com/";
+
+export const WINDOWS_WSL_MESSAGE =
+  "Fiveonefour installs the Moose and 514 CLIs on macOS, Linux, and VS Code Remote - WSL. On Windows, open the project in WSL and run the extension there.";

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,0 +1,204 @@
+import * as vscode from "vscode";
+
+import { createActivityController } from "./activityController";
+import {
+  COMMANDS,
+  EXTENSION_BRAND,
+  INSTALL_STATE_KEY,
+  OUTPUT_CHANNEL_NAME,
+} from "./constants";
+import { showHarnessSplashPanel } from "./getStartedPanel";
+import {
+  getUnsupportedPlatformMessage,
+  installLatestCli,
+  isInstallerSupportedPlatform,
+} from "./provisioning";
+import {
+  buildInstallStateSummary,
+  createInitialInstallState,
+  recordInstallAttempt,
+  recordInstallFailure,
+  recordInstallSuccess,
+  recordUnsupportedPlatform,
+  shouldShowHarnessSplash,
+} from "./status";
+import type { InstallState } from "./types";
+
+interface SessionState {
+  splashShown: boolean;
+  windowsWarningShown: boolean;
+}
+
+const OPEN_HARNESS_GUIDE_LABEL = "Open Harness Guide";
+const INSTALL_STATE_OUTPUT_MESSAGE = `${EXTENSION_BRAND} install state is available in the output panel.`;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getStoredInstallState(context: vscode.ExtensionContext): InstallState {
+  return (
+    context.globalState.get<InstallState>(INSTALL_STATE_KEY) ??
+    createInitialInstallState()
+  );
+}
+
+async function storeInstallState(
+  context: vscode.ExtensionContext,
+  state: InstallState,
+): Promise<void> {
+  await context.globalState.update(INSTALL_STATE_KEY, state);
+}
+
+type HarnessGuideMessageKind = "error" | "information" | "warning";
+
+async function showMessageWithHarnessGuide(
+  kind: HarnessGuideMessageKind,
+  message: string,
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+): Promise<void> {
+  const showMessage =
+    kind === "error" ? vscode.window.showErrorMessage
+    : kind === "warning" ? vscode.window.showWarningMessage
+    : vscode.window.showInformationMessage;
+  const selection = await showMessage(message, OPEN_HARNESS_GUIDE_LABEL);
+
+  if (selection === OPEN_HARNESS_GUIDE_LABEL) {
+    showHarnessSplashPanel(context, outputChannel);
+  }
+}
+
+async function showInstallState(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+): Promise<void> {
+  const state = getStoredInstallState(context);
+
+  outputChannel.appendLine("");
+  outputChannel.appendLine(`${EXTENSION_BRAND} install state`);
+  outputChannel.appendLine(buildInstallStateSummary(state));
+  outputChannel.show(true);
+
+  const kind =
+    state.lastResult === "failure" ? "error"
+    : state.lastResult === "unsupported-platform" ? "warning"
+    : "information";
+
+  await showMessageWithHarnessGuide(
+    kind,
+    INSTALL_STATE_OUTPUT_MESSAGE,
+    context,
+    outputChannel,
+  );
+}
+
+async function runInstallerOnActivation(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+  activityController: ReturnType<typeof createActivityController>,
+  session: SessionState,
+): Promise<void> {
+  const previousState = getStoredInstallState(context);
+  const platform = process.platform;
+  const now = new Date().toISOString();
+  const attemptedState = recordInstallAttempt(previousState, { now, platform });
+  await storeInstallState(context, attemptedState);
+
+  if (!isInstallerSupportedPlatform(platform)) {
+    const unsupportedState = recordUnsupportedPlatform(
+      attemptedState,
+      getUnsupportedPlatformMessage(platform),
+      { now, platform },
+    );
+    await storeInstallState(context, unsupportedState);
+
+    if (!session.windowsWarningShown) {
+      session.windowsWarningShown = true;
+      await showMessageWithHarnessGuide(
+        "warning",
+        getUnsupportedPlatformMessage(platform),
+        context,
+        outputChannel,
+      );
+    }
+    return;
+  }
+
+  const activity = activityController.begin(
+    "Fiveonefour: Installing Moose and 514 CLIs",
+  );
+
+  try {
+    activity.step("Running the latest Fiveonefour installer");
+    const versions = await installLatestCli(outputChannel);
+    const successState = recordInstallSuccess(attemptedState, versions, {
+      platform,
+    });
+    await storeInstallState(context, successState);
+    activity.complete();
+
+    if (shouldShowHarnessSplash(successState, session.splashShown)) {
+      session.splashShown = true;
+      showHarnessSplashPanel(context, outputChannel);
+    }
+  } catch (error) {
+    const message = getErrorMessage(error);
+    const failureState = recordInstallFailure(attemptedState, message, {
+      platform,
+    });
+    await storeInstallState(context, failureState);
+    activity.fail(message);
+
+    await showMessageWithHarnessGuide(
+      "error",
+      `${EXTENSION_BRAND} could not update the Moose and 514 CLIs: ${message}`,
+      context,
+      outputChannel,
+    );
+  }
+}
+
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const outputChannel = vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+  );
+  const activityController = createActivityController(
+    statusBarItem,
+    outputChannel,
+  );
+  const session: SessionState = {
+    splashShown: false,
+    windowsWarningShown: false,
+  };
+
+  statusBarItem.name = EXTENSION_BRAND;
+  statusBarItem.command = COMMANDS.checkInstallState;
+
+  context.subscriptions.push(
+    outputChannel,
+    statusBarItem,
+    vscode.commands.registerCommand(COMMANDS.checkInstallState, async () => {
+      await showInstallState(context, outputChannel);
+    }),
+    {
+      dispose(): void {
+        activityController.dispose();
+      },
+    },
+  );
+
+  void runInstallerOnActivation(
+    context,
+    outputChannel,
+    activityController,
+    session,
+  ).catch((error) => {
+    const message = getErrorMessage(error);
+    outputChannel.appendLine(`Fatal error during installation: ${message}`);
+    outputChannel.show(true);
+  });
+}

--- a/apps/vscode-extension/src/getStartedPanel.ts
+++ b/apps/vscode-extension/src/getStartedPanel.ts
@@ -1,0 +1,363 @@
+import crypto from "node:crypto";
+import type * as vscode from "vscode";
+
+import {
+  COMMANDS,
+  EXTENSION_BRAND,
+  HARNESS_INIT_COMMAND,
+  MOOSESTACK_DOCS_URL,
+  SUPPORT_URL,
+} from "./constants";
+import { getVscodeApi } from "./vscodeApi";
+
+const PANEL_ID = "fiveonefour.harnessGuide";
+const PANEL_TITLE = "Create a Moose Harness Project";
+type EscapeGoatModule = typeof import("escape-goat");
+
+const importModule = new Function("specifier", "return import(specifier);") as <
+  T,
+>(
+  specifier: string,
+) => Promise<T>;
+
+function loadEscapeGoat(): Promise<EscapeGoatModule> {
+  return importModule<EscapeGoatModule>("escape-goat");
+}
+
+export function buildHarnessSplashHtml(
+  nonce = crypto.randomUUID().replaceAll("-", ""),
+): Promise<string> {
+  return loadEscapeGoat().then(({ htmlEscape }) => {
+    const escapedBrand = htmlEscape(EXTENSION_BRAND);
+    const escapedHarnessCommand = htmlEscape(HARNESS_INIT_COMMAND);
+    const escapedDocsUrl = htmlEscape(MOOSESTACK_DOCS_URL);
+    const escapedNonce = htmlEscape(nonce);
+    const escapedSupportUrl = htmlEscape(SUPPORT_URL);
+
+    return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${escapedNonce}';"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${PANEL_TITLE}</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0b0d12;
+        --panel: rgba(16, 20, 30, 0.94);
+        --panel-border: rgba(255, 255, 255, 0.08);
+        --muted: rgba(239, 240, 244, 0.72);
+        --text: #f5f7fb;
+        --accent: #48d3a7;
+        --accent-2: #7fd8ff;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--text);
+        background:
+          radial-gradient(circle at top left, rgba(72, 211, 167, 0.18), transparent 28%),
+          radial-gradient(circle at top right, rgba(127, 216, 255, 0.12), transparent 30%),
+          linear-gradient(180deg, #0b0d12 0%, #07090d 100%);
+        font-family:
+          "SF Pro Display",
+          "Inter",
+          "Segoe UI",
+          sans-serif;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 32px 24px 48px;
+      }
+
+      .hero,
+      .grid,
+      .actions {
+        border: 1px solid var(--panel-border);
+        border-radius: 28px;
+        background: var(--panel);
+        box-shadow:
+          0 24px 72px rgba(0, 0, 0, 0.28),
+          inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      }
+
+      .hero {
+        padding: 32px;
+        margin-bottom: 18px;
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        margin-bottom: 20px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(72, 211, 167, 0.12);
+        color: var(--accent);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: clamp(2.6rem, 6vw, 4.8rem);
+        line-height: 0.96;
+        letter-spacing: -0.07em;
+      }
+
+      .lede {
+        max-width: 760px;
+        margin: 0;
+        color: var(--muted);
+        font-size: 1.04rem;
+        line-height: 1.7;
+      }
+
+      .command-block {
+        margin-top: 24px;
+        border-radius: 22px;
+        padding: 18px 20px;
+        background: rgba(7, 10, 14, 0.96);
+        border: 1px solid rgba(127, 216, 255, 0.16);
+      }
+
+      .command-label {
+        color: var(--accent-2);
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      code {
+        display: block;
+        margin-top: 10px;
+        font-size: 1.2rem;
+        line-height: 1.4;
+        color: #f8fafc;
+        font-family: var(--vscode-editor-font-family, "SFMono-Regular", monospace);
+      }
+
+      .grid {
+        display: grid;
+        gap: 14px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        padding: 18px;
+        margin-bottom: 18px;
+      }
+
+      .card {
+        border-radius: 20px;
+        padding: 18px;
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .card h2 {
+        margin: 0 0 10px;
+        font-size: 1rem;
+        letter-spacing: -0.02em;
+      }
+
+      .card p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.65;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        padding: 18px;
+      }
+
+      button {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        padding: 11px 16px;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+        color: #04110c;
+        background: linear-gradient(135deg, #48d3a7, #7fd8ff);
+      }
+
+      button.secondary {
+        color: var(--text);
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding: 24px 16px 40px;
+        }
+
+        .hero,
+        .grid,
+        .actions {
+          border-radius: 24px;
+        }
+
+        .hero {
+          padding: 24px;
+        }
+
+        .actions {
+          flex-direction: column;
+        }
+
+        button {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <div class="eyebrow">${escapedBrand} Harness Guide</div>
+        <h1>Create a Moose Harness project.</h1>
+        <p class="lede">
+          ${escapedBrand} keeps the Moose and 514 CLIs installed and current in the background.
+          Once that is healthy, start a new Moose Harness project from any terminal with the command below.
+        </p>
+        <div class="command-block">
+          <div class="command-label">Current harness command</div>
+          <code>${escapedHarnessCommand}</code>
+        </div>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>1. Pick a directory</h2>
+          <p>Open a terminal in the parent directory where you want the new Harness project to live.</p>
+        </article>
+        <article class="card">
+          <h2>2. Run the init command</h2>
+          <p>Execute <code>${escapedHarnessCommand}</code> and follow the prompts to scaffold the project.</p>
+        </article>
+        <article class="card">
+          <h2>3. Windows note</h2>
+          <p>Fiveonefour supports Windows through WSL. Native Windows does not run the installer flow.</p>
+        </article>
+      </section>
+
+      <section class="actions">
+        <button type="button" data-command="copyHarnessCommand">Copy moose init</button>
+        <button type="button" class="secondary" data-link="${escapedDocsUrl}">Open MooseStack docs</button>
+        <button type="button" class="secondary" data-link="${escapedSupportUrl}">Open support</button>
+        <button type="button" class="secondary" data-command="checkInstallState">Check install state</button>
+        <button type="button" class="secondary" data-command="openOutput">Open Fiveonefour output</button>
+      </section>
+    </main>
+
+    <script nonce="${escapedNonce}">
+      const vscode = acquireVsCodeApi();
+      for (const element of document.querySelectorAll("[data-command], [data-link]")) {
+        element.addEventListener("click", (event) => {
+          event.preventDefault();
+          vscode.postMessage({
+            command: element.getAttribute("data-command"),
+            url: element.getAttribute("data-link"),
+          });
+        });
+      }
+    </script>
+  </body>
+</html>`;
+  });
+}
+
+export function showHarnessSplashPanel(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+): void {
+  const vscodeApi = getVscodeApi();
+  const panel = vscodeApi.window.createWebviewPanel(
+    PANEL_ID,
+    PANEL_TITLE,
+    vscodeApi.ViewColumn.Active,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: false,
+    },
+  );
+  let isDisposed = false;
+  panel.onDidDispose(() => {
+    isDisposed = true;
+  });
+
+  const setPanelHtml = (html: string): void => {
+    if (isDisposed) {
+      return;
+    }
+
+    panel.webview.html = html;
+  };
+
+  setPanelHtml(
+    '<!DOCTYPE html><html lang="en"><body>Loading Fiveonefour...</body></html>',
+  );
+  void buildHarnessSplashHtml()
+    .then((html) => {
+      setPanelHtml(html);
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      outputChannel.appendLine(
+        `Failed to render the harness guide: ${message}`,
+      );
+      setPanelHtml(
+        '<!DOCTYPE html><html lang="en"><body>Failed to load the Fiveonefour harness guide.</body></html>',
+      );
+    });
+  panel.webview.onDidReceiveMessage(
+    async (message: unknown) => {
+      if (typeof message !== "object" || message === null) {
+        return;
+      }
+
+      const command = (message as { command?: unknown }).command;
+      const url = (message as { url?: unknown }).url;
+
+      if (typeof url === "string" && url.length > 0) {
+        await vscodeApi.env.openExternal(vscodeApi.Uri.parse(url));
+        return;
+      }
+
+      if (command === "copyHarnessCommand") {
+        await vscodeApi.env.clipboard.writeText(HARNESS_INIT_COMMAND);
+        void vscodeApi.window.showInformationMessage(
+          "Copied `moose init` to the clipboard.",
+        );
+        return;
+      }
+
+      if (command === "checkInstallState") {
+        await vscodeApi.commands.executeCommand(COMMANDS.checkInstallState);
+        return;
+      }
+
+      if (command === "openOutput") {
+        outputChannel.show(true);
+      }
+    },
+    undefined,
+    context.subscriptions,
+  );
+}

--- a/apps/vscode-extension/src/processRunner.ts
+++ b/apps/vscode-extension/src/processRunner.ts
@@ -1,0 +1,77 @@
+import { spawn } from "node:child_process";
+
+import type { CommandResult, RunOptions } from "./types";
+
+export function runProcess(
+  command: string,
+  args: readonly string[],
+  options: RunOptions = {},
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      cwd: options.cwd,
+      env: options.env ? { ...process.env, ...options.env } : process.env,
+      shell: false,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function clearTimers(): void {
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = undefined;
+      }
+
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+        forceKillTimer = undefined;
+      }
+    }
+
+    if (options.timeoutMs) {
+      timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+        forceKillTimer = setTimeout(() => {
+          child.kill("SIGKILL");
+        }, 1000);
+      }, options.timeoutMs);
+    }
+
+    child.stdout.on("data", (chunk: { toString(): string } | string) => {
+      const text = chunk.toString();
+      stdout += text;
+      options.onStdout?.(text);
+    });
+
+    child.stderr.on("data", (chunk: { toString(): string } | string) => {
+      const text = chunk.toString();
+      stderr += text;
+      options.onStderr?.(text);
+    });
+
+    if (options.stdin !== undefined) {
+      child.stdin.end(options.stdin);
+    }
+
+    child.on("error", (error) => {
+      clearTimers();
+      reject(error);
+    });
+    child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      clearTimers();
+      resolve({ code, signal, stderr, stdout, timedOut });
+    });
+  });
+}
+
+export function runShell(
+  command: string,
+  options: RunOptions = {},
+): Promise<CommandResult> {
+  return runProcess("/bin/bash", ["-lc", command], options);
+}

--- a/apps/vscode-extension/src/provisioning.ts
+++ b/apps/vscode-extension/src/provisioning.ts
@@ -1,0 +1,142 @@
+import os from "node:os";
+import type * as vscode from "vscode";
+
+import {
+  INSTALLER_SCRIPT_URL,
+  INSTALLER_TARGETS,
+  WINDOWS_WSL_MESSAGE,
+} from "./constants";
+import { runProcess, runShell } from "./processRunner";
+import type { CommandResult, InstallVersions, RunOptions } from "./types";
+
+export interface InstallDependencies {
+  platform(): NodeJS.Platform;
+  runProcess(
+    command: string,
+    args: readonly string[],
+    options?: RunOptions,
+  ): Promise<CommandResult>;
+  runShell(command: string, options?: RunOptions): Promise<CommandResult>;
+}
+
+export class UnsupportedPlatformError extends Error {
+  constructor(message = WINDOWS_WSL_MESSAGE) {
+    super(message);
+    this.name = "UnsupportedPlatformError";
+  }
+}
+
+function isSafeCommandName(command: string): boolean {
+  return /^[A-Za-z0-9._-]+$/u.test(command);
+}
+
+function normalizeVersion(stdout: string): string | null {
+  const line = stdout
+    .split(/\r?\n/u)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.length > 0);
+
+  return line ?? null;
+}
+
+async function readVersion(
+  command: string,
+  dependencies: InstallDependencies,
+): Promise<string | null> {
+  if (!isSafeCommandName(command)) {
+    return null;
+  }
+
+  try {
+    const result = await dependencies.runShell(`${command} --version`);
+
+    if (result.code !== 0) {
+      return null;
+    }
+
+    return normalizeVersion(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+export function isInstallerSupportedPlatform(
+  platform = os.platform(),
+): boolean {
+  return platform === "darwin" || platform === "linux";
+}
+
+export function getUnsupportedPlatformMessage(
+  platform = os.platform(),
+): string {
+  if (platform === "win32") {
+    return WINDOWS_WSL_MESSAGE;
+  }
+
+  return "Fiveonefour currently installs the Moose and 514 CLIs on macOS and Linux only.";
+}
+
+export function buildInstallerCommand(): string {
+  return `bash <(curl -sSfL ${INSTALLER_SCRIPT_URL}) ${INSTALLER_TARGETS.join(",")}`;
+}
+
+export async function detectInstalledVersions(
+  dependencies: Partial<InstallDependencies> = {},
+): Promise<InstallVersions> {
+  const resolvedDependencies: InstallDependencies = {
+    platform: () => os.platform(),
+    runProcess,
+    runShell,
+    ...dependencies,
+  };
+
+  return {
+    cli514Version: await readVersion("514", resolvedDependencies),
+    mooseVersion: await readVersion("moose", resolvedDependencies),
+  };
+}
+
+export async function installLatestCli(
+  outputChannel: vscode.OutputChannel,
+  dependencies: Partial<InstallDependencies> = {},
+): Promise<InstallVersions> {
+  const resolvedDependencies: InstallDependencies = {
+    platform: () => os.platform(),
+    runProcess,
+    runShell,
+    ...dependencies,
+  };
+  const platform = resolvedDependencies.platform();
+
+  if (!isInstallerSupportedPlatform(platform)) {
+    throw new UnsupportedPlatformError(getUnsupportedPlatformMessage(platform));
+  }
+
+  outputChannel.appendLine(
+    "Running the Fiveonefour installer for the Moose and 514 CLIs.",
+  );
+
+  const result = await resolvedDependencies.runShell(buildInstallerCommand(), {
+    onStderr: (chunk) => outputChannel.append(chunk),
+    onStdout: (chunk) => outputChannel.append(chunk),
+  });
+
+  if (result.code !== 0) {
+    throw new Error(
+      result.stderr.trim() ||
+        result.stdout.trim() ||
+        "Failed to install the Moose and 514 CLIs.",
+    );
+  }
+
+  outputChannel.appendLine("Installer completed. Detecting CLI versions...");
+  const versions = await detectInstalledVersions(resolvedDependencies);
+  outputChannel.appendLine(
+    `Detected Moose CLI: ${versions.mooseVersion ?? "not detected"}`,
+  );
+  outputChannel.appendLine(
+    `Detected 514 CLI: ${versions.cli514Version ?? "not detected"}`,
+  );
+
+  return versions;
+}

--- a/apps/vscode-extension/src/status.ts
+++ b/apps/vscode-extension/src/status.ts
@@ -1,0 +1,147 @@
+import { HARNESS_INIT_COMMAND, WINDOWS_WSL_MESSAGE } from "./constants";
+import type { InstallState, InstallVersions } from "./types";
+
+interface InstallStateUpdateOptions {
+  now?: string;
+  platform?: NodeJS.Platform;
+}
+
+function resolveNow(now?: string): string {
+  return now ?? new Date().toISOString();
+}
+
+function resolvePlatform(platform?: NodeJS.Platform): NodeJS.Platform {
+  return platform ?? process.platform;
+}
+
+function formatTimestamp(value: string | null): string {
+  return value ?? "never";
+}
+
+function describeLastResult(state: InstallState): string {
+  switch (state.lastResult) {
+    case "success":
+      return "latest installer run succeeded";
+    case "failure":
+      return "latest installer run failed";
+    case "unsupported-platform":
+      return "native Windows is unsupported";
+    default:
+      return "installer has not run yet";
+  }
+}
+
+function describePlatformSupport(platform: NodeJS.Platform): string {
+  if (platform === "win32") {
+    return "Windows via WSL only";
+  }
+
+  return "macOS, Linux, and VS Code Remote - WSL";
+}
+
+export function createInitialInstallState(
+  platform = process.platform,
+): InstallState {
+  return {
+    cli514Version: null,
+    lastAttemptAt: null,
+    lastFailureAt: null,
+    lastFailureMessage: null,
+    lastResult: "never",
+    lastSuccessAt: null,
+    mooseVersion: null,
+    platform,
+  };
+}
+
+export function recordInstallAttempt(
+  state: InstallState,
+  options: InstallStateUpdateOptions = {},
+): InstallState {
+  return {
+    ...state,
+    lastAttemptAt: resolveNow(options.now),
+    platform: resolvePlatform(options.platform),
+  };
+}
+
+export function recordInstallSuccess(
+  state: InstallState,
+  versions: InstallVersions,
+  options: InstallStateUpdateOptions = {},
+): InstallState {
+  const now = resolveNow(options.now);
+
+  return {
+    ...state,
+    cli514Version: versions.cli514Version,
+    lastAttemptAt: now,
+    lastFailureAt: null,
+    lastFailureMessage: null,
+    lastResult: "success",
+    lastSuccessAt: now,
+    mooseVersion: versions.mooseVersion,
+    platform: resolvePlatform(options.platform),
+  };
+}
+
+export function recordInstallFailure(
+  state: InstallState,
+  message: string,
+  options: InstallStateUpdateOptions = {},
+): InstallState {
+  const now = resolveNow(options.now);
+
+  return {
+    ...state,
+    lastAttemptAt: now,
+    lastFailureAt: now,
+    lastFailureMessage: message,
+    lastResult: "failure",
+    platform: resolvePlatform(options.platform),
+  };
+}
+
+export function recordUnsupportedPlatform(
+  state: InstallState,
+  message = WINDOWS_WSL_MESSAGE,
+  options: InstallStateUpdateOptions = {},
+): InstallState {
+  const now = resolveNow(options.now);
+
+  return {
+    ...state,
+    lastAttemptAt: now,
+    lastFailureAt: now,
+    lastFailureMessage: message,
+    lastResult: "unsupported-platform",
+    platform: resolvePlatform(options.platform),
+  };
+}
+
+export function shouldShowHarnessSplash(
+  state: InstallState,
+  splashAlreadyShown: boolean,
+): boolean {
+  return !splashAlreadyShown && state.lastResult === "success";
+}
+
+export function buildInstallStateSummary(state: InstallState): string {
+  const lines = [
+    `Platform: ${state.platform}`,
+    `Supported environments: ${describePlatformSupport(state.platform)}`,
+    `Last result: ${describeLastResult(state)}`,
+    `Last attempt: ${formatTimestamp(state.lastAttemptAt)}`,
+    `Last success: ${formatTimestamp(state.lastSuccessAt)}`,
+    `Last failure: ${formatTimestamp(state.lastFailureAt)}`,
+    `Moose CLI: ${state.mooseVersion ?? "not detected"}`,
+    `514 CLI: ${state.cli514Version ?? "not detected"}`,
+    `Harness init command: ${HARNESS_INIT_COMMAND}`,
+  ];
+
+  if (state.lastFailureMessage) {
+    lines.push(`Last message: ${state.lastFailureMessage}`);
+  }
+
+  return lines.join("\n");
+}

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -1,0 +1,38 @@
+export type InstallResultStatus =
+  | "failure"
+  | "never"
+  | "success"
+  | "unsupported-platform";
+
+export interface InstallState {
+  cli514Version: string | null;
+  lastAttemptAt: string | null;
+  lastFailureAt: string | null;
+  lastFailureMessage: string | null;
+  lastResult: InstallResultStatus;
+  lastSuccessAt: string | null;
+  mooseVersion: string | null;
+  platform: NodeJS.Platform;
+}
+
+export interface InstallVersions {
+  cli514Version: string | null;
+  mooseVersion: string | null;
+}
+
+export interface CommandResult {
+  code: number | null;
+  stderr: string;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  timedOut: boolean;
+}
+
+export interface RunOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  onStderr?: (chunk: string) => void;
+  onStdout?: (chunk: string) => void;
+  stdin?: string;
+  timeoutMs?: number;
+}

--- a/apps/vscode-extension/src/vscodeApi.ts
+++ b/apps/vscode-extension/src/vscodeApi.ts
@@ -1,0 +1,3 @@
+export function getVscodeApi(): typeof import("vscode") {
+  return require("vscode") as typeof import("vscode");
+}

--- a/apps/vscode-extension/test/activityController.test.ts
+++ b/apps/vscode-extension/test/activityController.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type * as vscode from "vscode";
+
+import { createActivityController } from "../src/activityController";
+
+function createStatusBarItem(): vscode.StatusBarItem {
+  return {
+    hide(): void {
+      return;
+    },
+    show(): void {
+      return;
+    },
+    text: "",
+    tooltip: "",
+  } as unknown as vscode.StatusBarItem;
+}
+
+function createOutputChannel(): {
+  lines: string[];
+  outputChannel: vscode.OutputChannel;
+  showCalls: boolean[];
+} {
+  const lines: string[] = [];
+  const showCalls: boolean[] = [];
+
+  return {
+    lines,
+    outputChannel: {
+      append(): void {
+        return;
+      },
+      appendLine(value: string): void {
+        lines.push(value);
+      },
+      clear(): void {
+        return;
+      },
+      dispose(): void {
+        return;
+      },
+      hide(): void {
+        return;
+      },
+      name: "Fiveonefour",
+      replace(): void {
+        return;
+      },
+      show(preserveFocus?: boolean): void {
+        showCalls.push(Boolean(preserveFocus));
+      },
+    } as unknown as vscode.OutputChannel,
+    showCalls,
+  };
+}
+
+test("createActivityController keeps logs hidden until a failure occurs", () => {
+  const statusBarItem = createStatusBarItem();
+  const { lines, outputChannel, showCalls } = createOutputChannel();
+  const controller = createActivityController(statusBarItem, outputChannel);
+
+  const activity = controller.begin("Fiveonefour: Bootstrapping Workspace");
+
+  assert.deepEqual(lines, ["Fiveonefour: Bootstrapping Workspace started."]);
+  assert.deepEqual(showCalls, []);
+
+  activity.fail("boom");
+
+  assert.deepEqual(showCalls, [true]);
+  assert.match(
+    lines.at(-1) ?? "",
+    /Fiveonefour: Bootstrapping Workspace failed: boom/,
+  );
+
+  controller.dispose();
+});

--- a/apps/vscode-extension/test/getStartedPanel.test.ts
+++ b/apps/vscode-extension/test/getStartedPanel.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildHarnessSplashHtml } from "../src/getStartedPanel";
+
+test("buildHarnessSplashHtml renders the harness command and support links", async () => {
+  const html = await buildHarnessSplashHtml();
+
+  assert.match(html, /Create a Moose Harness Project/);
+  assert.match(html, /moose init/);
+  assert.match(html, /Open MooseStack docs/);
+  assert.match(html, /Open support/);
+  assert.match(html, /Windows through WSL/);
+  assert.match(html, /https:\/\/docs\.fiveonefour\.com\/moosestack/);
+  assert.match(html, /http:\/\/slack\.moosestack\.com\//);
+});
+
+test("buildHarnessSplashHtml uses a per-panel CSP nonce", async () => {
+  const html = await buildHarnessSplashHtml();
+
+  const cspNonceMatch = html.match(/script-src 'nonce-([^']+)'/);
+  const scriptNonceMatch = html.match(/<script nonce="([^"]+)">/);
+
+  assert.ok(cspNonceMatch);
+  assert.ok(scriptNonceMatch);
+  assert.equal(cspNonceMatch[1], scriptNonceMatch[1]);
+  assert.notEqual(cspNonceMatch[1], "fiveonefour");
+});

--- a/apps/vscode-extension/test/manifest.test.ts
+++ b/apps/vscode-extension/test/manifest.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const extensionRoot = path.resolve(__dirname, "../..");
+const manifestPath = path.join(extensionRoot, "package.json");
+const readmePath = path.join(extensionRoot, "README.md");
+
+function readManifest(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+test("package manifest matches the installer-only extension scope", () => {
+  const manifest = readManifest();
+  const activationEvents = manifest.activationEvents as string[];
+  const commandContributions = (
+    manifest.contributes as {
+      commands: Array<{ command: string; title: string }>;
+    }
+  ).commands;
+
+  assert.equal(manifest.name, "fiveonefour");
+  assert.equal(manifest.displayName, "Fiveonefour");
+  assert.match(
+    String(manifest.description),
+    /Install the Moose and 514 CLIs, keep them current/,
+  );
+  assert.deepEqual(activationEvents, [
+    "onStartupFinished",
+    "onCommand:fiveonefour.checkInstallState",
+  ]);
+  assert.equal(Array.isArray(manifest.extensionPack), false);
+  assert.deepEqual(commandContributions, [
+    {
+      command: "fiveonefour.checkInstallState",
+      title: "Fiveonefour: Check Install State",
+    },
+  ]);
+});
+
+test("README describes the installer-only harness workflow", () => {
+  const readme = fs.readFileSync(readmePath, "utf8");
+
+  assert.match(readme, /Runs the Fiveonefour installer on every activation/);
+  assert.match(readme, /moose init/);
+  assert.match(
+    readme,
+    /On Windows, Fiveonefour does not attempt to run the installer/,
+  );
+});

--- a/apps/vscode-extension/test/processRunner.test.ts
+++ b/apps/vscode-extension/test/processRunner.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runProcess } from "../src/processRunner";
+
+test("runProcess forwards stdin to the child process", async () => {
+  const result = await runProcess(
+    process.execPath,
+    [
+      "-e",
+      "let data=''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => data += chunk); process.stdin.on('end', () => process.stdout.write(data));",
+    ],
+    {
+      stdin: "hello from stdin",
+    },
+  );
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout, "hello from stdin");
+  assert.equal(result.timedOut, false);
+});
+
+test("runProcess marks commands that exceed the timeout", async () => {
+  const result = await runProcess(
+    process.execPath,
+    ["-e", "setTimeout(() => undefined, 1_000);"],
+    {
+      timeoutMs: 50,
+    },
+  );
+
+  assert.equal(result.timedOut, true);
+  assert.notEqual(result.signal, null);
+});
+
+test("runProcess merges custom env values with the parent environment", async () => {
+  const result = await runProcess(
+    process.execPath,
+    [
+      "-e",
+      "process.stdout.write(JSON.stringify({ foo: process.env.FOO, hasPath: Boolean(process.env.PATH) }));",
+    ],
+    {
+      env: {
+        FOO: "bar",
+      },
+    },
+  );
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    foo: "bar",
+    hasPath: true,
+  });
+});

--- a/apps/vscode-extension/test/provisioning.test.ts
+++ b/apps/vscode-extension/test/provisioning.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type * as vscode from "vscode";
+
+import {
+  buildInstallerCommand,
+  getUnsupportedPlatformMessage,
+  installLatestCli,
+  UnsupportedPlatformError,
+} from "../src/provisioning";
+import type { CommandResult, RunOptions } from "../src/types";
+
+function createOutputRecorder(): {
+  lines: string[];
+  outputChannel: vscode.OutputChannel;
+} {
+  const lines: string[] = [];
+
+  return {
+    lines,
+    outputChannel: {
+      append(value: string): void {
+        lines.push(value);
+      },
+      appendLine(value: string): void {
+        lines.push(value);
+      },
+    } as vscode.OutputChannel,
+  };
+}
+
+function createCommandResult(
+  overrides: Partial<CommandResult> = {},
+): CommandResult {
+  return {
+    code: 0,
+    signal: null,
+    stderr: "",
+    stdout: "",
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+test("buildInstallerCommand installs both cli tools", () => {
+  assert.equal(
+    buildInstallerCommand(),
+    "bash <(curl -sSfL https://fiveonefour.com/install.sh) moose,514",
+  );
+});
+
+test("installLatestCli runs the installer and records detected versions", async () => {
+  const { lines, outputChannel } = createOutputRecorder();
+  const shellCommands: string[] = [];
+
+  const versions = await installLatestCli(outputChannel, {
+    platform: () => "linux",
+    async runProcess(): Promise<CommandResult> {
+      throw new Error("runProcess should not be called");
+    },
+    async runShell(
+      command: string,
+      options?: RunOptions,
+    ): Promise<CommandResult> {
+      shellCommands.push(command);
+
+      if (command === buildInstallerCommand()) {
+        options?.onStdout?.("install ok");
+        return createCommandResult();
+      }
+
+      if (command === "514 --version") {
+        return createCommandResult({ stdout: "514 4.5.6\n" });
+      }
+
+      if (command === "moose --version") {
+        return createCommandResult({ stdout: "moose 1.2.3\n" });
+      }
+
+      return createCommandResult();
+    },
+  });
+
+  assert.deepEqual(shellCommands, [
+    buildInstallerCommand(),
+    "514 --version",
+    "moose --version",
+  ]);
+  assert.deepEqual(versions, {
+    cli514Version: "514 4.5.6",
+    mooseVersion: "moose 1.2.3",
+  });
+  assert.match(lines.join("\n"), /Running the Fiveonefour installer/);
+  assert.match(lines.join("\n"), /Detected Moose CLI: moose 1\.2\.3/);
+});
+
+test("installLatestCli refuses to run on native Windows", async () => {
+  let shellCalled = false;
+
+  await assert.rejects(
+    installLatestCli(createOutputRecorder().outputChannel, {
+      platform: () => "win32",
+      async runProcess(): Promise<CommandResult> {
+        throw new Error("runProcess should not be called");
+      },
+      async runShell(): Promise<CommandResult> {
+        shellCalled = true;
+        return createCommandResult();
+      },
+    }),
+    UnsupportedPlatformError,
+  );
+
+  assert.equal(shellCalled, false);
+  assert.match(getUnsupportedPlatformMessage("win32"), /WSL/);
+});
+
+test("installLatestCli surfaces installer failures", async () => {
+  await assert.rejects(
+    installLatestCli(createOutputRecorder().outputChannel, {
+      platform: () => "darwin",
+      async runProcess(): Promise<CommandResult> {
+        throw new Error("runProcess should not be called");
+      },
+      async runShell(): Promise<CommandResult> {
+        return createCommandResult({
+          code: 1,
+          stderr: "permission denied",
+        });
+      },
+    }),
+    /permission denied/,
+  );
+});

--- a/apps/vscode-extension/test/status.test.ts
+++ b/apps/vscode-extension/test/status.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildInstallStateSummary,
+  createInitialInstallState,
+  recordInstallAttempt,
+  recordInstallFailure,
+  recordInstallSuccess,
+  recordUnsupportedPlatform,
+  shouldShowHarnessSplash,
+} from "../src/status";
+
+test("recordInstallSuccess captures versions and clears failure state", () => {
+  const state = recordInstallSuccess(
+    createInitialInstallState("linux"),
+    {
+      cli514Version: "514 1.0.0",
+      mooseVersion: "moose 2.0.0",
+    },
+    {
+      now: "2026-03-29T12:00:00.000Z",
+      platform: "linux",
+    },
+  );
+
+  assert.equal(state.lastResult, "success");
+  assert.equal(state.lastSuccessAt, "2026-03-29T12:00:00.000Z");
+  assert.equal(state.lastFailureMessage, null);
+  assert.equal(state.cli514Version, "514 1.0.0");
+  assert.equal(state.mooseVersion, "moose 2.0.0");
+});
+
+test("buildInstallStateSummary returns a readable installer status block", () => {
+  const state = recordInstallSuccess(
+    recordInstallAttempt(createInitialInstallState("linux"), {
+      now: "2026-03-29T11:59:00.000Z",
+      platform: "linux",
+    }),
+    {
+      cli514Version: "514 1.0.0",
+      mooseVersion: "moose 2.0.0",
+    },
+    {
+      now: "2026-03-29T12:00:00.000Z",
+      platform: "linux",
+    },
+  );
+
+  const summary = buildInstallStateSummary(state);
+
+  assert.match(summary, /Platform: linux/);
+  assert.match(summary, /Last result: latest installer run succeeded/);
+  assert.match(summary, /Moose CLI: moose 2\.0\.0/);
+  assert.match(summary, /514 CLI: 514 1\.0\.0/);
+  assert.match(summary, /Harness init command: moose init/);
+});
+
+test("recordUnsupportedPlatform preserves the WSL guidance", () => {
+  const state = recordUnsupportedPlatform(
+    createInitialInstallState("win32"),
+    undefined,
+    {
+      now: "2026-03-29T12:00:00.000Z",
+      platform: "win32",
+    },
+  );
+
+  const summary = buildInstallStateSummary(state);
+
+  assert.equal(state.lastResult, "unsupported-platform");
+  assert.match(summary, /Windows via WSL only/);
+  assert.match(summary, /WSL/);
+});
+
+test("recordInstallFailure keeps the failure message for later inspection", () => {
+  const state = recordInstallFailure(
+    createInitialInstallState("darwin"),
+    "curl failed",
+    {
+      now: "2026-03-29T12:00:00.000Z",
+      platform: "darwin",
+    },
+  );
+
+  assert.equal(state.lastResult, "failure");
+  assert.equal(state.lastFailureMessage, "curl failed");
+});
+
+test("shouldShowHarnessSplash only opens after the first success in a session", () => {
+  const successfulState = recordInstallSuccess(
+    createInitialInstallState("linux"),
+    {
+      cli514Version: "514 1.0.0",
+      mooseVersion: "moose 2.0.0",
+    },
+    {
+      now: "2026-03-29T12:00:00.000Z",
+      platform: "linux",
+    },
+  );
+
+  assert.equal(shouldShowHarnessSplash(successfulState, false), true);
+  assert.equal(shouldShowHarnessSplash(successfulState, true), false);
+  assert.equal(
+    shouldShowHarnessSplash(createInitialInstallState("linux"), false),
+    false,
+  );
+});

--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../packages/ts-config/base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "types": ["node", "vscode"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}

--- a/apps/vscode-extension/tsconfig.test.json
+++ b/apps/vscode-extension/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-test",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,7 +326,7 @@ importers:
         version: 12.23.24(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next:
         specifier: 'catalog:'
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-mdx-remote:
         specifier: 'catalog:'
         version: 6.0.0(@types/react@19.2.2)(react@19.2.0)
@@ -462,6 +462,25 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  apps/vscode-extension:
+    dependencies:
+      escape-goat:
+        specifier: ^4.0.0
+        version: 4.0.0
+    devDependencies:
+      '@repo/ts-config':
+        specifier: workspace:^
+        version: link:../../packages/ts-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.24
+      '@types/vscode':
+        specifier: ^1.90.0
+        version: 1.110.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/design-system-base:
     dependencies:
       '@514labs/event-capture':
@@ -554,7 +573,7 @@ importers:
         version: 0.18.1
       next:
         specifier: 'catalog:'
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -636,7 +655,7 @@ importers:
         version: 0.18.1
       next:
         specifier: 'catalog:'
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@types/react':
         specifier: ^19.0.1
@@ -1757,78 +1776,92 @@ packages:
     resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.3':
     resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.3':
     resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.3':
     resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.3':
     resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
     resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.3':
     resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.4':
     resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.4':
     resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.4':
     resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.4':
     resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.4':
     resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.4':
     resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.4':
     resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.4':
     resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
@@ -2044,24 +2077,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -3716,6 +3753,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5100,6 +5140,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-goat@4.0.0:
+    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
+    engines: {node: '>=12'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -5617,11 +5661,13 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -5631,7 +5677,7 @@ packages:
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-prefix@4.0.0:
     resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
@@ -10787,7 +10833,7 @@ snapshots:
       '@sentry/vercel-edge': 7.120.4
       '@sentry/webpack-plugin': 1.21.0
       chalk: 3.0.0
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       resolve: 1.22.8
       rollup: 2.79.2
@@ -11725,6 +11771,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/vscode@1.110.0': {}
+
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -12047,7 +12095,7 @@ snapshots:
       '@vercel/edge-config-fs': 0.1.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@vercel/microfrontends@1.3.0(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@5.4.21(@types/node@20.19.24)(lightningcss@1.30.2)(terser@5.44.0))':
     dependencies:
@@ -12061,7 +12109,7 @@ snapshots:
       nanoid: 3.3.11
       path-to-regexp: 6.2.1
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       vite: 5.4.21(@types/node@20.19.24)(lightningcss@1.30.2)(terser@5.44.0)
@@ -12080,7 +12128,7 @@ snapshots:
       jsonc-parser: 3.3.1
       strip-ansi: 6.0.1
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       vite: 5.4.21(@types/node@20.19.24)(lightningcss@1.30.2)(terser@5.44.0)
     transitivePeerDependencies:
@@ -13350,6 +13398,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-goat@4.0.0: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
@@ -13436,7 +13486,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13932,7 +13982,7 @@ snapshots:
       jose: 5.9.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -15575,15 +15625,15 @@ snapshots:
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   next-themes@0.2.1(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -15592,7 +15642,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.0)
+      styled-jsx: 5.1.6(react@19.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -16731,12 +16781,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.6
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.0):
+  styled-jsx@5.1.6(react@19.2.0):
     dependencies:
       client-only: 0.0.1
       react: 19.2.0
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because the extension executes a remote installer script (`bash <(curl ...)`) on activation and persists install state; failures or unexpected script behavior could impact developer machines.
> 
> **Overview**
> Introduces a new `apps/vscode-extension` workspace extension that runs the Fiveonefour installer on startup (macOS/Linux/WSL only), detects `moose`/`514` versions, and records the latest attempt/success/failure state in global storage.
> 
> Adds a single command (`fiveonefour.checkInstallState`) plus a status-bar activity indicator and output logging, and opens a CSP-locked “Harness guide” webview after the first successful install/update in a session (with copy/docs/support actions).
> 
> Includes build/test/packaging scripts, TypeScript configs, unit tests for the installer runner/state tracking/panel HTML, and updates `pnpm-lock.yaml` to add the extension dependencies (notably `escape-goat`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0b0c9b39237684dbf27ec41eeb4014bb76e006b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->