### PR TITLE
chore: remove unused docker_client() accessor

### DIFF
--- a/apps/framework-cli/src/utilities/docker_provider.rs
+++ b/apps/framework-cli/src/utilities/docker_provider.rs
@@ -30,12 +30,6 @@ impl DockerInfraProvider {
             docker_client: DockerClient::new(settings),
         }
     }
-
-    /// Access the underlying `DockerClient` for operations not covered by
-    /// the trait (e.g. `buildx`, `tail_container_logs`, compose file creation).
-    pub fn docker_client(&self) -> &DockerClient {
-        &self.docker_client
-    }
 }
 
 impl InfraProvider for DockerInfraProvider {


### PR DESCRIPTION
The method had zero callers and added dead public API surface.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>