### PR TITLE
Add VS Code extension publish guardrails

### DIFF
--- a/.github/workflows/release-vscode-extension.yaml
+++ b/.github/workflows/release-vscode-extension.yaml
@@ -125,6 +125,18 @@ jobs:
           echo "Publish: ${PUBLISH}"
           echo "Pre-release: ${PRE_RELEASE}"
 
+      - name: Validate publish target
+        if: ${{ steps.publish-settings.outputs.publish == 'true' }}
+        env:
+          PRE_RELEASE: ${{ steps.publish-settings.outputs.pre-release }}
+          REF_NAME: ${{ github.ref_name }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [[ "${PRE_RELEASE}" != "true" && "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "::error title=Invalid publish target::Stable publishing is only allowed from refs/heads/main. Use pre-release=true to validate publishing from ${REF_NAME}."
+            exit 1
+          fi
+
       - name: Validate publish secrets
         if: ${{ steps.publish-settings.outputs.publish == 'true' }}
         env:
@@ -178,7 +190,7 @@ jobs:
   publish-vscode:
     name: Publish to VS Code Marketplace
     needs: build
-    if: ${{ needs.build.outputs.publish == 'true' }}
+    if: ${{ needs.build.outputs.publish == 'true' && (needs.build.outputs.pre-release == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact
@@ -218,7 +230,7 @@ jobs:
   publish-openvsx:
     name: Publish to Open VSX
     needs: build
-    if: ${{ needs.build.outputs.publish == 'true' }}
+    if: ${{ needs.build.outputs.publish == 'true' && (needs.build.outputs.pre-release == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -82,8 +82,5 @@
     "eslint": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "8.55.0"
-  },
-  "dependencies": {
-    "escape-goat": "^4.0.0"
   }
 }

--- a/apps/vscode-extension/src/getStartedPanel.ts
+++ b/apps/vscode-extension/src/getStartedPanel.ts
@@ -12,29 +12,26 @@ import { getVscodeApi } from "./vscodeApi";
 
 const PANEL_ID = "fiveonefour.harnessGuide";
 const PANEL_TITLE = "Create a Moose Harness Project";
-type EscapeGoatModule = typeof import("escape-goat");
 
-const importModule = new Function("specifier", "return import(specifier);") as <
-  T,
->(
-  specifier: string,
-) => Promise<T>;
-
-function loadEscapeGoat(): Promise<EscapeGoatModule> {
-  return importModule<EscapeGoatModule>("escape-goat");
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
 export function buildHarnessSplashHtml(
   nonce = crypto.randomUUID().replaceAll("-", ""),
-): Promise<string> {
-  return loadEscapeGoat().then(({ htmlEscape }) => {
-    const escapedBrand = htmlEscape(EXTENSION_BRAND);
-    const escapedHarnessCommand = htmlEscape(HARNESS_INIT_COMMAND);
-    const escapedDocsUrl = htmlEscape(MOOSESTACK_DOCS_URL);
-    const escapedNonce = htmlEscape(nonce);
-    const escapedSupportUrl = htmlEscape(SUPPORT_URL);
+): string {
+  const escapedBrand = escapeHtml(EXTENSION_BRAND);
+  const escapedHarnessCommand = escapeHtml(HARNESS_INIT_COMMAND);
+  const escapedDocsUrl = escapeHtml(MOOSESTACK_DOCS_URL);
+  const escapedNonce = escapeHtml(nonce);
+  const escapedSupportUrl = escapeHtml(SUPPORT_URL);
 
-    return `<!DOCTYPE html>
+  return `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -280,7 +277,6 @@ export function buildHarnessSplashHtml(
     </script>
   </body>
 </html>`;
-  });
 }
 
 export function showHarnessSplashPanel(
@@ -297,35 +293,7 @@ export function showHarnessSplashPanel(
       retainContextWhenHidden: false,
     },
   );
-  let isDisposed = false;
-  panel.onDidDispose(() => {
-    isDisposed = true;
-  });
-
-  const setPanelHtml = (html: string): void => {
-    if (isDisposed) {
-      return;
-    }
-
-    panel.webview.html = html;
-  };
-
-  setPanelHtml(
-    '<!DOCTYPE html><html lang="en"><body>Loading Fiveonefour...</body></html>',
-  );
-  void buildHarnessSplashHtml()
-    .then((html) => {
-      setPanelHtml(html);
-    })
-    .catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
-      outputChannel.appendLine(
-        `Failed to render the harness guide: ${message}`,
-      );
-      setPanelHtml(
-        '<!DOCTYPE html><html lang="en"><body>Failed to load the Fiveonefour harness guide.</body></html>',
-      );
-    });
+  panel.webview.html = buildHarnessSplashHtml();
   panel.webview.onDidReceiveMessage(
     async (message: unknown) => {
       if (typeof message !== "object" || message === null) {

--- a/apps/vscode-extension/test/getStartedPanel.test.ts
+++ b/apps/vscode-extension/test/getStartedPanel.test.ts
@@ -3,8 +3,8 @@ import test from "node:test";
 
 import { buildHarnessSplashHtml } from "../src/getStartedPanel";
 
-test("buildHarnessSplashHtml renders the harness command and support links", async () => {
-  const html = await buildHarnessSplashHtml();
+test("buildHarnessSplashHtml renders the harness command and support links", () => {
+  const html = buildHarnessSplashHtml();
 
   assert.match(html, /Create a Moose Harness Project/);
   assert.match(html, /moose init/);
@@ -15,8 +15,8 @@ test("buildHarnessSplashHtml renders the harness command and support links", asy
   assert.match(html, /http:\/\/slack\.moosestack\.com\//);
 });
 
-test("buildHarnessSplashHtml uses a per-panel CSP nonce", async () => {
-  const html = await buildHarnessSplashHtml();
+test("buildHarnessSplashHtml uses a per-panel CSP nonce", () => {
+  const html = buildHarnessSplashHtml();
 
   const cspNonceMatch = html.match(/script-src 'nonce-([^']+)'/);
   const scriptNonceMatch = html.match(/<script nonce="([^"]+)">/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ catalogs:
       version: 10.0.10
     '@types/node':
       specifier: ^20
-      version: 20.19.37
+      version: 20.19.24
     axios:
       specifier: 1.7.9
       version: 1.7.9
@@ -326,7 +326,7 @@ importers:
         version: 12.23.24(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next:
         specifier: 'catalog:'
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-mdx-remote:
         specifier: 'catalog:'
         version: 6.0.0(@types/react@19.2.2)(react@19.2.0)
@@ -463,10 +463,6 @@ importers:
         version: 5.9.3
 
   apps/vscode-extension:
-    dependencies:
-      escape-goat:
-        specifier: ^4.0.0
-        version: 4.0.0
     devDependencies:
       '@eslint/js':
         specifier: 9.39.2
@@ -582,7 +578,7 @@ importers:
         version: 0.18.1
       next:
         specifier: 'catalog:'
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -643,7 +639,7 @@ importers:
         version: 9.39.2
       eslint-config-next:
         specifier: 'catalog:'
-        version: 16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.1
         version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
@@ -664,7 +660,7 @@ importers:
         version: 0.18.1
       next:
         specifier: 'catalog:'
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@types/react':
         specifier: ^19.0.1
@@ -5171,10 +5167,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-goat@4.0.0:
-    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
-    engines: {node: '>=12'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -10869,7 +10861,7 @@ snapshots:
       '@sentry/vercel-edge': 7.120.4
       '@sentry/webpack-plugin': 1.21.0
       chalk: 3.0.0
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       resolve: 1.22.8
       rollup: 2.79.2
@@ -12131,7 +12123,7 @@ snapshots:
       '@vercel/edge-config-fs': 0.1.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@vercel/microfrontends@1.3.0(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@5.4.21(@types/node@20.19.24)(lightningcss@1.30.2)(terser@5.44.0))':
     dependencies:
@@ -12145,7 +12137,7 @@ snapshots:
       nanoid: 3.3.11
       path-to-regexp: 6.2.1
     optionalDependencies:
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       vite: 5.4.21(@types/node@20.19.24)(lightningcss@1.30.2)(terser@5.44.0)
@@ -12164,7 +12156,7 @@ snapshots:
       jsonc-parser: 3.3.1
       strip-ansi: 6.0.1
     optionalDependencies:
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       vite: 5.4.21(@types/node@20.19.24)(lightningcss@1.30.2)(terser@5.44.0)
     transitivePeerDependencies:
@@ -13434,8 +13426,6 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-goat@4.0.0: {}
-
   escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
@@ -13452,26 +13442,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
     optional: true
-
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.1.6
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.4(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
 
   eslint-config-next@16.1.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -13522,48 +13492,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
@@ -13577,7 +13517,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14018,7 +13958,7 @@ snapshots:
       jose: 5.9.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -15661,15 +15601,15 @@ snapshots:
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   next-themes@0.2.1(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -15678,7 +15618,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      styled-jsx: 5.1.6(react@19.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -16817,10 +16757,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.6
 
-  styled-jsx@5.1.6(react@19.2.0):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.0):
     dependencies:
       client-only: 0.0.1
       react: 19.2.0
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Release workflow logic now blocks stable marketplace publishing from non-`main` refs, which could unintentionally prevent or delay releases if the conditions are misconfigured. The extension webview HTML generation was refactored to be synchronous with a custom escaping helper, so regressions could affect panel rendering or HTML escaping behavior.
> 
> **Overview**
> **Publishing guardrails:** The `release-vscode-extension` workflow now validates that *stable* publishing only occurs from `refs/heads/main`, and additionally gates the `publish-vscode`/`publish-openvsx` jobs to run only on `main` unless `pre-release=true`.
> 
> **Extension packaging simplification:** `buildHarnessSplashHtml` in `getStartedPanel.ts` is now synchronous, replaces dynamic `escape-goat` import with an inlined `escapeHtml` helper, and simplifies panel rendering by setting `panel.webview.html` directly; tests were updated accordingly and `escape-goat` was removed from `apps/vscode-extension` dependencies (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b746b43fa976f6fd19a285b514c1c439d188b2dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->