### PR TITLE
add COPY migrations dir to dockerfile

### DIFF
--- a/apps/framework-cli/src/cli/routines/build.rs
+++ b/apps/framework-cli/src/cli/routines/build.rs
@@ -36,6 +36,7 @@ use crate::framework::languages::SupportedLanguages;
 use crate::project::Project;
 use crate::project::ProjectFileError;
 use crate::utilities::constants::LIB_DIR;
+use crate::utilities::constants::MIGRATIONS_DIR;
 use crate::utilities::constants::PACKAGE_JSON;
 use crate::utilities::constants::PROJECT_CONFIG_FILE;
 use crate::utilities::constants::REQUIREMENTS_TXT;
@@ -197,6 +198,7 @@ pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
                 PROJECT_CONFIG_FILE,
                 PACKAGE_JSON,
                 TSCONFIG_JSON,
+                MIGRATIONS_DIR,
             ]
         }
         SupportedLanguages::Python => {
@@ -205,6 +207,7 @@ pub fn build_package(project: &Project) -> Result<PathBuf, BuildError> {
                 PROJECT_CONFIG_FILE,
                 REQUIREMENTS_TXT,
                 SETUP_PY,
+                MIGRATIONS_DIR,
             ]
         }
     };

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -3,8 +3,8 @@ use crate::cli::display::with_spinner_completion;
 use crate::cli::routines::util::ensure_docker_running;
 use crate::framework::languages::SupportedLanguages;
 use crate::utilities::constants::{
-    OLD_PROJECT_CONFIG_FILE, PACKAGE_JSON, PROJECT_CONFIG_FILE, REQUIREMENTS_TXT, SETUP_PY,
-    TSCONFIG_JSON,
+    MIGRATIONS_DIR, OLD_PROJECT_CONFIG_FILE, PACKAGE_JSON, PROJECT_CONFIG_FILE, REQUIREMENTS_TXT,
+    SETUP_PY, TSCONFIG_JSON,
 };
 use crate::utilities::docker::DockerClient;
 use crate::utilities::nodejs_version::determine_node_version_from_package_json;
@@ -264,6 +264,7 @@ COPY_PACKAGE_FILE
 COPY --chown=moose:moose ./project.tom[l] ./project.toml
 COPY --chown=moose:moose ./moose.config.tom[l] ./moose.config.toml
 COPY --chown=moose:moose ./versions .moose/versions
+COPY --chown=moose:moose ./migration[s] ./migrations
 
 
 # Placeholder for the language specific install command
@@ -728,6 +729,7 @@ pub fn build_dockerfile(
         TSCONFIG_JSON,
         PROJECT_CONFIG_FILE,
         OLD_PROJECT_CONFIG_FILE,
+        MIGRATIONS_DIR,
     ];
 
     // Handle lock file copying for TypeScript projects only (may be from parent directories for monorepos)
@@ -877,6 +879,12 @@ pub fn build_dockerfile(
                             "COPY --chown=moose:moose ./versions",
                             &format!(
                                 "COPY --chown=moose:moose {relative_project_path}/.moose/packager/versions"
+                            ),
+                        )
+                        .replace(
+                            "COPY --chown=moose:moose ./migration[s]",
+                            &format!(
+                                "COPY --chown=moose:moose {relative_project_path}/migration[s]"
                             ),
                         );
 

--- a/apps/framework-cli/src/utilities/constants.rs
+++ b/apps/framework-cli/src/utilities/constants.rs
@@ -135,6 +135,7 @@ pub const ENV_REDIS_URL: &str = "MOOSE_REDIS_CONFIG__URL";
 /// and no per-table `seedFilter.limit` is configured.
 pub const DEFAULT_SEED_LIMIT: usize = 1000;
 
+pub const MIGRATIONS_DIR: &str = "migrations";
 pub const MIGRATION_FILE: &str = "./migrations/plan.yaml";
 pub const MIGRATION_BEFORE_STATE_FILE: &str = "./migrations/remote_state.json";
 pub const MIGRATION_AFTER_STATE_FILE: &str = "./migrations/local_infra_map.json";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to packaging/copy logic to include the `migrations` directory in ZIP and Docker build contexts, with minimal impact on runtime behavior.
> 
> **Overview**
> Deployment packaging now includes the `migrations/` directory for both non-Docker builds and Docker-based packaging.
> 
> This introduces a `MIGRATIONS_DIR` constant and updates the build routines/Dockerfile template (including monorepo path rewriting) so `migrations` is copied into the final artifact/container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d960b14edbc7dc33cb1b649c40d1f93683a1266c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->