### PR TITLE
update version docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ content-generation.mdc
 # Claude local marketing context
 .claude/marketing-context/
 .pnpm-store
+.cursor

--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,3 @@ content-generation.mdc
 # Claude local marketing context
 .claude/marketing-context/
 .pnpm-store
-.cursor

--- a/apps/framework-docs-v2/content/moosestack/migrate/planned-migrations.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/planned-migrations.mdx
@@ -133,6 +133,10 @@ These flags control the interactive confirmation prompts during plan generation:
 | `--yes-rename` | `MOOSE_ACCEPT_RENAME=1` | Auto-accept detected column renames as genuine renames. |
 | `--no-auto-backfill-sql` | — | Disable automatic backfill SQL generation for versioned tables. |
 
+<Callout type="info" title="Versioned table backfills" compact>
+If you are using planned migrations for a breaking OLAP table change, see [Schema Versioning](/moosestack/olap/schema-versioning) for the end-to-end version bump and generated backfill workflow.
+</Callout>
+
 ## Drift Detection
 
 Drift occurs when the target database's schema changes between the time you generate a plan and the time you apply it.

--- a/apps/framework-docs-v2/content/moosestack/olap/model-materialized-view.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/model-materialized-view.mdx
@@ -613,14 +613,6 @@ mv2 = MaterializedView[DailyCounts](MaterializedViewOptions(
   </LanguageTabContent>
 </LanguageTabs>
 
-### Blue/green schema migrations
-
-Create a new table for a breaking schema change and use an MV to copy data from the old table; when complete, switch reads to the new table and drop just the MV and old table.
-
-<Callout type="info" title="Blue/green table migrations" href="/moosestack/olap/schema-versioning" ctaLabel="Learn more">
-For more information on how to use materialized views to perform blue/green schema migrations, see the [Schema Versioning](/moosestack/olap/schema-versioning) guide.
-</Callout>
-
 ## Defining the transformation
 
 The `selectStatement` (TypeScript) or `select_statement` (Python) is a static SQL query that Moose runs to transform data from your source table(s) into rows for the destination table.

--- a/apps/framework-docs-v2/content/moosestack/olap/planned-migrations.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/planned-migrations.mdx
@@ -94,6 +94,10 @@ During plan generation, Moose will prompt you interactively when it detects:
 
 3. **Backfill for versioned tables** — When creating a new versioned table (e.g., `Events_0_1` with `version: "0.1"`) whose schema matches the existing base table, Moose can append an `INSERT INTO ... SELECT` backfill operation to the plan. In an interactive terminal, Moose prompts you for each candidate (defaulting to **Yes**). In non-interactive runs (CI/CD), Moose automatically appends the backfill SQL without prompting. Pass `--no-auto-backfill-sql` to disable backfill detection entirely in either mode.
 
+<Callout type="info" title="Versioned table example" compact>
+For the full version bump and generated backfill workflow for breaking OLAP changes, see [Schema Versioning](/moosestack/olap/schema-versioning).
+</Callout>
+
 ### CI/CD and non-interactive usage
 
 Rename and destructive prompts require a TTY. In non-interactive environments (CI/CD pipelines), Moose will error unless you explicitly opt in with override flags or environment variables:

--- a/apps/framework-docs-v2/content/moosestack/olap/schema-versioning.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/schema-versioning.mdx
@@ -1,175 +1,171 @@
 ---
-title: Schema Versioning with Materialized Views
-description: Use table versions and materialized views to migrate breaking schema changes safely
+title: Schema Versioning
+description: Use the `version` field on an `OlapTable` to model breaking ClickHouse schema changes and review generated backfill SQL
 order: 8
 category: olap
 ---
 
-import { Callout, LanguageTabs, LanguageTabContent, BulletPointsCard } from "@/components/mdx";
+import {
+  Callout,
+  LanguageTabs,
+  LanguageTabContent,
+  ToggleBlock,
+} from "@/components/mdx";
 
-# Table Versioning & Blue/Green Migrations
+# Schema Versioning
 
-## Overview
+Moose lets you declare schema versioning directly in your table definition:
+- Set `version` to create a new physical ClickHouse table while keeping the logical table name stable in code
+- Generate reviewed backfill SQL in `migrations/plan.yaml` when the old and new versions are equivalent enough for a straight copy
 
-Changing a table's storage layout (engine or sorting key) in ClickHouse requires a full table rewrite. Doing it in-place can block or slow concurrent reads and writes due to heavy merges and metadata changes, creating real risk for production workloads. Blue/Green avoids this by creating a new versioned table and migrating data live via a materialized view, so traffic continues uninterrupted.
+## When to use schema versioning
 
-**When to use it**: 
-- Change the **table engine** (e.g., MergeTree → ReplacingMergeTree)
+- Change the **table engine** (e.g., `MergeTree` → `ReplacingMergeTree`)
 - Update **ORDER BY fields** (sorting keys) to better match query patterns
 - Reshape **primary keys** or perform type changes that require a rewrite
+- Keep the old physical table in place until you finish cutover and later cleanup
 
-**How Moose does it**:
-1. Define a new table with the same logical name and a bumped `version`, setting the new <LanguageTabs><LanguageTabContent value="typescript">`orderByFields`</LanguageTabContent><LanguageTabContent value="python">`order_by_fields`</LanguageTabContent></LanguageTabs> and/or `engine` ([Table modeling](/moosestack/olap/model-table)).
-2. Create a [Materialized view](/moosestack/olap/model-materialized-view) that selects from the old table and writes to the new one; Moose backfills once and keeps the view live for new inserts.
-3. Later on, cut over readers/writers to the new export and clean up old resources ([Applying migrations](/moosestack/olap/apply-migrations)).
+## Configuration
 
-<Callout type="info" title="Version configuration">
-Setting `config.version` on an `OlapTable` changes only the underlying table name (suffixes dots with underscores). Your code still refers to the logical table you exported.
-</Callout>
-
-## High-level workflow
-
-<BulletPointsCard
-  title="Versioned migration flow"
-  bullets={[
-    "Create the new schema for the new table",
-    "Create the new table with the same logical name, but set config.version to e.g. \"0.1\"",
-    "Create a materialized view that SELECTs from the old table and writes into the new table (its targetTable)",
-    "Let the view backfill and keep migrating new inserts automatically",
-    "Cut over your readers/writers to the new versioned table, then drop the old one when ready"
-  ]}
-  bulletStyle="check"
-  divider={false}
-/>
-
-## Example: change sorting key (ORDER BY)
-
-Assume the original `events` table orders by `id` only. We want to update the
-sorting key to optimize reads by ordering on `id, createdAt`.
-
-### Original table (version 0.0)
+Set `version` on the `OlapTable` config:
 
 <LanguageTabs>
   <LanguageTabContent value="typescript">
-```ts filename="app/tables/events.ts" copy
-import { Key, OlapTable } from "@514labs/moose-lib";
-
-interface EventV0 {
-  id: string;
-  name: string;
-  createdAt: Date;
-}
-
-export const events = new OlapTable<EventV0>("events", { version: "0.0", orderByFields: ["id"] });
+```ts filename="app/tables/aircraft_tracking_data.ts" copy
+export const aircraftTrackingData = new OlapTable<AircraftTrackingData>(
+  "aircraft_tracking_data",
+  { version: "0.1" }
+);
 ```
   </LanguageTabContent>
   <LanguageTabContent value="python">
-```python filename="app/tables/events.py" copy
-from typing import Annotated
-from pydantic import BaseModel
-from moose_lib import OlapTable, Key, OlapConfig
-
-class EventV0(BaseModel):
-    id: str
-    name: str
-    created_at: str  # datetime in your format
-
-events = OlapTable[EventV0]("events", config=OlapConfig(version="0.0", order_by_fields=["id"]))
-```
-  </LanguageTabContent>
-</LanguageTabs>
-
-### New table (bump to version 0.1)
-
-Create a new table with the same logical name, but set `version: "0.1"` and update the ordering to `id, createdAt`. Moose will create `events_0_1` in ClickHouse.
-
-<LanguageTabs>
-  <LanguageTabContent value="typescript">
-```ts filename="app/tables/events_v01.ts" copy
-import { Key, OlapTable } from "@514labs/moose-lib";
-
-interface EventV1 {
-  id: Key<string>;
-  name: string;
-  createdAt: Date;
-}
-
-export const eventsV1 = new OlapTable<EventV1>("events", { version: "0.1", orderByFields: ["id", "createdAt"] });
-```
-  </LanguageTabContent>
-  <LanguageTabContent value="python">
-```python filename="app/tables/events_v01.py" copy
-class EventV1(BaseModel):
-    id: Key[str]
-    name: str
-    created_at: str
-
-events_v1 = OlapTable[EventV1]("events", config=OlapConfig(version="0.1", order_by_fields=["id", "created_at"]))
-```
-  </LanguageTabContent>
-</LanguageTabs>
-
-### Create the materialized view to migrate data
-
-Create a materialized view that:
-- SELECTs from the old table (`events_v0`)
-- copies fields 1:1 to the new table
-- writes into the versioned target table (`events_v1`)
-
-<Callout type="warning">
-Pass the versioned `OlapTable` instance as `targetTable`. If you only pass a `tableName`, Moose will create an unversioned target.
-</Callout>
-
-<LanguageTabs>
-  <LanguageTabContent value="typescript">
-```ts filename="app/views/migrate_events_to_v01.ts" copy
-import { MaterializedView, sql } from "@514labs/moose-lib";
-import { events } from "../tables/events";        // old table
-import { eventsV1, EventV1 } from "../tables/events_v01";  // new versioned table
-
-export const migrateEventsToV01 = new MaterializedView<EventV1>({
-  materializedViewName: "mv_events_to_0_1",
-  selectTables: [events],
-  selectStatement: sql.statement`
-    SELECT * FROM ${events}
-  `,
-  targetTable: eventsV1,
-});
-```
-  </LanguageTabContent>
-  <LanguageTabContent value="python">
-```python filename="app/views/migrate_events_to_v01.py" copy
-from moose_lib import MaterializedView, MaterializedViewOptions
-from app.tables.events import events
-from app.tables.events_v01 import events_v1, EventV1
-
-migrate_events_to_v01 = MaterializedView[EventV1](
-    MaterializedViewOptions(
-        materialized_view_name="mv_events_to_0_1",
-        select_statement=(
-            f"SELECT * FROM {events.name}"
-        ),
-        select_tables=[events],
-    ),
-    target_table=events_v1,
+```python filename="app/tables/aircraft_tracking_data.py" copy
+aircraft_tracking_data = OlapTable[AircraftTrackingData](
+    "aircraft_tracking_data",
+    config=OlapConfig(version="0.1"),
 )
 ```
   </LanguageTabContent>
 </LanguageTabs>
 
-What happens when you export this view:
-- Moose creates the versioned table if needed
-- Moose creates the MATERIALIZED VIEW and immediately runs a one-time backfill (`INSERT INTO ... SELECT ...`)
-- ClickHouse keeps the view active: any new inserts into `events` automatically flow into `events_0_1`
 
-## Cutover and cleanup
+### Version changes
 
-- Update readers to query the new table export (`eventsV1`).
-- Update writers/streams to produce to the new table if applicable.
-- After verifying parity and retention windows, drop the old table and the migration view.
+Bumping the `version` field on the `OlapTable` config creates a new physical table while keeping the logical table name stable in code.
 
-## Notes and tips
+<LanguageTabs>
+  <LanguageTabContent value="typescript">
+```diff filename="app/tables/aircraft_tracking_data.ts" copy
+import { OlapTable } from "@514labs/moose-lib";
 
-- Use semantic versions like `0.1`, `1.0`, `1.1`. Moose will render `events_1_1` as the physical name.
-- Keep the migration view simple and deterministic. If you need complex transforms, prefer explicit SQL in the `selectStatement`.
-- Very large backfills can take time. Consider deploying during low-traffic windows.
+interface AircraftTrackingData {
+  icao24: string;
+  callsign: string;
+  longitude: number;
+  latitude: number;
+}
+
+export const aircraftTrackingData = new OlapTable<AircraftTrackingData>(
+  "aircraft_tracking_data",
+- { version: "0.0", orderByFields: ["icao24"] }
++ { version: "0.1", orderByFields: ["icao24", "callsign"] }
+);
+```
+  </LanguageTabContent>
+  <LanguageTabContent value="python">
+```diff filename="app/tables/aircraft_tracking_data.py" copy
+from pydantic import BaseModel
+from moose_lib import OlapTable, OlapConfig
+
+class AircraftTrackingData(BaseModel):
+    icao24: str
+    callsign: str
+    longitude: float
+    latitude: float
+
+aircraft_tracking_data = OlapTable[AircraftTrackingData](
+    "aircraft_tracking_data",
+-    config=OlapConfig(version="0.0", order_by_fields=["icao24"]),
++    config=OlapConfig(version="0.1", order_by_fields=["icao24", "callsign"]),
+)
+```
+  </LanguageTabContent>
+</LanguageTabs>
+
+
+<Callout type="info" title="Version configuration">
+Setting `config.version` on an `OlapTable` changes only the underlying table name (suffixes dots with underscores). Your code still refers to the logical table you exported.
+</Callout>
+
+## Migration plan
+
+When you bump `version`, Moose plans a new physical table instead of rewriting the existing one. Run `moose generate migration --save` to write those reviewed operations to `migrations/plan.yaml`.
+
+For this `version: "0.0"` to `version: "0.1"` change, the plan can include:
+- `CreateTable` for the new `version: "0.1"` physical table, such as `aircraft_tracking_data_0_1`, with the updated sort key.
+- Optional `RawSql` `INSERT INTO ... SELECT ...` to copy rows from the `version: "0.0"` physical table into the `version: "0.1"` physical table when Moose detects a straight-copy backfill.
+
+For command options and connection modes, see [Planned Migrations](/moosestack/migrate/planned-migrations) and the [`moose generate migration` CLI reference](/moosestack/moose-cli).
+
+<Callout type="info" title="Backfill detection" compact>
+Moose detects a backfill opportunity when the old and new tables have the same schema. It will prompt you to accept the backfill if you run `moose generate migration --save` in an interactive terminal.
+
+<ToggleBlock
+  openText="Show example CLI backfill prompt"
+  closeText="Hide example CLI backfill prompt"
+>
+```text title="Terminal output" copy=false
+$ moose generate migration --save
+Remote Plan  Comparing local project code with deployed infrastructure
+Remote Plan  Calculated plan differences locally
+Backfill     Checking versioned table backfill opportunities...
+Equivalent   `aircraft_tracking_data_0_1` <- `aircraft_tracking_data_0_0`
+Append RawSql backfill operation to plan.yaml? [Y/n] (default: Y)
+> y
+Appended     RawSql backfill: `aircraft_tracking_data_0_1` <- `aircraft_tracking_data_0_0`
+Migration    generated
+```
+</ToggleBlock>
+
+You can decline the prompt if you want to run the backfill separately or add different SQL later.
+</Callout>
+
+```yaml filename="migrations/plan.yaml" copy=false
+created_at: 2026-04-09T12:00:00Z
+operations:
+  - CreateTable:
+      table:
+        name: aircraft_tracking_data_0_1
+        columns:
+          # generated column definitions omitted for brevity
+        order_by:
+          - icao24
+          - callsign
+        engine: MergeTree
+        version: "0.1"
+  - RawSql:
+      description: Backfill `514-demos-planes`.`aircraft_tracking_data_0_1` from `514-demos-planes`.`aircraft_tracking_data_0_0`
+      sql:
+        - |
+          INSERT INTO `514-demos-planes`.`aircraft_tracking_data_0_1` (`icao24`, `callsign`, `longitude`, `latitude`)
+          SELECT `icao24`, `callsign`, `longitude`, `latitude`
+          FROM `514-demos-planes`.`aircraft_tracking_data_0_0`
+```
+
+
+
+## Notes
+
+- A version bump creates a new physical table. Moose does not rewrite the old table in place or create a long-lived materialized view between versions.
+- If the same branch also adds other tables, views, or materialized views, they appear in the same plan alongside the versioned-table backfill. Review the whole file, not just the `RawSql` block.
+- If the old and new tables are not equivalent enough for a straight `INSERT INTO ... SELECT ...`, Moose will not offer the generated backfill you want. Edit `plan.yaml` and provide the exact SQL you want to run.
+- If you decline the generated backfill prompt, the plan can still create the new versioned table. You can backfill it later outside the migration, or add your own `RawSql` operation when you are ready.
+- Very large backfills can take time. Review the generated SQL and apply it during a low-traffic window if needed.
+- After applying the reviewed plan, update readers and writers to the new table version before you remove the old one.
+- Cleanup is a separate reviewed migration, not an automatic side effect of the version bump.
+
+## Related
+
+- [Modeling Tables](/moosestack/olap/model-table)
+- [Planned Migrations](/moosestack/migrate/planned-migrations)
+- [Applying Migrations](/moosestack/olap/apply-migrations)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime or API behavior is modified.
> 
> **Overview**
> Clarifies the **schema versioning** story by rewriting `schema-versioning.mdx` to focus on using `OlapTable.version`, how version bumps produce new physical tables, and how `moose generate migration --save` can append reviewed `RawSql` backfills (including an example prompt and `plan.yaml` snippet).
> 
> Adds small cross-links from both planned migrations pages to the schema versioning/backfill workflow, and removes the older *blue/green schema migrations* callout from the materialized view modeling doc in favor of the dedicated guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740e7a1b3dfa911cc466d818fe3bcb8d2cc9033a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->