### PR TITLE
Remove mentions for moose generate migration

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -989,7 +989,9 @@ pub async fn start_production_mode(
                  destructive operation(s) but no plan.yaml was found.\n\
                  {}\n\n\
                  To proceed, either:\n  \
-                 1. Run `moose generate migration` to create a reviewed plan.yaml, or\n  \
+                 1. Create a new version of the table by setting the `version` field in your \
+                 OlapTable config and updating the table name (e.g. my_table_v2) — the backfill \
+                 heuristic uses these to migrate data automatically\n  \
                  2. Set `prod_auto_allow_destructive = true` under [migration_config] \
                  in moose.config.toml to allow unplanned destructive changes.",
                 risk.destructive_changes.len(),

--- a/apps/framework-cli/src/framework/core/plan_risk.rs
+++ b/apps/framework-cli/src/framework/core/plan_risk.rs
@@ -789,7 +789,7 @@ pub fn print_migration_rejected_guidance(
     println!("\nNext Steps");
     println!("  1. {version_hint}");
     println!("  2. Export the new table from root `{root_file}`");
-    println!("  3. Run `moose generate migration` again");
+    println!("  3. Run `moose dev` to apply the changes");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates CLI/user-facing guidance strings; no changes to migration planning or execution behavior.
> 
> **Overview**
> Updates destructive-change guidance shown by the CLI to **stop recommending `moose generate migration`**.
> 
> In production startup blocking and migration rejection messaging, the suggested next step is now to **version the `OlapTable` and apply via `moose dev`**, rather than regenerating a migration plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69642396260b555af9cd55a80c64a864f25c4d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->