### PR TITLE
Update query clients to be read-only

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/reference/testing-utilities.mdx
+++ b/apps/framework-docs-v2/content/moosestack/reference/testing-utilities.mdx
@@ -35,7 +35,7 @@ Run a query N times and return server-side profiling data with percentile summar
 import { getMooseUtils } from "@514labs/moose-lib";
 import { profileBenchmark } from "@514labs/moose-lib/testing";
 
-const { client, sql } = await getMooseUtils();
+const { client, sql } = await getMooseUtils({ readonly: true });
 const query = sql`SELECT count() FROM MyTable WHERE status = 'active'`;
 
 const { profiles, p50, p95 } = await profileBenchmark(client.query, query, 12);

--- a/packages/ts-moose-lib/src/consumption-apis/query-client.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/query-client.ts
@@ -34,15 +34,18 @@ export class QueryClient {
   client: ClickHouseClient;
   query_id_prefix: string;
   private rowPolicyOptions?: RowPolicyOptions;
+  private readonlyMode: boolean;
 
   constructor(
     client: ClickHouseClient,
     query_id_prefix: string,
     rowPolicyOptions?: RowPolicyOptions,
+    readonlyMode: boolean = false,
   ) {
     this.client = client;
     this.query_id_prefix = query_id_prefix;
     this.rowPolicyOptions = rowPolicyOptions;
+    this.readonlyMode = readonlyMode;
   }
 
   async execute<T = any>(
@@ -63,6 +66,7 @@ export class QueryClient {
         asterisk_include_materialized_columns: 1,
         asterisk_include_alias_columns: 1,
         ...this.rowPolicyOptions?.clickhouse_settings,
+        ...(this.readonlyMode && { readonly: "2" }),
       },
       ...(this.rowPolicyOptions && {
         role: this.rowPolicyOptions.role,

--- a/packages/ts-moose-lib/src/consumption-apis/standalone.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/standalone.ts
@@ -50,6 +50,8 @@ export function runWithRequestContext<T>(
 export interface GetMooseUtilsOptions {
   /** Map of JWT claim names to their values for row policy scoping */
   rlsContext?: Record<string, string>;
+  /** When true, enforce ClickHouse readonly mode on all queries (SELECTs/EXPLAINs). */
+  readonly?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,14 +147,36 @@ export async function getMooseUtils(
   // Check if running in Moose runtime
   const runtimeContext = (globalThis as any)._mooseRuntimeContext;
   if (runtimeContext) {
-    return resolveRuntimeUtils(runtimeContext, options);
+    return resolveRuntimeUtils(
+      runtimeContext,
+      options,
+      Boolean(options?.readonly),
+    );
   }
 
   // Standalone path — outside Moose (cron job, separate server, ad-hoc script)
   await ensureStandaloneInit();
 
   if (options?.rlsContext) {
-    return createStandaloneRlsUtils(options.rlsContext);
+    return createStandaloneRlsUtils(
+      options.rlsContext,
+      Boolean(options?.readonly),
+    );
+  }
+
+  if (options?.readonly) {
+    const baseClient = standaloneUtils!.client.query.client;
+    const readonlyQueryClient = new QueryClient(
+      baseClient,
+      "standalone-ro",
+      undefined,
+      true,
+    );
+    return {
+      client: new MooseClient(readonlyQueryClient),
+      sql: sql,
+      jwt: undefined,
+    };
   }
 
   return standaloneUtils!;
@@ -173,6 +197,7 @@ export async function getMooseUtils(
 function resolveRuntimeUtils(
   runtimeContext: any,
   options?: GetMooseUtilsOptions,
+  readonlyMode: boolean = false,
 ): MooseUtils {
   const reqCtx = requestContextStorage.getStore();
   const jwt = reqCtx?.jwt ?? runtimeContext.jwt;
@@ -200,9 +225,27 @@ function resolveRuntimeUtils(
       rlsClient,
       "rls-scoped",
       rowPolicyOpts,
+      readonlyMode,
     );
     return {
       client: new MooseClient(scopedQueryClient, runtimeContext.temporalClient),
+      sql: sql,
+      jwt,
+    };
+  }
+
+  if (readonlyMode) {
+    const readonlyQueryClient = new QueryClient(
+      runtimeContext.clickhouseClient,
+      "runtime-ro",
+      undefined,
+      true,
+    );
+    return {
+      client: new MooseClient(
+        readonlyQueryClient,
+        runtimeContext.temporalClient,
+      ),
       sql: sql,
       jwt,
     };
@@ -267,6 +310,7 @@ async function ensureStandaloneInit(): Promise<void> {
 /** Build RLS-scoped MooseUtils for standalone mode. */
 function createStandaloneRlsUtils(
   rlsContext: Record<string, string>,
+  readonlyMode: boolean = false,
 ): MooseUtils {
   const rowPoliciesConfig = getRowPoliciesConfigFromRegistry();
   if (!rowPoliciesConfig) {
@@ -297,6 +341,7 @@ function createStandaloneRlsUtils(
     rlsClient,
     "rls-scoped",
     rowPolicyOpts,
+    readonlyMode,
   );
   return {
     client: new MooseClient(scopedQueryClient),

--- a/templates/typescript-benchmark/query-benchmarks/benchmark/core.ts
+++ b/templates/typescript-benchmark/query-benchmarks/benchmark/core.ts
@@ -32,7 +32,7 @@ export interface BenchmarkContext {
 }
 
 export async function createBenchmarkContext(): Promise<BenchmarkContext> {
-  const { client } = await getMooseUtils();
+  const { client } = await getMooseUtils({ readonly: true });
   const targetDb = process.env.MOOSE_CLICKHOUSE_CONFIG__DB_NAME ?? "local";
   return {
     client,


### PR DESCRIPTION
This updates query clients & benchmark clients to support read-only mode
to improve safety.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default behavior is unchanged; readonly mode is only enabled when explicitly requested, with limited surface-area changes to query execution settings and benchmark/docs usage.
> 
> **Overview**
> Adds an opt-in **read-only** mode for ClickHouse queries by threading a `readonly` option through `getMooseUtils` and into `QueryClient`, which then injects `clickhouse_settings.readonly = "2"` on query execution.
> 
> Updates the benchmark template and testing-utilities docs to call `getMooseUtils({ readonly: true })` so profiling/benchmark code runs against ClickHouse in read-only mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 408c4851d1447d06c86b26f86a5996b745298337. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->