### PR TITLE
fix: log failed SQL statement at debug level

### DIFF
--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/client.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/client.rs
@@ -218,6 +218,7 @@ impl ClickHouseClient {
 
         if status != 200 {
             error!("Failed to execute SQL: Res {} - {}", &status, body_str);
+            debug!("Failed SQL statement:\n{}", sql);
             Err(anyhow::anyhow!("Failed to execute SQL: {}", body_str))
         } else {
             debug!("SQL executed successfully: {}", sql);


### PR DESCRIPTION
## Summary

- When a ClickHouse SQL execution fails (non-200 response), log the full SQL statement at `debug` level to aid debugging
- The error log already captures the status/body; this adds the SQL itself so developers can reproduce and inspect the failing query without hunting through code

## Test plan

- [ ] Trigger a ClickHouse SQL failure and confirm the failed statement appears in debug logs (`RUST_LOG=debug` or `MOOSE_LOGGER__LEVEL=Debug`)
- [ ] Confirm successful SQL execution still logs at debug level as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk logging-only change; the main impact is additional debug output which could expose query text (and any embedded sensitive values) when debug logging is enabled.
> 
> **Overview**
> When `ClickHouseClient::execute_sql_with_database` receives a non-200 response, it now logs the full failed SQL statement at `debug` level in addition to the existing error log that includes status and response body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0c24b33d312493902158973032acab74746d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->