### PR TITLE
Create dependabot groups for less PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,13 +56,13 @@ updates:
     labels:
       - "dependencies"
     groups:
-      npm-moose:
+      templates-examples-npm-moose:
         patterns:
           - "@514labs/moose-cli"
           - "@514labs/moose-lib"
-      npm-minor-patch:
+      templates-examples-npm-minor-patch:
         update-types: ["minor", "patch"]
-      npm-major:
+      templates-examples-npm-major:
         update-types: ["major"]
     ignore:
       # Keep @types/node at 20.x.x for backward compatibility
@@ -81,11 +81,11 @@ updates:
       - "dependencies"
       - "python"
     groups:
-      pip-moose:
+      templates-examples-pip-moose:
         patterns:
           - "moose-cli"
           - "moose-lib"
-      pip-minor-patch:
+      templates-examples-pip-minor-patch:
         update-types: ["minor", "patch"]
-      pip-major:
+      templates-examples-pip-major:
         update-types: ["major"]


### PR DESCRIPTION
| # | Group | Entry | What it catches |
|---|-------|-------|-----------------|
| 1 | workspace-minor-patch | / npm | Root catalog minor+patch bumps |
| 2 | workspace-major | / npm | Root catalog major bumps |
| 3 | cargo-minor-patch | / cargo | Rust crate minor+patch bumps |
| 4 | cargo-major | / cargo | Rust crate major bumps |
| 5 | templates-npm-moose | /templates/** npm | moose-cli + moose-lib for TS templates |
| 6 | templates-minor-patch | /templates/** npm | All other TS template minor+patch |
| 7 | templates-major | /templates/** npm | All other TS template major |
| 8 | templates-pip-moose | /templates/** pip | moose-cli + moose-lib for Python templates |
| 9 | templates-pip-minor-patch | /templates/** pip | All other Python template minor+patch |
| 10 | templates-pip-major | /templates/** pip | All other Python template major |
| 11 | examples-npm-moose | /examples/** npm | moose-cli + moose-lib for examples |
| 12 | examples-minor-patch | /examples/** npm | All other example minor+patch |
| 13 | examples-major | /examples/** npm | All other example major |
| 14 | examples-pip-moose | /examples/** pip | moose-cli + moose-lib for Python examples |
| 15 | examples-pip-minor-patch | /examples/** pip | All other Python example minor+patch |
| 16 | examples-pip-major | /examples/** pip | All other Python example major |

**Week of Mar 16 — 39 PRs → would be 6 PRs**

| New group | PRs absorbed | Count |
|-----------|-------------|-------|
| templates-minor-patch | #3759,3764,3770,3771,3775,3776,3778,3781,3791,3792 | 10 |
| templates-major | #3761,3768,3773,3777,3779,3784,3788,3794,3797,3800 | 10 |
| templates-pip-minor-patch | #3750,3752,3753,3754,3755,3756,3757 | 7 |
| templates-pip-moose | #3735 | 1 |
| examples-minor-patch | #3765,3767,3774,3782,3793,3796 | 6 |
| examples-major | #3766,3769,3772,3785,3795 | 5 |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes Dependabot configuration and grouping/labeling behavior; the main impact is on update PR volume and how dependency bumps are batched (minor/patch vs major).
> 
> **Overview**
> Reduces Dependabot noise by restructuring `.github/dependabot.yml` to **group dependency updates** (separating *minor/patch* vs *major*) for the root workspace (`npm`) and Rust (`cargo`).
> 
> Consolidates templates/examples dependency monitoring for both `npm` and `pip`, adds grouped rules (including dedicated `moose-*` package groupings), updates labels, and tweaks PR limits (notably raising the root workspace limit and lowering the `rust-toolchain` limit).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6178d398242c3b0e953c77ba4c51bbfbc1fdc92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->