### PR TITLE
fix: template message at start up and ordering of instructions

### DIFF
--- a/apps/framework-cli-e2e/test/typescript-agent.test.ts
+++ b/apps/framework-cli-e2e/test/typescript-agent.test.ts
@@ -468,6 +468,7 @@ describe("TypeScript Agent Template E2E", function () {
   let serviceEnvPath: string;
   let webAppEnvPath: string;
   let webAppPort: number;
+  let initOutput = "";
   let webProcess: ChildProcess | null = null;
   let mooseProcess: ChildProcess | null = null;
 
@@ -495,7 +496,12 @@ describe("TypeScript Agent Template E2E", function () {
       MOOSE_LIB_PATH,
       APP_NAME,
       "pnpm",
-      { logger: testLogger },
+      {
+        logger: testLogger,
+        onInitComplete: ({ stdout }) => {
+          initOutput = stdout;
+        },
+      },
     );
 
     testLogger.info("Preparing local env files with root pnpm env:prepare");
@@ -631,6 +637,25 @@ describe("TypeScript Agent Template E2E", function () {
     expect(readEnvValue(webAppEnvPath, "AUTH_SECRET")).to.not.equal(
       "replace-me-with-a-random-secret",
     );
+  });
+
+  it("should print start instructions before seed instructions during init", function () {
+    expect(initOutput).to.include("pnpm dev:start");
+    expect(initOutput).to.include("pnpm seed");
+    expect(initOutput.indexOf("pnpm dev:start")).to.be.lessThan(
+      initOutput.indexOf("pnpm seed"),
+    );
+  });
+
+  it("should prebuild the workspace before dev entrypoints", function () {
+    const rootPackageJson = JSON.parse(
+      fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(rootPackageJson.scripts?.predev).to.equal("pnpm build");
+    expect(rootPackageJson.scripts?.["predev:start"]).to.equal("pnpm build");
   });
 
   it("should render the unauthenticated landing page and provider status", async function () {

--- a/apps/framework-cli-e2e/test/utils/project-setup.ts
+++ b/apps/framework-cli-e2e/test/utils/project-setup.ts
@@ -8,6 +8,7 @@ const projectSetupLogger = logger.scope("utils:project-setup");
 
 export interface ProjectSetupOptions {
   logger?: ScopedLogger;
+  onInitComplete?: (result: { stdout: string; stderr: string }) => void;
 }
 
 const execAsync = promisify(require("child_process").exec);
@@ -102,6 +103,10 @@ export const setupTypeScriptProject = async (
     if (result.stderr) {
       log.debug("CLI init stderr", { stderr: result.stderr });
     }
+    options.onInitComplete?.({
+      stdout: result.stdout,
+      stderr: result.stderr ?? "",
+    });
   } catch (error: any) {
     log.error("CLI init failed", error);
     throw error;

--- a/apps/framework-cli/src/cli/routines/templates.rs
+++ b/apps/framework-cli/src/cli/routines/templates.rs
@@ -692,6 +692,28 @@ dockerfile_path = "./Dockerfile"
 mod tests {
     use super::*;
     use crate::test_utils::ensure_test_environment;
+    use serde_json::Value as JsonValue;
+    use std::fs;
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+    }
+
+    fn read_toml_file(relative_path: &str) -> Value {
+        let file_path = repo_root().join(relative_path);
+        let content =
+            fs::read_to_string(&file_path).expect("template config fixture should be readable");
+        toml::from_str(&content).expect("template config fixture should parse")
+    }
+
+    fn read_json_file(relative_path: &str) -> JsonValue {
+        let file_path = repo_root().join(relative_path);
+        let content =
+            fs::read_to_string(&file_path).expect("template package fixture should be readable");
+        serde_json::from_str(&content).expect("template package fixture should parse")
+    }
 
     #[tokio::test]
     async fn test_list_available_templates_local() {
@@ -847,5 +869,43 @@ mod tests {
         let templates_table = manifest["templates"].as_table().unwrap();
         assert!(templates_table.contains_key("typescript"));
         assert!(templates_table.contains_key("python"));
+    }
+
+    #[test]
+    fn test_typescript_agent_post_install_print_starts_before_seed() {
+        let manifest = read_toml_file("templates/typescript-agent/template.config.toml");
+        let config = TemplateConfig::from_toml(&manifest)
+            .expect("typescript-agent template config should be valid");
+        let start_index = config
+            .post_install_print
+            .find("pnpm dev:start")
+            .expect("post-install print should mention pnpm dev:start");
+        let seed_index = config
+            .post_install_print
+            .find("pnpm seed")
+            .expect("post-install print should mention pnpm seed");
+
+        assert!(
+            start_index < seed_index,
+            "pnpm dev:start should be printed before pnpm seed",
+        );
+    }
+
+    #[test]
+    fn test_typescript_agent_dev_entrypoints_prebuild_workspace() {
+        let package_json = read_json_file("templates/typescript-agent/package.json");
+        let scripts = package_json
+            .get("scripts")
+            .and_then(JsonValue::as_object)
+            .expect("typescript-agent package.json should define scripts");
+
+        assert_eq!(
+            scripts.get("predev").and_then(JsonValue::as_str),
+            Some("pnpm build"),
+        );
+        assert_eq!(
+            scripts.get("predev:start").and_then(JsonValue::as_str),
+            Some("pnpm build"),
+        );
     }
 }

--- a/templates/typescript-agent/AGENTS.md
+++ b/templates/typescript-agent/AGENTS.md
@@ -41,7 +41,7 @@ The user knows their data and use case; if the ClickHouse Best Practices Skill i
 
 ### 3. Agent tools available
 
-1. **Dev server** — Prefer `pnpm dev:start` from the template root. It prepares local env files, validates Docker or Finch, waits for Moose readiness, and then starts the web app. Use `pnpm dev:moose` / `pnpm dev:web` separately only when you need split terminals.
+1. **Dev server** — Prefer `pnpm dev:start` from the template root. It runs the workspace build, prepares local env files, validates Docker or Finch, waits for Moose readiness, and then starts the web app. Use `pnpm dev:moose` / `pnpm dev:web` separately only when you need split terminals.
 
 2. **MooseDev MCP** — Primary tool for inspecting the project (see Available Tools below).
 

--- a/templates/typescript-agent/README.md
+++ b/templates/typescript-agent/README.md
@@ -75,7 +75,7 @@ Start with these files if you want to customize the pattern:
 - One local container runtime: Docker Desktop / Docker Engine, or Finch
 - Provider credentials if you want chat to be usable immediately: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or AWS Bedrock credentials plus `BEDROCK_MODEL_ID`
 
-`pnpm dev:start` auto-detects Docker or Finch, prefers Docker when both are ready, and passes the selected container CLI to the spawned Moose process.
+`pnpm dev:start` runs the workspace build first, then auto-detects Docker or Finch, prefers Docker when both are ready, and passes the selected container CLI to the spawned Moose process.
 
 If you run `pnpm dev:moose` or `moose dev` directly with Finch, set `MOOSE_DEV__CONTAINER_CLI_PATH=finch` or add `[dev] container_cli_path = "finch"` to `~/.moose/config.toml`.
 
@@ -93,7 +93,7 @@ pnpm dev:start
 
 `packages/web-app/.env.local` is intentionally not checked in. The generated app ships with safe defaults in `packages/web-app/.env.example`, and `pnpm env:prepare` writes the project-local secrets into `.env.local`.
 
-`pnpm dev:start` checks Docker or Finch, waits for the Moose service and MCP endpoint to come up, then starts the web app.
+`pnpm dev:start` runs the workspace build, checks Docker or Finch, waits for the Moose service and MCP endpoint to come up, then starts the web app.
 
 In a third terminal, seed starter data:
 
@@ -365,8 +365,8 @@ The workspace aliases point package imports like `agent-runtime`, `agent-contrac
 ## Notes
 
 - `pnpm env:prepare` creates local env files from the checked-in examples.
-- `pnpm dev:start` validates Docker or Finch, waits for readiness, and starts both services.
-- `pnpm dev` starts both the Moose service and the web app without the extra readiness checks.
+- `pnpm dev:start` runs the workspace build, validates Docker or Finch, waits for readiness, and starts both services.
+- `pnpm dev` runs the same workspace build, then starts both services without the extra readiness checks.
 - `pnpm build` uses Turbo to build the shared packages plus the Next app in dependency order.
 - `pnpm build:service` builds the Moose service docker image.
 - `pnpm test` uses Vitest at the workspace root and is safe to run before `pnpm dev`.

--- a/templates/typescript-agent/package.json
+++ b/templates/typescript-agent/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "build": "turbo run build --filter=web-app",
     "build:service": "pnpm --filter moosestack-service build",
+    "predev": "pnpm build",
+    "predev:start": "pnpm build",
     "dev": "pnpm --parallel --stream -r --if-present dev",
     "dev:start": "bash ./scripts/dev-start.sh",
     "dev:moose": "pnpm --filter moosestack-service dev",

--- a/templates/typescript-agent/template.config.toml
+++ b/templates/typescript-agent/template.config.toml
@@ -28,11 +28,11 @@ Run this next:
     3. If you are using an existing ClickHouse instance, fill in the `MOOSE_CLICKHOUSE_CONFIG__*` overrides in `packages/moosestack-service/.env.local`.
     4. Optionally configure Langfuse and Bedrock Guardrails in `packages/web-app/.env.local`.
 
+🚀 Build and start both services:
+    $ pnpm dev:start
+
 🌱 Seed starter data:
     $ pnpm seed
-
-🚀 Start both services:
-    $ pnpm dev:start
 
 Or start each service separately:
     $ pnpm dev:moose    # Start MooseStack service first


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to template scripts/docs and adds test assertions to prevent regressions, with no runtime backend/auth logic modifications.
> 
> **Overview**
> Updates the `typescript-agent` template to **build the workspace before `pnpm dev`/`pnpm dev:start`** by adding `predev` and `predev:start` scripts.
> 
> Reorders the template’s `post_install_print` so **start instructions (`pnpm dev:start`) appear before seeding (`pnpm seed`)**, and aligns README/AGENTS docs with the new “build first” behavior.
> 
> Strengthens coverage with new CLI/template tests: the E2E harness now captures `moose init` output and asserts instruction order, and Rust unit tests validate both the `template.config.toml` messaging and `package.json` prebuild scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1a84a203a4dc9cea7fdbb391826ba23dc1e970c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->