### PR TITLE
fix docker compose file

### DIFF
--- a/apps/framework-cli/src/utilities/docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/docker-compose.yml.hbs
@@ -149,6 +149,8 @@ services:
       {{/if}}
     environment:
       - CLICKHOUSE_DB=${DB_NAME:-local}
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:-panda}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-pandapass}
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
     ports:
       - "${CLICKHOUSE_HOST_PORT:-18123}:8123"
@@ -191,11 +193,6 @@ services:
           <!-- Default path: /clickhouse/tables/{uuid}/{shard} works with Atomic database (default) -->
         </clickhouse>
         EOF
-        mkdir -p /docker-entrypoint-initdb.d
-        cat > /docker-entrypoint-initdb.d/init-user.sql << 'EOSQL'
-        CREATE USER IF NOT EXISTS `{{clickhouse_user}}` IDENTIFIED BY '{{clickhouse_password}}';
-        GRANT CURRENT GRANTS ON *.* TO `{{clickhouse_user}}` WITH GRANT OPTION;
-        EOSQL
         exec /entrypoint.sh
 
   # ClickHouse Node 2 (for cluster replication testing)
@@ -215,6 +212,8 @@ services:
       {{/if}}
     environment:
       - CLICKHOUSE_DB=${DB_NAME:-local}
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:-panda}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-pandapass}
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
     ports:
       - "28123:8123"
@@ -255,11 +254,6 @@ services:
           </macros>
         </clickhouse>
         EOF
-        mkdir -p /docker-entrypoint-initdb.d
-        cat > /docker-entrypoint-initdb.d/init-user.sql << 'EOSQL'
-        CREATE USER IF NOT EXISTS `{{clickhouse_user}}` IDENTIFIED BY '{{clickhouse_password}}';
-        GRANT CURRENT GRANTS ON *.* TO `{{clickhouse_user}}` WITH GRANT OPTION;
-        EOSQL
         exec /entrypoint.sh
   {{/if}}
   {{/if}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ClickHouse container auth setup from entrypoint SQL bootstrapping to `CLICKHOUSE_USER`/`CLICKHOUSE_PASSWORD` env vars, which could break local setups relying on the old init script or implicit users.
> 
> **Overview**
> Updates the `docker-compose.yml.hbs` template to configure ClickHouse credentials via `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` environment variables (with defaults) for both single-node and clustered setups.
> 
> Removes the inline entrypoint logic that wrote an `init-user.sql` file to create/grant the ClickHouse user, relying on ClickHouse's env-based initialization instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e7142ababe1e48656e05bebb6c6aed16207ab71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->