### PR TITLE
update branch seeding docs

### DIFF
--- a/apps/framework-docs-v2/content/hosting/workflow/branch-data-seeding.mdx
+++ b/apps/framework-docs-v2/content/hosting/workflow/branch-data-seeding.mdx
@@ -22,6 +22,10 @@ Branch seeding runs automatically — no setup needed. Every table discovered in
 
 Seeding runs automatically during the `INITIALIZE_BRANCH_SCHEMA` phase of the first deployment. Subsequent pushes to the same branch do not re-seed.
 
+## Externally Managed Tables
+
+Seeding copies tables from the parent branch's infrastructure map, including [externally managed](/moosestack/olap/external-tables) tables. This ensures managed resources that depend on those tables work immediately. After seeding, MooseStack applies its own schema changes but leaves externally managed tables as-is.
+
 ## Deployment Status
 
 During seeding, your deployment progresses through these statuses:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds clarification about how seeding treats externally managed tables, with no runtime or API impact.
> 
> **Overview**
> Adds an **Externally Managed Tables** section to the Branch Data Seeding docs, clarifying that seeding includes externally managed tables from the parent infrastructure map and that subsequent schema application leaves those tables unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbf2d4e5a530f37e3b0b0eb684b61f9820f331a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->