### PR TITLE
logging for prod_auto_allow_destructive

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -975,9 +975,14 @@ pub async fn start_production_mode(
 
     let execute_migration_yaml = std::fs::exists(MIGRATION_FILE)?;
 
-    if !project.migration_config.prod_auto_allow_destructive {
+    if !execute_migration_yaml {
+        info!("Migration file not found.")
+    }
+
+    if !project.migration_config.prod_auto_allow_destructive && !execute_migration_yaml {
+        info!("prod_auto_allow_destructive is false, analysing risk.");
         let risk = classify_plan_risk(&plan.changes);
-        if risk.is_destructive() && !execute_migration_yaml {
+        if risk.is_destructive() {
             let summary = risk
                 .destructive_changes
                 .iter()
@@ -995,6 +1000,8 @@ pub async fn start_production_mode(
                 risk.destructive_changes.len(),
                 summary,
             ));
+        } else {
+            info!("PlanRisk: {:?}, proceeding.", risk)
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds informational logging and slightly tightens the conditional around when production performs destructive-risk analysis (only when `plan.yaml` is absent), without changing the actual block-on-destructive behavior.
> 
> **Overview**
> Improves `moose` production startup visibility around migration gating.
> 
> When `plan.yaml` is missing, the CLI now logs that the migration file wasn’t found and, if `migration_config.prod_auto_allow_destructive` is `false`, logs that it’s analyzing risk; it also logs the computed `PlanRisk` when the diff is non-destructive and startup proceeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1429dfbf3e9c4bb6edf7028d184c27f8da51bede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->