### PR TITLE
Fix cross db source tables not matchin local vs remote

### DIFF
--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -1899,4 +1899,102 @@ mod tests {
             "Pre-normalized Views should be equivalent"
         );
     }
+
+    /// Reproduces GitHub issue #3856: cross-database sourceTables mismatch.
+    /// Local infra map (Python/TS) produces backtick-qualified source tables like
+    /// `staging_lake`.`orders_cdc`, but the CLI's try_migrate_sql_resource_to_mv
+    /// should produce the same format from introspected ClickHouse SQL resources.
+    #[test]
+    fn test_cross_database_source_tables_mv_equivalence() {
+        use crate::framework::core::infrastructure::materialized_view::MaterializedView;
+        use crate::framework::core::infrastructure_map::InfrastructureMap;
+
+        let default_db = "analytics";
+
+        // Simulate the local side (Python/TS formatTableReference):
+        // source in staging_lake db, target in analytics db
+        let mv_local = MaterializedView {
+            name: "fact_orders_daily_mv".to_string(),
+            database: Some("analytics".to_string()),
+            target_table: "fact_orders_daily".to_string(),
+            target_database: Some("analytics".to_string()),
+            select_sql: "SELECT toDate(created_at) AS order_date, count() AS order_count FROM staging_lake.orders_cdc GROUP BY order_date".to_string(),
+            source_tables: vec!["`staging_lake`.`orders_cdc`".to_string()],
+            metadata: None,
+            life_cycle: crate::framework::core::partial_infrastructure_map::LifeCycle::FullyManaged,
+        };
+
+        // Simulate the remote side: build a SqlResource as ClickHouse introspection would,
+        // then convert it via try_migrate_sql_resource_to_mv
+        let setup_sql = "CREATE MATERIALIZED VIEW IF NOT EXISTS fact_orders_daily_mv TO analytics.fact_orders_daily AS SELECT toDate(created_at) AS order_date, count() AS order_count FROM staging_lake.orders_cdc GROUP BY order_date";
+        let teardown_sql = "DROP VIEW IF EXISTS `fact_orders_daily_mv`";
+
+        let sql_resource = crate::framework::core::infrastructure::sql_resource::SqlResource {
+            name: "fact_orders_daily_mv".to_string(),
+            database: Some("analytics".to_string()),
+            source_file: None,
+            source_line: None,
+            source_column: None,
+            setup: vec![setup_sql.to_string()],
+            teardown: vec![teardown_sql.to_string()],
+            pulls_data_from: vec![],
+            pushes_data_to: vec![],
+        };
+
+        let mv_remote =
+            InfrastructureMap::try_migrate_sql_resource_to_mv(&sql_resource, default_db)
+                .expect("Should successfully convert SqlResource to MaterializedView");
+
+        assert!(
+            materialized_views_are_equivalent(&mv_local, &mv_remote, default_db),
+            "Cross-database source tables should match.\nLocal source_tables: {:?}\nRemote source_tables: {:?}",
+            mv_local.source_tables,
+            mv_remote.source_tables,
+        );
+    }
+
+    /// Same as above but for Views with cross-database source tables.
+    #[test]
+    fn test_cross_database_source_tables_view_equivalence() {
+        use crate::framework::core::infrastructure::view::View;
+        use crate::framework::core::infrastructure_map::InfrastructureMap;
+
+        let default_db = "analytics";
+
+        // Local side: view reading from staging_lake.orders_cdc
+        let view_local = View {
+            name: "orders_summary_view".to_string(),
+            database: None,
+            select_sql: "SELECT toDate(created_at) AS order_date, count() AS order_count FROM staging_lake.orders_cdc GROUP BY order_date".to_string(),
+            source_tables: vec!["`staging_lake`.`orders_cdc`".to_string()],
+            metadata: None,
+        };
+
+        // Remote side: SqlResource from ClickHouse introspection
+        let setup_sql = "CREATE VIEW IF NOT EXISTS orders_summary_view AS SELECT toDate(created_at) AS order_date, count() AS order_count FROM staging_lake.orders_cdc GROUP BY order_date";
+        let teardown_sql = "DROP VIEW IF EXISTS `orders_summary_view`";
+
+        let sql_resource = crate::framework::core::infrastructure::sql_resource::SqlResource {
+            name: "orders_summary_view".to_string(),
+            database: Some("analytics".to_string()),
+            source_file: None,
+            source_line: None,
+            source_column: None,
+            setup: vec![setup_sql.to_string()],
+            teardown: vec![teardown_sql.to_string()],
+            pulls_data_from: vec![],
+            pushes_data_to: vec![],
+        };
+
+        let view_remote =
+            InfrastructureMap::try_migrate_sql_resource_to_view(&sql_resource, default_db)
+                .expect("Should successfully convert SqlResource to View");
+
+        assert!(
+            views_are_equivalent(&view_local, &view_remote, default_db),
+            "Cross-database source tables should match.\nLocal source_tables: {:?}\nRemote source_tables: {:?}",
+            view_local.source_tables,
+            view_remote.source_tables,
+        );
+    }
 }

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -3064,11 +3064,11 @@ impl InfrastructureMap {
         // Parse the CREATE MATERIALIZED VIEW statement
         let parsed = parse_create_materialized_view(setup_sql).ok()?;
 
-        // Convert source tables to unqualified names for consistency
+        // Format source tables with backtick quoting to match Python/TS conventions
         let source_tables: Vec<String> = parsed
             .source_tables
             .iter()
-            .map(|t| t.table.clone())
+            .map(|t| t.format_for_source_tables())
             .collect();
 
         // Migrate source_file to metadata.source.file
@@ -3128,11 +3128,13 @@ impl InfrastructureMap {
         let as_pos = upper.find(" AS ")?;
         let select_sql = setup_sql[(as_pos + 4)..].trim().to_string();
 
-        // Extract source tables (use unqualified names for consistency)
-        // Try AST parser first (same approach as MaterializedView migration),
-        // fall back to regex if it fails on ClickHouse-specific syntax
+        // Format source tables with backtick quoting to match Python/TS conventions.
+        // Try AST parser first, fall back to regex if it fails on ClickHouse-specific syntax.
         let source_tables: Vec<String> = match extract_source_tables_from_query(&select_sql) {
-            Ok(tables) => tables.iter().map(|t| t.table.clone()).collect(),
+            Ok(tables) => tables
+                .iter()
+                .map(|t| t.format_for_source_tables())
+                .collect(),
             Err(e) => {
                 tracing::debug!(
                     "AST parser failed to extract source tables from view '{}' SELECT query: {}. \
@@ -3141,7 +3143,10 @@ impl InfrastructureMap {
                     e
                 );
                 match extract_source_tables_from_query_regex(&select_sql, default_database) {
-                    Ok(tables) => tables.iter().map(|t| t.table.clone()).collect(),
+                    Ok(tables) => tables
+                        .iter()
+                        .map(|t| t.format_for_source_tables())
+                        .collect(),
                     Err(e) => {
                         tracing::debug!(
                             "Regex parser also failed to extract source tables from view '{}' SELECT query: {}. \

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/sql_parser.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/sql_parser.rs
@@ -119,6 +119,15 @@ impl TableReference {
             None => self.table.clone(),
         }
     }
+
+    /// Formats the table reference with backtick quoting, matching the
+    /// Python `_format_table_reference` and TypeScript `formatTableReference` conventions.
+    pub fn format_for_source_tables(&self) -> String {
+        match &self.database {
+            Some(db) => format!("`{}`.`{}`", db, self.table),
+            None => format!("`{}`", self.table),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1335,6 +1344,19 @@ pub mod tests {
     use super::*;
 
     pub const NESTED_OBJECTS_SQL: &str = "CREATE TABLE local.NestedObjects (`id` String, `timestamp` DateTime('UTC'), `address` Nested(street String, city String, coordinates Nested(lat Float64, lng Float64)), `metadata` Nested(tags Array(String), priority Int64, config Nested(enabled Bool, settings Nested(theme String, notifications Bool)))) ENGINE = MergeTree PRIMARY KEY id ORDER BY id SETTINGS enable_mixed_granularity_parts = 1, index_granularity = 8192, index_granularity_bytes = 10485760";
+
+    #[test]
+    fn test_format_for_source_tables_without_database() {
+        let tr = TableReference::new("events".to_string());
+        assert_eq!(tr.format_for_source_tables(), "`events`");
+    }
+
+    #[test]
+    fn test_format_for_source_tables_with_database() {
+        let tr =
+            TableReference::with_database("staging_lake".to_string(), "orders_cdc".to_string());
+        assert_eq!(tr.format_for_source_tables(), "`staging_lake`.`orders_cdc`");
+    }
 
     // Tests for extract_engine_from_create_table
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the CLI derives `source_tables` for migrated ClickHouse views/materialized views, which can affect dependency tracking and reality-check diff results across databases.
> 
> **Overview**
> Fixes cross-database `source_tables` mismatches between locally-generated infra maps (Python/TS) and ClickHouse-introspected SQL resources by **standardizing source table formatting**.
> 
> `try_migrate_sql_resource_to_mv` and `try_migrate_sql_resource_to_view` now emit backtick-quoted table references (including database when present) via a new `TableReference::format_for_source_tables()` helper, and adds unit tests (including a repro for issue #3856) to ensure local vs remote equivalence for cross-database views/MVs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dfe109f3a8a88024a23b70ace44ebb747ce6488. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->