### PR TITLE
chore: update moose to the latest version

### DIFF
--- a/templates/_versions.toml
+++ b/templates/_versions.toml
@@ -1,3 +1,3 @@
 [versions]
-moose-lib = "0.6.463"
-moose-cli = "0.6.463"
+moose-lib = "0.6.505"
+moose-cli = "0.6.505"

--- a/templates/next-app-empty/moose/package-lock.json
+++ b/templates/next-app-empty/moose/package-lock.json
@@ -8,12 +8,12 @@
       "name": "moose",
       "version": "0.0",
       "dependencies": {
-        "@514labs/moose-lib": "0.6.439",
+        "@514labs/moose-lib": "0.6.505",
         "ts-patch": "^3.3.0",
         "typia": "^9.6.1"
       },
       "devDependencies": {
-        "@514labs/moose-cli": "0.6.439",
+        "@514labs/moose-cli": "0.6.505",
         "@types/node": "^20.12.12"
       }
     },
@@ -33,68 +33,41 @@
       }
     },
     "node_modules/@514labs/moose-cli": {
-      "version": "0.6.439",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.439.tgz",
-      "integrity": "sha512-LzmTC/vP6BSkhoD2+MNN/w449Z5R4RlnLTxENvkfAZCfhQJisjxFwkv3SOPpHTbJ8d5zwWF2e4eRVb3FGGHlFg==",
+      "version": "0.6.505",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.505.tgz",
+      "integrity": "sha512-18g/7+g/fV7GQNiQ00mGxy+/++xsBMpD68cd4bU5IWoo+VxFF3u6AKwnNNWti3KTXDESKQDceMiBevagU1dLOg==",
       "dev": true,
       "bin": {
         "moose": "dist/index.js",
         "moose-cli": "dist/index.js"
       },
       "optionalDependencies": {
-        "@514labs/moose-cli-darwin-arm64": "0.6.439",
-        "@514labs/moose-cli-darwin-x64": "0.6.439",
-        "@514labs/moose-cli-linux-arm64": "0.6.439",
-        "@514labs/moose-cli-linux-x64": "0.6.439"
+        "@514labs/moose-cli-darwin-arm64": "0.6.505",
+        "@514labs/moose-cli-darwin-x64": "0.6.505",
+        "@514labs/moose-cli-linux-arm64": "0.6.505",
+        "@514labs/moose-cli-linux-x64": "0.6.505"
       }
     },
