### PR TITLE
chore: update moose init to be moose harness init in the splash page

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -14,7 +14,7 @@ Fiveonefour is a narrow VS Code workspace extension for keeping the Moose and `5
 When the installer run succeeds, Fiveonefour opens a splash page focused on the current Harness init command:
 
 ```bash
-moose init
+moose harness init
 ```
 
 Use that command from a terminal in the parent directory where you want the new Harness project to be created.

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -8,9 +8,10 @@ export const COMMANDS = {
 
 export const INSTALLER_SCRIPT_URL = "https://fiveonefour.com/install.sh";
 export const INSTALLER_TARGETS = ["moose", "514"] as const;
-export const HARNESS_INIT_COMMAND = "moose init";
+export const HARNESS_INIT_COMMAND = "moose harness init";
 
-export const MOOSESTACK_DOCS_URL = "https://docs.fiveonefour.com/moosestack";
+export const MOOSESTACK_DOCS_URL =
+  "https://docs.fiveonefour.com/moosestack?utm_source=vscode-extension";
 export const SUPPORT_URL = "http://slack.moosestack.com/";
 
 export const WINDOWS_WSL_MESSAGE =

--- a/apps/vscode-extension/src/getStartedPanel.ts
+++ b/apps/vscode-extension/src/getStartedPanel.ts
@@ -255,7 +255,7 @@ export function buildHarnessSplashHtml(
       </section>
 
       <section class="actions">
-        <button type="button" data-command="copyHarnessCommand">Copy moose init</button>
+        <button type="button" data-command="copyHarnessCommand">Copy ${escapedHarnessCommand}</button>
         <button type="button" class="secondary" data-link="${escapedDocsUrl}">Open MooseStack docs</button>
         <button type="button" class="secondary" data-link="${escapedSupportUrl}">Open support</button>
         <button type="button" class="secondary" data-command="checkInstallState">Check install state</button>
@@ -311,7 +311,7 @@ export function showHarnessSplashPanel(
       if (command === "copyHarnessCommand") {
         await vscodeApi.env.clipboard.writeText(HARNESS_INIT_COMMAND);
         void vscodeApi.window.showInformationMessage(
-          "Copied `moose init` to the clipboard.",
+          `Copied \`${HARNESS_INIT_COMMAND}\` to the clipboard.`,
         );
         return;
       }

--- a/apps/vscode-extension/test/getStartedPanel.test.ts
+++ b/apps/vscode-extension/test/getStartedPanel.test.ts
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { HARNESS_INIT_COMMAND } from "../src/constants";
 import { buildHarnessSplashHtml } from "../src/getStartedPanel";
 
 test("buildHarnessSplashHtml renders the harness command and support links", () => {
   const html = buildHarnessSplashHtml();
 
-  assert.match(html, /Create a Moose Harness Project/);
-  assert.match(html, /moose init/);
+  assert.match(html, /Create a Moose Harness project/i);
+  assert.ok(html.includes(HARNESS_INIT_COMMAND));
+  assert.ok(html.includes(`Copy ${HARNESS_INIT_COMMAND}`));
   assert.match(html, /Open MooseStack docs/);
   assert.match(html, /Open support/);
   assert.match(html, /Windows through WSL/);

--- a/apps/vscode-extension/test/manifest.test.ts
+++ b/apps/vscode-extension/test/manifest.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
+import { HARNESS_INIT_COMMAND } from "../src/constants";
+
 interface ExtensionManifest {
   activationEvents?: unknown;
   bugs?: {
@@ -100,7 +102,7 @@ test("README describes the installer-only harness workflow", () => {
     readme,
     /Runs the official Fiveonefour installer on every activation/,
   );
-  assert.match(readme, /moose init/);
+  assert.ok(readme.includes(HARNESS_INIT_COMMAND));
   assert.match(
     readme,
     /On Windows, Fiveonefour does not attempt to run the installer/,

--- a/apps/vscode-extension/test/status.test.ts
+++ b/apps/vscode-extension/test/status.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { HARNESS_INIT_COMMAND } from "../src/constants";
 import {
   buildInstallStateSummary,
   createInitialInstallState,
@@ -53,7 +54,7 @@ test("buildInstallStateSummary returns a readable installer status block", () =>
   assert.match(summary, /Last result: latest installer run succeeded/);
   assert.match(summary, /Moose CLI: moose 2\.0\.0/);
   assert.match(summary, /514 CLI: 514 1\.0\.0/);
-  assert.match(summary, /Harness init command: moose init/);
+  assert.ok(summary.includes(`Harness init command: ${HARNESS_INIT_COMMAND}`));
 });
 
 test("recordUnsupportedPlatform preserves the WSL guidance", () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String/UX copy changes plus a docs URL query param; no installer, auth, or data-handling logic is modified.
> 
> **Overview**
> Updates the VS Code extension’s Harness onboarding flow to use the new init command `moose harness init` (README, `HARNESS_INIT_COMMAND`, splash page copy button, and clipboard toast).
> 
> Adds a `utm_source=vscode-extension` query param to the MooseStack docs URL, and updates tests to assert against the shared `HARNESS_INIT_COMMAND` value and the new/looser splash page title matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d6b27110b7332630e31e0f496e7762e0f8fffb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->