### PR TITLE
mention the function types in AggregatingMergeTree

### DIFF
--- a/packages/py-moose-lib/moose_lib/blocks.py
+++ b/packages/py-moose-lib/moose_lib/blocks.py
@@ -66,7 +66,44 @@ class ReplacingMergeTreeEngine(EngineConfig):
 
 @dataclass
 class AggregatingMergeTreeEngine(EngineConfig):
-    """Configuration for AggregatingMergeTree engine"""
+    """Configuration for AggregatingMergeTree engine, which stores pre-aggregated
+    values and aggregate states that are automatically merged during background
+    compaction.
+
+    Fields in the model that hold aggregate data must use the corresponding type
+    annotation so the correct ClickHouse column type is generated:
+
+    - ``Annotated[T, AggregateFunction(agg_func=..., param_types=[...])]`` produces
+      ``AggregateFunction(fn, ...types)``. Data is written via ``fnState(...)``
+      and queried with ``fnMerge(...)``.
+    - ``simple_aggregated(fn, arg_type)`` produces
+      ``SimpleAggregateFunction(fn, type)``. Stores the merged value directly
+      (no state/merge round-trip).
+
+    Non-annotated fields are treated as ordinary dimensions (part of the ORDER BY
+    key, etc.).
+
+    Example::
+
+        from moose_lib import (
+            OlapTable, OlapConfig, AggregatingMergeTreeEngine,
+            simple_aggregated, AggregateFunction,
+        )
+        from typing import Annotated
+        from pydantic import BaseModel
+        from datetime import datetime
+
+        class DailyStats(BaseModel):
+            date: datetime
+            user_id: str
+            total_views: simple_aggregated("sum", int)
+            avg_rating: Annotated[float, AggregateFunction(agg_func="avg", param_types=[float])]
+
+        stats = OlapTable[DailyStats]("daily_stats", OlapConfig(
+            engine=AggregatingMergeTreeEngine(),
+            order_by_fields=["date", "user_id"],
+        ))
+    """
 
     pass
 

--- a/packages/ts-moose-lib/src/dataModels/types.ts
+++ b/packages/ts-moose-lib/src/dataModels/types.ts
@@ -310,6 +310,35 @@ export enum ClickHouseEngines {
   MergeTree = "MergeTree",
   ReplacingMergeTree = "ReplacingMergeTree",
   SummingMergeTree = "SummingMergeTree",
+  /**
+   * Stores pre-aggregated values and aggregate states that are automatically
+   * merged during background compaction.
+   *
+   * Columns in `T` that hold aggregate data must be intersected with a tag
+   * type so the compiler plugin emits the correct ClickHouse column type:
+   *
+   * - `& Aggregated<FnName, ArgTypes>` — produces `AggregateFunction(fn, ...types)`.
+   *   Data is written via `fnState(...)` and queried with `fnMerge(...)`.
+   * - `& SimpleAggregated<FnName, ArgType>` — produces `SimpleAggregateFunction(fn, type)`.
+   *   Stores the merged value directly (no state/merge round-trip).
+   *
+   * Non-annotated columns are ordinary dimensions (ORDER BY key, etc.).
+   *
+   * @example
+   * ```typescript
+   * interface DailyStats {
+   *   date: DateTime;
+   *   userId: string;
+   *   totalViews: number & SimpleAggregated<"sum", number>;
+   *   avgRating: number & Aggregated<"avg", [number]>;
+   * }
+   *
+   * const stats = new OlapTable<DailyStats>("daily_stats", {
+   *   engine: ClickHouseEngines.AggregatingMergeTree,
+   *   orderByFields: ["date", "userId"],
+   * });
+   * ```
+   */
   AggregatingMergeTree = "AggregatingMergeTree",
   CollapsingMergeTree = "CollapsingMergeTree",
   VersionedCollapsingMergeTree = "VersionedCollapsingMergeTree",

--- a/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/olapTable.ts
@@ -290,7 +290,11 @@ export type ReplacingMergeTreeConfig<T> = BaseOlapConfig<T> & {
 };
 
 /**
- * Configuration for AggregatingMergeTree engine
+ * Configuration for AggregatingMergeTree engine.
+ *
+ * See {@link ClickHouseEngines.AggregatingMergeTree} for guidance on annotating
+ * aggregate columns in `T` with `Aggregated` / `SimpleAggregated`.
+ *
  * @template T The data type of the records stored in the table.
  */
 export type AggregatingMergeTreeConfig<T> = BaseOlapConfig<T> & {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/comment updates only and do not modify runtime behavior or schema generation logic.
> 
> **Overview**
> **Clarifies how to model aggregate columns for `AggregatingMergeTree`.**
> 
> Updates the Python `AggregatingMergeTreeEngine` docstring and the TypeScript `ClickHouseEngines.AggregatingMergeTree`/`AggregatingMergeTreeConfig` comments to explicitly describe using `AggregateFunction`/`simple_aggregated` (Python) and `Aggregated`/`SimpleAggregated` (TS) type annotations, including an end-to-end example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f4fdc95d845c6368201a57d036b351432d6e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->