-    "node_modules/@514labs/moose-cli-darwin-arm64": {
-      "version": "0.6.439",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-darwin-arm64/-/moose-cli-darwin-arm64-0.6.439.tgz",
-      "integrity": "sha512-sUbQpwcgy6KUXBpPopzW1ogHw0GHbOk/6mtEo50CH+LSpmWhWTRKQz+YJ3UJns5iowl26CVcvBprR3t+HCKEug==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-darwin-arm64": {
       "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@514labs/moose-cli-linux-arm64": {
-      "version": "0.6.439",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-arm64/-/moose-cli-linux-arm64-0.6.439.tgz",
-      "integrity": "sha512-/jUT3Jco5W6Qx0uey/H6dVXtjC2bAfN3npIZsb6H6r7MFSAVpmENgIuQDk0+CVBRw1OeA305EiVc5Z2EfHNuZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@514labs/moose-cli-linux-x64": {
-      "version": "0.6.439",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-x64/-/moose-cli-linux-x64-0.6.439.tgz",
-      "integrity": "sha512-Iyk+DNTaqRYer9CycMqwTplLBNI5iANSw5ZQb5WuoGCfqo+4OiXzwvopbTUorekV1fBS/MFpFrawOv/eeboDfg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "optional": true
     },
     "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-darwin-x64": {
       "dev": true,
       "optional": true
     },
+    "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-linux-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-linux-x64": {
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@514labs/moose-lib": {
-      "version": "0.6.439",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.439.tgz",
-      "integrity": "sha512-WN5HuCLA/EBeh4fbTzo/bsbX4/Bezbc7NuNq/bEOuqL1FlBqrtuvFafaLaBY5y49/7/JAjCpfqjrQMv8sRrX0w==",
+      "version": "0.6.505",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.505.tgz",
+      "integrity": "sha512-dCO8daqsECgSxIG1GVHCISlvP41nbYvNKQ0fusZX0FzJppl6wNEe/ih7sKq3MpF7UvWuuRn71BmzS01MzDiJiA==",
       "dependencies": {
         "@514labs/kafka-javascript": "1.7.1-patch",
         "@clickhouse/client": "1.8.1",

--- a/templates/next-app-empty/moose/package.json
+++ b/templates/next-app-empty/moose/package.json
@@ -7,13 +7,13 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.439",
+    "@514labs/moose-lib": "0.6.505",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "@514labs/moose-cli": "0.6.439"
+    "@514labs/moose-cli": "0.6.505"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/python-cluster/requirements.txt
+++ b/templates/python-cluster/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505
 faker
 sqlglot[c]>=29.0.1

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,5 +1,5 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505

--- a/templates/python-fastapi-client-only/requirements.txt
+++ b/templates/python-fastapi-client-only/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505
 faker
 fastapi[standard]

--- a/templates/python-fastapi/requirements.txt
+++ b/templates/python-fastapi/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505
 faker
 fastapi[standard]

--- a/templates/python-tests/requirements.txt
+++ b/templates/python-tests/requirements.txt
@@ -1,8 +1,8 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505
 faker
 sqlglot[c]>=29.0.1
 fastapi[standard]

--- a/templates/python-webapp/requirements.txt
+++ b/templates/python-webapp/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505
 faker==40.8.0
 fastapi[standard]==0.135.1

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.439
-moose-lib==0.6.439
+moose-cli==0.6.505
+moose-lib==0.6.505
 faker
 sqlglot[c]>=29.0.1

--- a/templates/typescript-agent/pnpm-lock.yaml
+++ b/templates/typescript-agent/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@514labs/moose-cli':
-      specifier: 0.6.483
-      version: 0.6.483
+      specifier: 0.6.505
+      version: 0.6.505
     '@514labs/moose-lib':
-      specifier: 0.6.483
-      version: 0.6.483
+      specifier: 0.6.505
+      version: 0.6.505
     '@ai-sdk/amazon-bedrock':
       specifier: 4.0.83
       version: 4.0.83
@@ -370,7 +370,7 @@ importers:
     dependencies:
       '@514labs/moose-lib':
         specifier: 'catalog:'
-        version: 0.6.483(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))
+        version: 0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 'catalog:'
         version: 4.1.1
@@ -395,7 +395,7 @@ importers:
     devDependencies:
       '@514labs/moose-cli':
         specifier: 'catalog:'
-        version: 0.6.483
+        version: 0.6.505
       '@types/express':
         specifier: 'catalog:'
         version: 5.0.6
@@ -674,27 +674,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.483':
-    resolution: {integrity: sha512-fST6ol+5ZO0IEcD5FQ6cx+mKkQHwvHnCJXbeBp6R4ASf6gI6+ukAy8tqmG0qLDcF9xOUhp1VSoGLnsga1A/36g==}
+  '@514labs/moose-cli-darwin-arm64@0.6.505':
+    resolution: {integrity: sha512-CiHB2YwNFJhiR95A4E5REZETFGobtV4Fycxc3GJ1dwml8OUD0wVlIGlw1TG6rF3HGfoJRUBC7wkylfsW4g/4OQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.483':
-    resolution: {integrity: sha512-rW3zMFpM95J3JnI/oia7PmRuYlFG7XajOddzGB6yAsDoehEEL1SaDt5bwPEthroXKTgvzJTQKuXJVnhofncYpQ==}
+  '@514labs/moose-cli-linux-arm64@0.6.505':
+    resolution: {integrity: sha512-BTpJGSlHl8uTz+pTDDMyXcxsLhDXqA7oEOOZXfKSOTG3LbxOzQQREKRSmfqpKNBbxhjsW73oiN7owKSf/SZzeg==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.483':
-    resolution: {integrity: sha512-lVpSIZZ8LUuHykiIQc5n1ezTfSf1Xo5ZCeHoBe7rUk2IciFH/Y14OnDYoOrbWPXIGeFycmY6rlYq/XkGHn6GCg==}
+  '@514labs/moose-cli-linux-x64@0.6.505':
+    resolution: {integrity: sha512-Np0KokvmSHkbGJ7CWfVvBfSKIsxCPO2e1oV+9vrYHqmj1pVO+25zO01eeP4a3BZfP/1JRn+7scuOC0pZVYEnrQ==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.483':
-    resolution: {integrity: sha512-Gtt28Bt2eozVFAE3RJ4Xif6KANjHCt87rOFe8pRECAkR3FitnyXh8mUSL7EhYWLGoUNOLrShuH7gZ/tJGsdWLw==}
+  '@514labs/moose-cli@0.6.505':
+    resolution: {integrity: sha512-18g/7+g/fV7GQNiQ00mGxy+/++xsBMpD68cd4bU5IWoo+VxFF3u6AKwnNNWti3KTXDESKQDceMiBevagU1dLOg==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.483':
-    resolution: {integrity: sha512-Qx5v/hVc2U0y1emk5cSfOQi6Z2s0hyWhBG3kkQmQP7hKUZ70zbDvv9eV2Fr2tas9pciDfcbsiQl6vpE961Ba3A==}
+  '@514labs/moose-lib@0.6.505':
+    resolution: {integrity: sha512-dCO8daqsECgSxIG1GVHCISlvP41nbYvNKQ0fusZX0FzJppl6wNEe/ih7sKq3MpF7UvWuuRn71BmzS01MzDiJiA==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -7112,22 +7112,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.483':
+  '@514labs/moose-cli-darwin-arm64@0.6.505':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.483':
+  '@514labs/moose-cli-linux-arm64@0.6.505':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.483':
+  '@514labs/moose-cli-linux-x64@0.6.505':
     optional: true
 
-  '@514labs/moose-cli@0.6.483':
+  '@514labs/moose-cli@0.6.505':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.483
-      '@514labs/moose-cli-linux-arm64': 0.6.483
-      '@514labs/moose-cli-linux-x64': 0.6.483
+      '@514labs/moose-cli-darwin-arm64': 0.6.505
+      '@514labs/moose-cli-linux-arm64': 0.6.505
+      '@514labs/moose-cli-linux-x64': 0.6.505
 
-  '@514labs/moose-lib@0.6.483(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1
@@ -11384,8 +11384,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -11407,7 +11407,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11418,22 +11418,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11444,7 +11444,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/templates/typescript-agent/pnpm-workspace.yaml
+++ b/templates/typescript-agent/pnpm-workspace.yaml
@@ -2,8 +2,8 @@ packages:
   - "packages/*"
 
 catalog:
-  "@514labs/moose-cli": "0.6.483"
-  "@514labs/moose-lib": "0.6.483"
+  "@514labs/moose-cli": "0.6.505"
+  "@514labs/moose-lib": "0.6.505"
   "@ai-sdk/amazon-bedrock": "4.0.83"
   "@ai-sdk/anthropic": "3.0.64"
   "@ai-sdk/mcp": "1.0.30"

--- a/templates/typescript-cluster/package.json
+++ b/templates/typescript-cluster/package.json
@@ -11,7 +11,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"

--- a/templates/typescript-empty/package.json
+++ b/templates/typescript-empty/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.483",
+    "@514labs/moose-cli": "0.6.505",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "axios": "^1.7.7",
     "express": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.483",
+    "@514labs/moose-cli": "0.6.505",
     "@types/express": "^5.0.3",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"

--- a/templates/typescript-fastify/package.json
+++ b/templates/typescript-fastify/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "axios": "^1.7.7",
     "fastify": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.483",
+    "@514labs/moose-cli": "0.6.505",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },

--- a/templates/typescript-mcp/packages/moosestack-service/package.json
+++ b/templates/typescript-mcp/packages/moosestack-service/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "@514labs/express-pbkdf2-api-key-auth": "^1.0.4",
     "@cfworker/json-schema": "4.1.1",
     "@modelcontextprotocol/sdk": "1.26.0",
@@ -18,7 +18,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.483",
+    "@514labs/moose-cli": "0.6.505",
     "@types/express": "^5.0.3",
     "@types/node": "^20.12.12"
   }

--- a/templates/typescript-mcp/pnpm-lock.yaml
+++ b/templates/typescript-mcp/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4(express@5.2.1)
       '@514labs/moose-lib':
-        specifier: 0.6.483
-        version: 0.6.483(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
+        specifier: 0.6.505
+        version: 0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 4.1.1
         version: 4.1.1
@@ -42,8 +42,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@514labs/moose-cli':
-        specifier: 0.6.483
-        version: 0.6.483
+        specifier: 0.6.505
+        version: 0.6.505
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
@@ -253,27 +253,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.483':
-    resolution: {integrity: sha512-fST6ol+5ZO0IEcD5FQ6cx+mKkQHwvHnCJXbeBp6R4ASf6gI6+ukAy8tqmG0qLDcF9xOUhp1VSoGLnsga1A/36g==}
+  '@514labs/moose-cli-darwin-arm64@0.6.505':
+    resolution: {integrity: sha512-CiHB2YwNFJhiR95A4E5REZETFGobtV4Fycxc3GJ1dwml8OUD0wVlIGlw1TG6rF3HGfoJRUBC7wkylfsW4g/4OQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.483':
-    resolution: {integrity: sha512-rW3zMFpM95J3JnI/oia7PmRuYlFG7XajOddzGB6yAsDoehEEL1SaDt5bwPEthroXKTgvzJTQKuXJVnhofncYpQ==}
+  '@514labs/moose-cli-linux-arm64@0.6.505':
+    resolution: {integrity: sha512-BTpJGSlHl8uTz+pTDDMyXcxsLhDXqA7oEOOZXfKSOTG3LbxOzQQREKRSmfqpKNBbxhjsW73oiN7owKSf/SZzeg==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.483':
-    resolution: {integrity: sha512-lVpSIZZ8LUuHykiIQc5n1ezTfSf1Xo5ZCeHoBe7rUk2IciFH/Y14OnDYoOrbWPXIGeFycmY6rlYq/XkGHn6GCg==}
+  '@514labs/moose-cli-linux-x64@0.6.505':
+    resolution: {integrity: sha512-Np0KokvmSHkbGJ7CWfVvBfSKIsxCPO2e1oV+9vrYHqmj1pVO+25zO01eeP4a3BZfP/1JRn+7scuOC0pZVYEnrQ==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.483':
-    resolution: {integrity: sha512-Gtt28Bt2eozVFAE3RJ4Xif6KANjHCt87rOFe8pRECAkR3FitnyXh8mUSL7EhYWLGoUNOLrShuH7gZ/tJGsdWLw==}
+  '@514labs/moose-cli@0.6.505':
+    resolution: {integrity: sha512-18g/7+g/fV7GQNiQ00mGxy+/++xsBMpD68cd4bU5IWoo+VxFF3u6AKwnNNWti3KTXDESKQDceMiBevagU1dLOg==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.483':
-    resolution: {integrity: sha512-Qx5v/hVc2U0y1emk5cSfOQi6Z2s0hyWhBG3kkQmQP7hKUZ70zbDvv9eV2Fr2tas9pciDfcbsiQl6vpE961Ba3A==}
+  '@514labs/moose-lib@0.6.505':
+    resolution: {integrity: sha512-dCO8daqsECgSxIG1GVHCISlvP41nbYvNKQ0fusZX0FzJppl6wNEe/ih7sKq3MpF7UvWuuRn71BmzS01MzDiJiA==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -551,89 +551,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -4825,22 +4841,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.483':
+  '@514labs/moose-cli-darwin-arm64@0.6.505':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.483':
+  '@514labs/moose-cli-linux-arm64@0.6.505':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.483':
+  '@514labs/moose-cli-linux-x64@0.6.505':
     optional: true
 
-  '@514labs/moose-cli@0.6.483':
+  '@514labs/moose-cli@0.6.505':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.483
-      '@514labs/moose-cli-linux-arm64': 0.6.483
-      '@514labs/moose-cli-linux-x64': 0.6.483
+      '@514labs/moose-cli-darwin-arm64': 0.6.505
+      '@514labs/moose-cli-linux-arm64': 0.6.505
+      '@514labs/moose-cli-linux-x64': 0.6.505
 
-  '@514labs/moose-lib@0.6.483(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1
@@ -7513,7 +7529,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7535,7 +7551,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/templates/typescript-migrate-test/migration/package.json
+++ b/templates/typescript-migrate-test/migration/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "0.6.439",
+    "@514labs/moose-lib": "0.6.505",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.439",
+    "@514labs/moose-cli": "0.6.505",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-migrate-test/package.json
+++ b/templates/typescript-migrate-test/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.483",
+    "@514labs/moose-cli": "0.6.505",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -13,14 +13,14 @@
     "generate-runtime": "tspc app/index.ts"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.483",
+    "@514labs/moose-lib": "0.6.505",
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.483",
+    "@514labs/moose-cli": "0.6.505",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump limited to template dependency pins and lockfiles; main risk is template builds changing behavior due to upstream `moose` releases.
> 
> **Overview**
> Updates all shipped templates to use `@514labs/moose-lib`/`@514labs/moose-cli` **0.6.505** (from prior `0.6.439`/`0.6.483` pins), including the central `templates/_versions.toml`.
> 
> Refreshes associated dependency lockfiles (`package-lock.json`, `pnpm-lock.yaml`) and Python `requirements.txt` files to match the new versions (including updated optional platform-specific `moose-cli` packages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e166dbf97d96be292d754de806b60cdd91879b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->