### PR TITLE
Add container runtime docs for Finch/Podman/nerdctl setup

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
@@ -41,7 +41,7 @@ MOOSE_DEV__CONTAINER_CLI_PATH=finch moose dev
 3. Configure Moose to use Finch:
 
 ```bash
-mkdir -p ~/.moose && echo -e '\n[dev]\ncontainer_cli_path = "finch"' >> ~/.moose/config.toml
+echo -e '\n[dev]\ncontainer_cli_path = "finch"' >> ~/.moose/config.toml
 ```
 </Callout>
 


### PR DESCRIPTION
Document how to configure alternative container runtimes via
~/.moose/config.toml and MOOSE_DEV__CONTAINER_CLI_PATH env var.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change describing how to run `moose dev` with alternative Docker-compatible CLIs; no runtime or configuration parsing code is modified.
> 
> **Overview**
> Adds a new **Container Runtime** section to the dev environment docs describing how to switch `moose dev` from `docker` to alternative Docker-compatible CLIs (Finch/Podman/`nerdctl`) via `~/.moose/config.toml` (`dev.container_cli_path`) or `MOOSE_DEV__CONTAINER_CLI_PATH`.
> 
> Includes a small reference table for the new setting and an *info* callout with step-by-step Finch setup commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c75312b535a60273db3b173081c59d383b38ca59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->