### PR TITLE
nklmish ref

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/release-notes/2026-04-09.mdx
+++ b/apps/framework-docs-v2/content/moosestack/release-notes/2026-04-09.mdx
@@ -45,7 +45,7 @@ import { Callout } from "@/components/mdx";
 - `moose init` no longer requires a `--language` flag — the language is inferred from the template. Template is now a positional argument alongside the project name. ([@callicles](https://github.com/callicles))
 
 
-- Fix `moose harness init --from-remote` failing when used with templates in nested moose project directories. ([@callicles](https://github.com/callicles)) (thanks @nklmish for reporting)
+- Fix `moose harness init --from-remote` failing when used with templates in nested moose project directories. ([@callicles](https://github.com/callicles)) (thanks [@nklmish](https://github.com/nklmish) for reporting)
 - Return 404 instead of 500 for unknown consumption API routes, with a helpful message listing available APIs. ([@03cranec](https://github.com/03cranec))
 - Fix backtick stripping in materialized view and regular view SQL normalization — identifiers containing special characters (e.g. hyphens) now preserve their backtick quoting, preventing invalid SQL during migration comparison. ([@514Ben](https://github.com/514Ben))
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating attribution formatting; no runtime or behavioral impact.
> 
> **Overview**
> Fixes the April 9, 2026 release notes entry for `moose harness init --from-remote` by converting the reporter mention to a proper GitHub profile link (`thanks [@nklmish](https://github.com/nklmish)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d722eb78a4ff86d59a079d26f00eeb4d1627c1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->