### PR TITLE
Fix types and docs

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/apis/semantic-layer.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/semantic-layer.mdx
@@ -402,13 +402,13 @@ The query model's `required: true` filters (e.g., `studioId`) carry through to t
 ```ts filename="apis/mcp.ts" copy
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { registerModelTools } from "@514labs/moose-lib";
+import { registerModelTools, getMooseUtils } from "@514labs/moose-lib";
 import { visitMetrics } from "../query-layer/visits-model";
 import { revenueMetrics } from "../query-layer/revenue-model";
 import { clientMetrics } from "../query-layer/client-model";
-import { client } from "../db"; // your ClickHouse client instance
 
 export default async function handler(req, res) {
+  const { client } = await getMooseUtils();
   const server = new McpServer({
     name: "my-analytics",
     version: "1.0.0",
@@ -417,13 +417,7 @@ export default async function handler(req, res) {
   registerModelTools(
     server,
     [visitMetrics, revenueMetrics, clientMetrics],
-    async (model, request, limit) => {
-      const sql = model.toSql({ ...request, limit });
-      const rows = await client.query(sql);
-      return {
-        content: [{ type: "text", text: JSON.stringify(rows) }],
-      };
-    },
+    client.query,
   );
 
   const transport = new StreamableHTTPServerTransport({

--- a/packages/ts-moose-lib/src/query-layer/model-tools.ts
+++ b/packages/ts-moose-lib/src/query-layer/model-tools.ts
@@ -11,7 +11,12 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toQuery, type Sql } from "../sqlHelpers";
 import { QueryClient } from "../consumption-apis/helpers";
-import type { FilterInputTypeHint, SortDir } from "./types";
+import type {
+  DimensionDef,
+  FilterInputTypeHint,
+  MetricDef,
+  SortDir,
+} from "./types";
 
 export const DEFAULT_LIMIT = 1000;
 
@@ -48,8 +53,8 @@ export interface QueryModelBase {
   };
   readonly filters: Record<string, QueryModelFilter>;
   readonly sortable: readonly string[];
-  readonly dimensions?: Record<string, { description?: string }>;
-  readonly metrics?: Record<string, { description?: string }>;
+  readonly dimensions?: Record<string, DimensionDef>;
+  readonly metrics?: Record<string, MetricDef>;
   readonly columnNames: readonly string[];
   toSql(request: Record<string, unknown>): Sql;
 }

--- a/packages/ts-moose-lib/tests/query-layer-descriptions.test.ts
+++ b/packages/ts-moose-lib/tests/query-layer-descriptions.test.ts
@@ -2,7 +2,9 @@ import { describe, it } from "mocha";
 import { expect } from "chai";
 import { createModelTool } from "../src/query-layer/model-tools";
 import type { QueryModelBase } from "../src/query-layer/model-tools";
-import { sql } from "../src/sqlHelpers";
+import { sql, type Sql } from "../src/sqlHelpers";
+
+const dummyAgg: Sql = sql`count(*)`;
 
 function mockModel(overrides: Partial<QueryModelBase> = {}): QueryModelBase {
   return {
@@ -37,8 +39,11 @@ describe("description propagation into MCP tool schemas", () => {
   it("should propagate metric descriptions into the metrics schema", () => {
     const model = mockModel({
       metrics: {
-        revenue: { description: "Total revenue from completed events" },
-        totalEvents: { description: "Count of all events" },
+        revenue: {
+          agg: dummyAgg,
+          description: "Total revenue from completed events",
+        },
+        totalEvents: { agg: dummyAgg, description: "Count of all events" },
       },
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public TypeScript typings for `createModelTool`/`registerModelTools` are tightened to use `DimensionDef`/`MetricDef`, which could cause downstream compile breaks for any custom model-like objects. Functional behavior changes are minimal and primarily documentation/test adjustments.
> 
> **Overview**
> Updates the MCP docs example to use `getMooseUtils()` and pass `client.query` directly into `registerModelTools`, removing the inline SQL/build/execute callback.
> 
> In `ts-moose-lib`, refines `QueryModelBase` typings so `dimensions` and `metrics` use the shared `DimensionDef`/`MetricDef` shapes, and updates tests to construct metrics with the required `agg` field to match the new type expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a1128cc2e7130765c3109097f00d61e63c68638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->