### PR TITLE
feat: add context_path for custom Dockerfile monorepo builds

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -955,11 +955,7 @@ pub fn build_dockerfile(
             project.docker_config.context_path.as_deref(),
         )
         .map_err(|err| {
-            let ctx_path = project
-                .docker_config
-                .context_path
-                .as_deref()
-                .unwrap_or(".");
+            let ctx_path = project.docker_config.context_path.as_deref().unwrap_or(".");
             error!("Failed to resolve context_path '{}': {}", ctx_path, err);
             RoutineFailure::new(
                 Message::new(

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -62,6 +62,39 @@ fn resolve_dockerfile_path(project: &Project, internal_dir: &Path) -> PathBuf {
     }
 }
 
+/// Resolves the Docker build context directory for a custom Dockerfile build.
+///
+/// When `context_path` is set, resolves it relative to `project_location` and
+/// canonicalizes the result. Returns `project_location` when `context_path` is None.
+fn resolve_custom_build_context(
+    project_location: &Path,
+    context_path: Option<&str>,
+) -> Result<PathBuf, std::io::Error> {
+    match context_path {
+        Some(ctx_path) => {
+            let resolved = project_location.join(ctx_path);
+            resolved.canonicalize()
+        }
+        None => Ok(project_location.to_path_buf()),
+    }
+}
+
+/// Determines whether to pass a `-f` flag to `docker buildx` for the Dockerfile location.
+///
+/// Returns `Some(dockerfile_path)` when using a custom Dockerfile with `context_path`,
+/// since the Dockerfile is no longer at the build context root.
+fn resolve_dockerfile_for_buildx(
+    custom_dockerfile: bool,
+    context_path: &Option<String>,
+    dockerfile_path: &Path,
+) -> Option<PathBuf> {
+    if custom_dockerfile && context_path.is_some() {
+        Some(dockerfile_path.to_path_buf())
+    } else {
+        None
+    }
+}
+
 /// Checks if we should skip Dockerfile generation to preserve user customizations
 fn should_skip_dockerfile_generation(project: &Project, target_path: &Path) -> bool {
     // If custom_dockerfile is enabled and the target file already exists,
@@ -917,30 +950,29 @@ pub fn build_dockerfile(
     } else if project.docker_config.custom_dockerfile {
         // Custom Dockerfile build
         // Resolve build context: use context_path if set, otherwise project root
-        let build_context = if let Some(ref ctx_path) = project.docker_config.context_path {
-            let resolved = project.project_location.join(ctx_path);
-            let canonical = resolved.canonicalize().map_err(|err| {
-                error!("Failed to resolve context_path '{}': {}", ctx_path, err);
-                RoutineFailure::new(
-                    Message::new(
-                        "Failed".to_string(),
-                        format!("to resolve docker_config.context_path '{ctx_path}'"),
-                    ),
-                    err,
-                )
-            })?;
-            info!(
-                "Using custom Dockerfile at {:?} with context_path resolved to {:?}",
-                file_path, canonical
-            );
-            canonical
-        } else {
-            info!(
-                "Using custom Dockerfile at {:?} with project root as build context",
-                file_path
-            );
-            project.project_location.clone()
-        };
+        let build_context = resolve_custom_build_context(
+            &project.project_location,
+            project.docker_config.context_path.as_deref(),
+        )
+        .map_err(|err| {
+            let ctx_path = project
+                .docker_config
+                .context_path
+                .as_deref()
+                .unwrap_or(".");
+            error!("Failed to resolve context_path '{}': {}", ctx_path, err);
+            RoutineFailure::new(
+                Message::new(
+                    "Failed".to_string(),
+                    format!("to resolve docker_config.context_path '{ctx_path}'"),
+                ),
+                err,
+            )
+        })?;
+        info!(
+            "Using custom Dockerfile at {:?} with build context {:?}",
+            file_path, build_context
+        );
 
         // For custom Dockerfile builds, copy versions directory to project root
         // so the Dockerfile can find it at ./versions
@@ -980,13 +1012,11 @@ pub fn build_dockerfile(
     };
 
     // When using context_path, Docker needs -f to find the Dockerfile
-    let dockerfile_for_buildx = if project.docker_config.custom_dockerfile
-        && project.docker_config.context_path.is_some()
-    {
-        Some(dockerfile_path.clone())
-    } else {
-        None
-    };
+    let dockerfile_for_buildx = resolve_dockerfile_for_buildx(
+        project.docker_config.custom_dockerfile,
+        &project.docker_config.context_path,
+        &dockerfile_path,
+    );
 
     let build_all = is_amd64 == is_arm64;
 
@@ -1501,4 +1531,64 @@ fn create_standard_typescript_dockerfile(
         "Successfully".to_string(),
         "created dockerfile".to_string(),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_custom_build_context_without_context_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_location = temp_dir.path();
+
+        let result = resolve_custom_build_context(project_location, None).unwrap();
+        assert_eq!(result, project_location);
+    }
+
+    #[test]
+    fn resolve_custom_build_context_with_relative_path() {
+        let temp_dir = TempDir::new().unwrap();
+        // Create nested structure: temp/services/analytics/
+        let analytics_dir = temp_dir.path().join("services").join("analytics");
+        fs::create_dir_all(&analytics_dir).unwrap();
+
+        // context_path = "../.." should resolve to temp_dir root
+        let result = resolve_custom_build_context(&analytics_dir, Some("../..")).unwrap();
+        assert_eq!(result, temp_dir.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_custom_build_context_with_nonexistent_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let result = resolve_custom_build_context(temp_dir.path(), Some("nonexistent/dir"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_dockerfile_for_buildx_with_context_path() {
+        let dockerfile = PathBuf::from("/project/Dockerfile");
+        let context_path = Some("../../..".to_string());
+
+        let result = resolve_dockerfile_for_buildx(true, &context_path, &dockerfile);
+        assert_eq!(result, Some(PathBuf::from("/project/Dockerfile")));
+    }
+
+    #[test]
+    fn resolve_dockerfile_for_buildx_without_context_path() {
+        let dockerfile = PathBuf::from("/project/Dockerfile");
+
+        let result = resolve_dockerfile_for_buildx(true, &None, &dockerfile);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_dockerfile_for_buildx_not_custom() {
+        let dockerfile = PathBuf::from("/project/Dockerfile");
+        let context_path = Some("../../..".to_string());
+
+        let result = resolve_dockerfile_for_buildx(false, &context_path, &dockerfile);
+        assert!(result.is_none());
+    }
 }

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -915,11 +915,32 @@ pub fn build_dockerfile(
             }
         }
     } else if project.docker_config.custom_dockerfile {
-        // Custom Dockerfile build - use project root as build context
-        info!(
-            "Using custom Dockerfile at {:?} with project root as build context",
-            file_path
-        );
+        // Custom Dockerfile build
+        // Resolve build context: use context_path if set, otherwise project root
+        let build_context = if let Some(ref ctx_path) = project.docker_config.context_path {
+            let resolved = project.project_location.join(ctx_path);
+            let canonical = resolved.canonicalize().map_err(|err| {
+                error!("Failed to resolve context_path '{}': {}", ctx_path, err);
+                RoutineFailure::new(
+                    Message::new(
+                        "Failed".to_string(),
+                        format!("to resolve docker_config.context_path '{ctx_path}'"),
+                    ),
+                    err,
+                )
+            })?;
+            info!(
+                "Using custom Dockerfile at {:?} with context_path resolved to {:?}",
+                file_path, canonical
+            );
+            canonical
+        } else {
+            info!(
+                "Using custom Dockerfile at {:?} with project root as build context",
+                file_path
+            );
+            project.project_location.clone()
+        };
 
         // For custom Dockerfile builds, copy versions directory to project root
         // so the Dockerfile can find it at ./versions
@@ -952,10 +973,19 @@ pub fn build_dockerfile(
             false
         };
 
-        (project.project_location.clone(), file_path, copied_versions)
+        (build_context, file_path, copied_versions)
     } else {
         // Standard build
         (internal_dir.join("packager"), file_path, false)
+    };
+
+    // When using context_path, Docker needs -f to find the Dockerfile
+    let dockerfile_for_buildx = if project.docker_config.custom_dockerfile
+        && project.docker_config.context_path.is_some()
+    {
+        Some(dockerfile_path.clone())
+    } else {
+        None
     };
 
     let build_all = is_amd64 == is_arm64;
@@ -983,7 +1013,7 @@ pub fn build_dockerfile(
                     "linux/amd64",
                     "x86_64-unknown-linux-gnu",
                     release_channel,
-                    None,
+                    dockerfile_for_buildx.as_deref(),
                 )
             },
             !project.is_production,
@@ -1025,7 +1055,7 @@ pub fn build_dockerfile(
                     "linux/arm64",
                     "aarch64-unknown-linux-gnu",
                     release_channel,
-                    None,
+                    dockerfile_for_buildx.as_deref(),
                 )
             },
             !project.is_production,

--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -983,6 +983,7 @@ pub fn build_dockerfile(
                     "linux/amd64",
                     "x86_64-unknown-linux-gnu",
                     release_channel,
+                    None,
                 )
             },
             !project.is_production,
@@ -1024,6 +1025,7 @@ pub fn build_dockerfile(
                     "linux/arm64",
                     "aarch64-unknown-linux-gnu",
                     release_channel,
+                    None,
                 )
             },
             !project.is_production,

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -179,6 +179,12 @@ pub struct DockerConfig {
     /// Path to custom Dockerfile (relative to project root)
     #[serde(default = "default_dockerfile_path")]
     pub dockerfile_path: String,
+
+    /// Docker build context path, relative to project root.
+    /// Only used when custom_dockerfile is true.
+    /// Example: "../../.." to use monorepo root as context.
+    #[serde(default)]
+    pub context_path: Option<String>,
 }
 
 impl Default for DockerConfig {
@@ -186,6 +192,7 @@ impl Default for DockerConfig {
         Self {
             custom_dockerfile: false,
             dockerfile_path: default_dockerfile_path(),
+            context_path: None,
         }
     }
 }

--- a/apps/framework-cli/src/project.rs
+++ b/apps/framework-cli/src/project.rs
@@ -774,4 +774,47 @@ pub mod tests {
             "Deserializing an empty [migration_config] must not auto-allow destructive changes"
         );
     }
+
+    #[test]
+    fn docker_config_default_has_no_context_path() {
+        let config = DockerConfig::default();
+        assert!(!config.custom_dockerfile);
+        assert_eq!(config.dockerfile_path, "./Dockerfile");
+        assert!(config.context_path.is_none());
+    }
+
+    #[test]
+    fn docker_config_deserializes_without_context_path() {
+        let config: DockerConfig = toml::from_str(
+            r#"
+            custom_dockerfile = true
+            dockerfile_path = "./Dockerfile"
+            "#,
+        )
+        .unwrap();
+        assert!(config.custom_dockerfile);
+        assert!(config.context_path.is_none());
+    }
+
+    #[test]
+    fn docker_config_deserializes_with_context_path() {
+        let config: DockerConfig = toml::from_str(
+            r#"
+            custom_dockerfile = true
+            dockerfile_path = "./Dockerfile"
+            context_path = "../../.."
+            "#,
+        )
+        .unwrap();
+        assert!(config.custom_dockerfile);
+        assert_eq!(config.context_path.as_deref(), Some("../../.."));
+    }
+
+    #[test]
+    fn docker_config_deserializes_empty() {
+        let config: DockerConfig = toml::from_str("").unwrap();
+        assert!(!config.custom_dockerfile);
+        assert_eq!(config.dockerfile_path, "./Dockerfile");
+        assert!(config.context_path.is_none());
+    }
 }

--- a/apps/framework-cli/src/utilities/docker.rs
+++ b/apps/framework-cli/src/utilities/docker.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::json;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{error, info, warn};
@@ -690,6 +690,7 @@ system.forceSearchAttributesCacheRefreshOnRead:
     /// * `architecture` - The Docker platform architecture (e.g., "linux/amd64")
     /// * `binarylabel` - The target triple (e.g., "x86_64-unknown-linux-gnu")
     /// * `channel` - The release channel ("stable" or "dev")
+    /// * `dockerfile_path` - Optional path to a Dockerfile (passed as `-f <path>`); if `None`, Docker uses the default `Dockerfile` in the build context
     pub fn buildx(
         &self,
         directory: &PathBuf,
@@ -697,10 +698,10 @@ system.forceSearchAttributesCacheRefreshOnRead:
         architecture: &str,
         binarylabel: &str,
         channel: &str,
+        dockerfile_path: Option<&Path>,
     ) -> std::io::Result<()> {
-        let mut child = self
-            .create_command()
-            .current_dir(directory)
+        let mut cmd = self.create_command();
+        cmd.current_dir(directory)
             .arg("buildx")
             .arg("build")
             .arg("--build-arg")
@@ -712,10 +713,16 @@ system.forceSearchAttributesCacheRefreshOnRead:
             .arg("--load")
             .arg("--no-cache")
             .arg("-t")
-            .arg(format!("moose-df-deployment-{binarylabel}:latest"))
+            .arg(format!("moose-df-deployment-{binarylabel}:latest"));
+
+        if let Some(path) = dockerfile_path {
+            cmd.arg("-f").arg(path);
+        }
+
+        let mut child = cmd
             .arg(".")
-            .stdout(Stdio::inherit())  // ✅ Stream stdout directly to console
-            .stderr(Stdio::inherit())  // ✅ Stream stderr directly to console
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .spawn()?;
 
         let status = child.wait()?;

--- a/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
@@ -20,12 +20,15 @@ Docker build settings can be configured in `moose.config.toml` for project-wide 
 custom_dockerfile = false
 # Path to the Dockerfile relative to project root (Default: "./Dockerfile")
 dockerfile_path = "./Dockerfile"
+# Docker build context path relative to project root (Default: none, uses project root)
+# context_path = "../../.."
 ```
 
 | Key | Env Variable | Default | Description |
 |:----|:-------------|:--------|:------------|
 | `custom_dockerfile` | `MOOSE_DOCKER_CONFIG__CUSTOM_DOCKERFILE` | `false` | When `true`, Moose writes the Dockerfile to your project root (via `moose generate dockerfile` or on first `moose build --docker`) and preserves it on subsequent runs so you can customize it. |
 | `dockerfile_path` | `MOOSE_DOCKER_CONFIG__DOCKERFILE_PATH` | `"./Dockerfile"` | Path to the Dockerfile relative to the project root. Only used when `custom_dockerfile` is `true`. |
+| `context_path` | `MOOSE_DOCKER_CONFIG__CONTEXT_PATH` | none | Docker build context path relative to the project root. Only used when `custom_dockerfile` is `true`. When set, Docker receives `-f` pointing to your Dockerfile and uses the resolved path as the build context. |
 
 ## Behavior
 
@@ -37,6 +40,36 @@ When `custom_dockerfile = true`:
 2. **Subsequent runs**: Moose detects the existing Dockerfile, skips generation to preserve your customizations, and builds from your Dockerfile.
 
 This lets you iterate on the Dockerfile — add system dependencies, configure caching, adjust build stages — while still using `moose build --docker` to build images.
+
+## Monorepo Usage
+
+When your Moose project lives inside a monorepo (e.g., at `services/analytics/`), the auto-generated Dockerfile handles the monorepo build context automatically. However, if you use a custom Dockerfile, you likely need `COPY` commands that reference files outside the project directory (like `pnpm-workspace.yaml` or shared packages at the monorepo root).
+
+Use `context_path` to set the Docker build context to the monorepo root:
+
+```toml filename="services/analytics/moose.config.toml"
+[docker_config]
+custom_dockerfile = true
+dockerfile_path = "./Dockerfile"
+context_path = "../../.."  # resolves to monorepo root
+```
+
+With this configuration, `moose build --docker` will:
+- Use the monorepo root as the Docker build context
+- Pass `-f services/analytics/Dockerfile` to Docker so it finds your Dockerfile
+
+Your Dockerfile can then reference monorepo-root-relative paths:
+
+```dockerfile
+COPY pnpm-workspace.yaml ./
+COPY pnpm-lock.yaml ./
+COPY packages ./packages
+COPY services ./services
+```
+
+<Callout type="info" title="Docker Ignore">
+Place a `.dockerignore` file at the build context root (the monorepo root when using `context_path`) to control which files are sent to the Docker daemon. This is Docker's native mechanism — no Moose-specific ignore file is needed.
+</Callout>
 
 ## Related CLI Commands
 


### PR DESCRIPTION
- add `context_path` field to `[docker_config]` in moose.config.toml, allowing custom Dockerfiles in monorepos to specify the Docker build context directory (default is to treat the Dockerfile directory as the build dir)
- Documents the new field with a Monorepo Usage section in the Docker configuration docs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Docker image build context and `docker buildx` invocation for custom Dockerfile flows, which can break builds in monorepos or when paths are misconfigured. Adds canonicalization/error handling and new config surface area that needs validation across environments.
> 
> **Overview**
> Adds `docker_config.context_path` to let custom Dockerfile builds use a different Docker build context (e.g., monorepo root) instead of always using the project directory.
> 
> Updates the Docker packaging routine to resolve/canonicalize this context, surface a clear error when it can’t be resolved, and pass `docker buildx -f <Dockerfile>` when the Dockerfile is no longer at the context root. Extends `DockerClient::buildx` to accept an optional Dockerfile path, and adds unit tests plus docs describing monorepo usage and the new env var `MOOSE_DOCKER_CONFIG__CONTEXT_PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db1fda4688b09cee6fcbad914156f0f13503332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->