### PR TITLE
Add finch support to moose dev

### DIFF
--- a/apps/framework-cli/src/utilities/docker-compose.yml.hbs
+++ b/apps/framework-cli/src/utilities/docker-compose.yml.hbs
@@ -283,7 +283,7 @@ services:
       - POSTGRES_PWD=${TEMPORAL_DB_PASSWORD:-temporal}
       - POSTGRES_SEEDS=postgresql
       - DYNAMIC_CONFIG_FILE_PATH=/etc/temporal/config/dynamicconfig/development-sql.yaml
-    image: temporalio/auto-setup:${TEMPORAL_VERSION}
+    image: temporalio/auto-setup:{{temporal_version}}
     networks:
       - temporal-network
     ports:
@@ -291,7 +291,6 @@ services:
     configs:
       - source: temporal-config
         target: /etc/temporal/config/dynamicconfig/development-sql.yaml
-        mode: 0444
     volumes:
       - temporal-data:/var/temporal/data
     healthcheck:
@@ -306,11 +305,11 @@ services:
     environment:
       - TEMPORAL_ADDRESS=temporal:${TEMPORAL_PORT:-7233}
       - TEMPORAL_CLI_ADDRESS=temporal:${TEMPORAL_PORT:-7233}
-    image: temporalio/admin-tools:${TEMPORAL_ADMINTOOLS_VERSION}
+    image: temporalio/admin-tools:{{temporal_admintools_version}}
     networks:
       - temporal-network
-    stdin_open: true
-    tty: true
+    stdin_open: false
+    tty: false
 
   temporal-ui:
     depends_on:
@@ -318,7 +317,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=temporal:${TEMPORAL_PORT:-7233}
       - TEMPORAL_CORS_ORIGINS=${TEMPORAL_UI_CORS_ORIGINS:-http://localhost:3000}
-    image: temporalio/ui:${TEMPORAL_UI_VERSION}
+    image: temporalio/ui:{{temporal_ui_version}}
     networks:
       - temporal-network
     ports:

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -526,6 +526,25 @@ impl DockerClient {
             }
         }
 
+        // Pass temporal versions into template data so they're baked into the compose file
+        // (nerdctl compose doesn't support env var substitution from process environment)
+        if settings.features.scripts || project.features.workflows {
+            if let Some(obj) = data.as_object_mut() {
+                obj.insert(
+                    "temporal_version".to_string(),
+                    json!(project.temporal_config.temporal_version),
+                );
+                obj.insert(
+                    "temporal_admintools_version".to_string(),
+                    json!(project.temporal_config.admin_tools_version),
+                );
+                obj.insert(
+                    "temporal_ui_version".to_string(),
+                    json!(project.temporal_config.ui_version),
+                );
+            }
+        }
+
         // Write temporal dynamic config file when scripts/workflows are enabled
         if settings.features.scripts || project.features.workflows {
             let config_content = "\


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches dev `docker-compose` generation for Temporal, including writing a new config file and changing how image tags are resolved; mistakes could break local workflow infrastructure startup across container runtimes.
> 
> **Overview**
> Updates the generated dev `docker-compose.yml` to be more compatible with finch/`nerdctl compose` by **baking Temporal image tags into the template** (using `{{temporal_*_version}}` variables instead of runtime env substitution).
> 
> Switches Temporal dynamic config from inline compose `content` to a **real file (`temporal-dynamic-config.yaml`)**, and the CLI now writes that file into the project’s internal directory whenever scripts/workflows are enabled. Also disables interactive TTY/stdin settings for `temporal-admin-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5b7118f92bd93318e92e1845a69fc34f5f63cf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->