### PR TITLE
fix: resolve YAML syntax error in build-template-images workflow

### DIFF
--- a/.github/workflows/build-template-images.yaml
+++ b/.github/workflows/build-template-images.yaml
@@ -29,4 +29,5 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Placeholder
-        run: echo "TODO: Implement template image building"
+        run: |
+          echo "TODO: Implement template image building"


### PR DESCRIPTION
## Summary

- GitHub Actions' strict YAML parser has been rejecting `.github/workflows/build-template-images.yaml` with `Invalid workflow file` on line 32 since the workflow was first scaffolded (514-labs/moosestack#3599)
- The issue: double-quotes inside a plain (unquoted) YAML scalar (`run: echo "TODO: ..."`)
- Fix: switch to a block scalar (`run: |`) which is unambiguous and parser-safe

## Test plan

- [ ] Verify the workflow no longer shows `Invalid workflow file` on the next push touching `templates/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a tiny workflow syntax change with no behavioral impact beyond making the file parse correctly.
> 
> **Overview**
> Updates `.github/workflows/build-template-images.yaml` to use a block scalar (`run: |`) for the placeholder command, avoiding YAML parsing errors caused by quotes in the inline `run:` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97606328a4ba63de0e17b5ecacdfa5f6e6d3910d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->