### PR TITLE
Align cli texts

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -259,7 +259,7 @@ pub fn prompt_password(prompt_text: &str) -> Result<String, RoutineFailure> {
 #[command(
     author,
     version = constants::CLI_VERSION,
-    about = "MooseStack is a type-safe code-first developer framework for building real-time analytical backends, by the team at Fiveonefour.",
+    about = "MooseStack is a type-safe code-first developer framework for building real-time analytical backends.",
     long_about = None,
     arg_required_else_help(true),
     next_display_order = None,
@@ -282,11 +282,7 @@ pub struct Cli {
     debug: bool,
 
     /// Print backtraces for all errors (same as RUST_LIB_BACKTRACE=1)
-    #[arg(
-        long,
-        global = true,
-        help = "Print backtraces for all errors (same as RUST_LIB_BACKTRACE=1)"
-    )]
+    #[arg(long, global = true)]
     pub backtrace: bool,
 
     #[command(subcommand)]

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -8,7 +8,7 @@ use clap::{Args, Subcommand};
 #[derive(Subcommand)]
 pub enum Commands {
     // Initializes the developer environment with all the necessary directories including temporary ones for data storage
-    /// Initialize your data-intensive app or service
+    /// Initialize a new project
     #[command(visible_alias = "i")]
     Init {
         /// Name of your app or service
@@ -21,11 +21,11 @@ pub enum Commands {
         #[arg(short, long)]
         location: Option<String>,
 
-        /// By default, the init command fails if the location directory exists, to prevent accidental reruns. This flag disables the check.
+        /// Allow init in an existing directory
         #[arg(long)]
         no_fail_already_exists: bool,
 
-        /// Initialize from a remote database. E.g. https://play.clickhouse.com/?user=explorer
+        /// Initialize from a remote database
         #[arg(
             long,
             value_name = "CONNECTION_STRING",
@@ -33,14 +33,14 @@ pub enum Commands {
         )]
         from_remote: Option<Option<String>>,
 
-        /// Generate a custom Dockerfile at project root for customization
+        /// Generate a custom Dockerfile at project root
         #[arg(long)]
         custom_dockerfile: bool,
     },
-    /// Builds your moose project
+    /// Build your moose project
     #[command(visible_alias = "b")]
     Build {
-        /// Build for docker
+        /// Build for Docker
         #[arg(short, long, default_value = "false")]
         docker: bool,
         /// Build for amd64 architecture
@@ -50,22 +50,21 @@ pub enum Commands {
         #[arg(long)]
         arm64: bool,
     },
-    /// Checks the project for non-runtime errors
+    /// Check the project for non-runtime errors
     #[command(visible_alias = "c")]
     Check {
+        /// Write the infrastructure map to disk
         #[arg(long, default_value = "false")]
         write_infra_map: bool,
     },
-    /// Displays the changes that will be applied to the infrastructure during the next deployment
-    /// to production, considering the current state of the project
+    /// Preview infrastructure changes for next deployment
     #[command(visible_alias = "pl")]
     Plan {
         /// URL of the remote Moose instance (default: http://localhost:4000)
         #[arg(long, conflicts_with = "clickhouse_url")]
         url: Option<String>,
 
-        /// API token for authentication with the remote Moose instance
-        /// This token will be sent as a Bearer token in the Authorization header
+        /// API token for the remote Moose instance
         #[arg(long)]
         token: Option<String>,
 
@@ -73,7 +72,7 @@ pub enum Commands {
         #[arg(long, conflicts_with = "url")]
         clickhouse_url: Option<String>,
 
-        /// Output plan as JSON for programmatic use
+        /// Output plan as JSON
         #[arg(long)]
         json: bool,
     },
@@ -86,15 +85,11 @@ pub enum Commands {
         #[arg(long)]
         clickhouse_url: Option<String>,
 
-        /// Redis connection URL for state storage (e.g., redis://host:port)
-        /// Required when state_config.storage = "redis"
+        /// Redis connection URL for state storage
         #[arg(long)]
         redis_url: Option<String>,
 
-        /// Validate migration files without executing them.
-        /// Checks that the delta sequence is consistent (fold succeeds)
-        /// and detects semantic conflicts between migration files.
-        /// Does not require ClickHouse or Redis.
+        /// Validate migration files without executing them
         #[arg(long)]
         validate: bool,
     },
@@ -119,10 +114,10 @@ pub enum Commands {
         #[arg(short = 's', long = "stream", group = "resource_type")]
         stream: bool,
     },
-    /// Starts a local development environment to build your data-intensive app or service
+    /// Start a local development environment
     #[command(visible_alias = "d")]
     Dev {
-        /// Skip starting docker containers for infrastructure
+        /// Skip starting Docker containers for infrastructure
         #[arg(long)]
         no_infra: bool,
 
@@ -142,15 +137,15 @@ pub enum Commands {
         #[arg(long)]
         log_payloads: bool,
 
-        /// Skip all confirmation prompts (renames and destructive operations)
+        /// Skip all confirmation prompts
         #[arg(long)]
         yes_all: bool,
 
-        /// Skip the confirmation prompt for destructive operations (table, column, view, and materialized-view removals)
+        /// Auto-approve destructive operations
         #[arg(long)]
         yes_destructive: bool,
 
-        /// Skip the confirmation prompt for detected column renames (accept them as genuine renames)
+        /// Auto-approve column renames
         #[arg(long)]
         yes_rename: bool,
 
@@ -158,17 +153,17 @@ pub enum Commands {
         #[arg(long)]
         dockerless: bool,
     },
-    /// Start a remote environment for use in cloud deployments
+    /// Start a production environment
     #[command(visible_alias = "p")]
     Prod {
         /// Include and manage dependencies (ClickHouse, Redpanda, etc.) using Docker containers
         #[arg(long)]
         start_include_dependencies: bool,
     },
-    /// Generates helpers for your data models (i.e. sdk, api tokens)
+    /// Generate Dockerfiles, tokens, and migrations
     #[command(visible_alias = "g")]
     Generate(GenerateArgs),
-    /// Clears all temporary data and stops development infrastructure
+    /// Clear temporary data and stop development infrastructure
     #[command(visible_alias = "cl")]
     Clean {},
     /// View Moose logs
@@ -186,7 +181,7 @@ pub enum Commands {
     Ps {},
     /// View Moose primitives & infrastructure
     Ls {
-        /// Filter by infrastructure type (tables, streams, ingestion, sql_resource, consumption, workflows, web_apps)
+        /// Filter by infrastructure type
         #[arg(long)]
         _type: Option<String>,
 
@@ -199,33 +194,32 @@ pub enum Commands {
         json: bool,
     },
 
-    /// Opens metrics console for viewing live metrics from your moose app
+    /// Open the live metrics console
     #[command(visible_alias = "m")]
     Metrics {},
-    /// Manage data processing workflows
+    /// Manage workflows
     #[command(visible_alias = "w")]
     Workflow(WorkflowArgs),
     /// Manage templates
     #[command(visible_alias = "t")]
     Template(TemplateCommands),
-    /// Initialize a Moose project and developer harness
+    /// Initialize a project with developer harness
     Harness(HarnessCommands),
     #[command(
         about = "[EXPERIMENTAL] Manage components",
         long_about = "Manage components\n\n[EXPERIMENTAL] Component APIs and available components may change in future releases."
     )]
     Component(ComponentCommands),
-    /// Manage database schema import
+    /// Import external database schemas
     Db(DbArgs),
-    /// Integrate matching tables from a remote Moose instance into the local project
+    /// Integrate tables from a remote Moose instance
     #[command(visible_alias = "r")]
     Refresh {
         /// URL of the remote Moose instance (default: http://localhost:4000)
         #[arg(long)]
         url: Option<String>,
 
-        /// API token for authentication with the remote Moose instance
-        /// This token will be sent as a Bearer token in the Authorization header
+        /// API token for the remote Moose instance
         #[arg(long)]
         token: Option<String>,
         // #[arg(default_value = "true", short, long)]
@@ -249,7 +243,7 @@ pub enum Commands {
         #[arg(long)]
         rows: Option<u64>,
     },
-    /// Run a stdio MCP proxy server for AI agent integration (e.g., Claude Code)
+    /// Run MCP proxy server for AI agents
     Mcp {
         /// Host of the dev server to proxy to (auto-detected from project config if omitted)
         #[arg(long)]
@@ -262,7 +256,7 @@ pub enum Commands {
     /// Manage Kafka-related operations
     #[command(visible_alias = "k")]
     Kafka(KafkaArgs),
-    /// Submit feedback, report issues, or join the community
+    /// Submit feedback or report issues
     #[command(visible_alias = "f")]
     Feedback {
         /// Feedback message (e.g. moose feedback "loving the DX!" or moose feedback --bug "crash on startup")
@@ -299,11 +293,11 @@ pub enum Commands {
         #[arg(short = 'c', long = "format-query", value_name = "LANGUAGE")]
         format_query: Option<String>,
 
-        /// Prettify SQL before formatting (only with --format-query)
+        /// Prettify SQL before formatting
         #[arg(short = 'p', long = "prettify", requires = "format_query")]
         prettify: bool,
     },
-    /// Fetch and display LLM-optimized documentation for AI agents
+    /// Browse and search documentation
     #[command(visible_alias = "do")]
     Docs(DocsArgs),
     #[command(
@@ -376,8 +370,7 @@ pub enum GenerateCommand {
         #[arg(long, conflicts_with = "clickhouse_url")]
         url: Option<String>,
 
-        /// API token for authentication with the remote Moose instance
-        /// This token will be sent as a Bearer token in the Authorization header
+        /// API token for the remote Moose instance
         #[arg(long)]
         token: Option<String>,
 
@@ -385,28 +378,27 @@ pub enum GenerateCommand {
         #[arg(long, conflicts_with = "url")]
         clickhouse_url: Option<String>,
 
-        /// Redis connection URL for state storage (e.g., redis://host:port)
-        /// Required when state_config.storage = "redis"
+        /// Redis connection URL for state storage
         #[arg(long)]
         redis_url: Option<String>,
 
-        /// Save the migration files in the migrations/ directory
+        /// Save migration files to the migrations/ directory
         #[arg(long, default_value = "false")]
         save: bool,
 
-        /// Skip all confirmation prompts (renames and destructive operations)
+        /// Skip all confirmation prompts
         #[arg(long)]
         yes_all: bool,
 
-        /// Skip the confirmation prompt for destructive operations (table, column, view, and materialized-view removals)
+        /// Auto-approve destructive operations
         #[arg(long)]
         yes_destructive: bool,
 
-        /// Skip the confirmation prompt for detected column renames (accept them as genuine renames)
+        /// Auto-approve column renames
         #[arg(long)]
         yes_rename: bool,
 
-        /// Disable automatic backfill SQL generation for versioned tables
+        /// Disable automatic backfill SQL generation
         #[arg(long)]
         no_auto_backfill_sql: bool,
     },
@@ -554,11 +546,11 @@ pub struct HarnessInitArgs {
     #[command(subcommand)]
     pub action: Option<HarnessInitAction>,
 
-    /// Explicit project name. Use this when the name would otherwise conflict with a subcommand like `schema`
+    /// Project name (use instead of positional arg to avoid ambiguity)
     #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
     pub name_option: Option<String>,
 
-    /// Explicit template name. Use this with `--name` when positional parsing would be ambiguous
+    /// Template name (use instead of positional arg to avoid ambiguity)
     #[arg(
         long = "template",
         value_name = "TEMPLATE",
@@ -576,23 +568,23 @@ pub struct HarnessInitArgs {
     #[arg(short, long)]
     pub location: Option<String>,
 
-    /// Disable the existing-directory guard when reusing a location
+    /// Allow init in an existing directory
     #[arg(long)]
     pub no_fail_already_exists: bool,
 
-    /// Initialize from a remote ClickHouse database using an explicit connection string
+    /// Initialize from a remote ClickHouse database
     #[arg(long, value_name = "CONNECTION_STRING")]
     pub from_remote: Option<String>,
 
-    /// Generate a custom Dockerfile at project root for customization
+    /// Generate a custom Dockerfile at project root
     #[arg(long)]
     pub custom_dockerfile: bool,
 
-    /// Target specific coding agents instead of auto-detecting (repeatable)
+    /// Target specific coding agents instead of auto-detecting
     #[arg(long = "agent")]
     pub agents: Vec<String>,
 
-    /// Install and configure MooseStack LSP where supported (default behavior)
+    /// Install and configure MooseStack LSP
     #[arg(long, conflicts_with = "no_lsp")]
     pub lsp: bool,
 
@@ -649,20 +641,19 @@ pub enum SeedSubcommands {
         /// ClickHouse connection URL (e.g. 'clickhouse://explorer@play.clickhouse.com:9440/default')
         #[arg(long, alias = "connection-string")]
         clickhouse_url: Option<String>,
-        /// Limit the number of rows to copy per table.
-        /// When omitted, falls back to per-table seedFilter.limit, then to 1000.
+        /// Maximum rows to copy per table
         #[arg(long, value_name = "LIMIT", conflicts_with = "all")]
         limit: Option<usize>,
-        /// Copy all rows (ignore limit). If set for a table, copies entire table.
+        /// Copy all rows, ignoring limit
         #[arg(long, default_value = "false", conflicts_with = "limit")]
         all: bool,
-        /// ORDER BY clause of the query. e.g. `--order-by 'timestamp DESC' --limit 10` for the latest 10 rows
+        /// ORDER BY clause for the seed query
         #[arg(long)]
         order_by: Option<String>,
-        /// Only seed a specific table (optional)
+        /// Only seed a specific table
         #[arg(long, value_name = "TABLE_NAME")]
         table: Option<String>,
-        /// Report row counts after seeding. Counts shown for default database only (use --report=false to skip)
+        /// Show row counts after seeding
         #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
         report: bool,
     },
@@ -683,7 +674,7 @@ pub enum DbCommands {
         /// ClickHouse connection URL (e.g., clickhouse://user:pass@host:port/database or https://user:pass@host:port/database)
         #[arg(long)]
         clickhouse_url: Option<String>,
-        /// File storing the EXTERNALLY_MANAGED table definitions, defaults to app/external_models.py or app/externalModels.ts
+        /// Output file for external table definitions
         #[arg(long)]
         file_path: Option<String>,
     },
@@ -774,11 +765,11 @@ pub enum KafkaCommands {
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
 
-        /// Include pattern (glob). Defaults to '*'
+        /// Include pattern (glob)
         #[arg(long, default_value = "*")]
         include: String,
 
-        /// Exclude pattern (glob). Defaults to '{__consumer_offsets,_schemas}'
+        /// Exclude pattern (glob)
         #[arg(long, default_value = "{__consumer_offsets,_schemas}")]
         exclude: String,
 

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -238,7 +238,7 @@ pub enum Commands {
         #[arg(value_name = "TABLE", num_args = 0.., value_delimiter = ',')]
         tables: Vec<String>,
 
-        /// Apply the operation to all tables in the current database
+        /// Apply to all non-view tables in the current database
         #[arg(long, conflicts_with = "tables", default_value = "false")]
         all: bool,
 

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -89,7 +89,10 @@ pub enum Commands {
         #[arg(long)]
         redis_url: Option<String>,
 
-        /// Validate migration files without executing them
+        /// Validate migration files without executing them.
+        /// Checks that the delta sequence is consistent (fold succeeds)
+        /// and detects semantic conflicts between migration files.
+        /// Does not require ClickHouse or Redis.
         #[arg(long)]
         validate: bool,
     },
@@ -546,11 +549,11 @@ pub struct HarnessInitArgs {
     #[command(subcommand)]
     pub action: Option<HarnessInitAction>,
 
-    /// Project name (use instead of positional arg to avoid ambiguity)
+    /// Explicit project name. Use this when the name would otherwise conflict with a subcommand like `schema`
     #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
     pub name_option: Option<String>,
 
-    /// Template name (use instead of positional arg to avoid ambiguity)
+    /// Explicit template name. Use this with `--name` when positional parsing would be ambiguous
     #[arg(
         long = "template",
         value_name = "TEMPLATE",

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -120,7 +120,7 @@ pub enum Commands {
     /// Start a local development environment
     #[command(visible_alias = "d")]
     Dev {
-        /// Skip starting Docker containers for infrastructure
+        /// Skip starting local infrastructure
         #[arg(long)]
         no_infra: bool,
 

--- a/apps/framework-docs-v2/content/hosting/cli/agent/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/agent/index.mdx
@@ -44,7 +44,7 @@ See the full command reference: [`514 agent remove`](/hosting/cli/agent/remove).
 - `org`: Organization resources
 - `project`: Project resources
 - `deployment`: Deployment resources
-- `doc`: Documentation resources
+- `docs`: Documentation resources
 - `metrics`: Query metrics and analytics
 - `logs`: Query runtime application logs
 - `api-endpoint`: API endpoint resources

--- a/apps/framework-docs-v2/content/hosting/cli/doc/browse.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/doc/browse.mdx
@@ -1,17 +1,17 @@
 ---
-title: doc browse
+title: docs browse
 description: Interactively browse and select a documentation page.
 order: 4
 ---
 
-# 514 doc browse
+# 514 docs browse
 
-Use `514 doc browse` to interactively browse and select a documentation page.
+Use `514 docs browse` to interactively browse and select a documentation page.
 
 ## Usage
 
 ```bash
-514 doc browse [OPTIONS]
+514 docs browse [OPTIONS]
 ```
 
 ## Options
@@ -24,13 +24,13 @@ Additional command-specific options:
 ## Examples
 
 ```bash
-514 doc browse
+514 docs browse
 514 docs browse --web
 ```
 
 ## Related
 
-- [`514 doc`](/hosting/cli/doc)
-- [`514 doc list`](/hosting/cli/doc/list)
-- [`514 doc show`](/hosting/cli/doc/show)
-- [`514 doc search`](/hosting/cli/doc/search)
+- [`514 docs`](/hosting/cli/doc)
+- [`514 docs list`](/hosting/cli/doc/list)
+- [`514 docs show`](/hosting/cli/doc/show)
+- [`514 docs search`](/hosting/cli/doc/search)

--- a/apps/framework-docs-v2/content/hosting/cli/doc/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/doc/index.mdx
@@ -1,19 +1,17 @@
 ---
-title: doc
+title: docs
 description: Browse and search documentation from the 514 CLI.
 order: 8
 ---
 
-# 514 doc
+# 514 docs
 
-Use `514 doc` to browse, search, and open documentation pages directly from the CLI.
-
-Plural alias also works: `514 docs`.
+Use `514 docs` to browse, search, and open documentation pages directly from the CLI.
 
 ## Usage
 
 ```bash
-514 doc [OPTIONS] <COMMAND>
+514 docs [OPTIONS] <COMMAND>
 ```
 
 ## Subcommands
@@ -23,7 +21,7 @@ Plural alias also works: `514 docs`.
 List documentation pages.
 
 ```bash
-514 doc list [OPTIONS]
+514 docs list [OPTIONS]
 ```
 
 ### Show
@@ -31,7 +29,7 @@ List documentation pages.
 Show a documentation page by slug.
 
 ```bash
-514 doc show [OPTIONS] <SLUG>
+514 docs show [OPTIONS] <SLUG>
 ```
 
 Arguments:
@@ -42,7 +40,7 @@ Arguments:
 Search documentation by title or description.
 
 ```bash
-514 doc search [OPTIONS] <QUERY>
+514 docs search [OPTIONS] <QUERY>
 ```
 
 Arguments:
@@ -53,7 +51,7 @@ Arguments:
 Interactively browse and select a documentation page.
 
 ```bash
-514 doc browse [OPTIONS]
+514 docs browse [OPTIONS]
 ```
 
 ## Common options
@@ -66,11 +64,10 @@ Additional command-specific options:
 ## Examples
 
 ```bash
-514 doc list
-514 doc show moosestack/olap
-514 doc search "deployment"
-514 doc browse
-514 docs search "workflow"
+514 docs list
+514 docs show moosestack/olap
+514 docs search "deployment"
+514 docs browse
 ```
 
 ## Related

--- a/apps/framework-docs-v2/content/hosting/cli/doc/list.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/doc/list.mdx
@@ -1,17 +1,17 @@
 ---
-title: doc list
+title: docs list
 description: List documentation pages from the CLI.
 order: 1
 ---
 
-# 514 doc list
+# 514 docs list
 
-Use `514 doc list` to list documentation pages.
+Use `514 docs list` to list documentation pages.
 
 ## Usage
 
 ```bash
-514 doc list [OPTIONS]
+514 docs list [OPTIONS]
 ```
 
 ## Options
@@ -24,13 +24,13 @@ Additional command-specific options:
 ## Examples
 
 ```bash
-514 doc list
+514 docs list
 514 docs list --expand
 ```
 
 ## Related
 
-- [`514 doc`](/hosting/cli/doc)
-- [`514 doc show`](/hosting/cli/doc/show)
-- [`514 doc search`](/hosting/cli/doc/search)
-- [`514 doc browse`](/hosting/cli/doc/browse)
+- [`514 docs`](/hosting/cli/doc)
+- [`514 docs show`](/hosting/cli/doc/show)
+- [`514 docs search`](/hosting/cli/doc/search)
+- [`514 docs browse`](/hosting/cli/doc/browse)

--- a/apps/framework-docs-v2/content/hosting/cli/doc/search.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/doc/search.mdx
@@ -1,17 +1,17 @@
 ---
-title: doc search
+title: docs search
 description: Search documentation by title or description.
 order: 3
 ---
 
-# 514 doc search
+# 514 docs search
 
-Use `514 doc search` to search documentation by title or description.
+Use `514 docs search` to search documentation by title or description.
 
 ## Usage
 
 ```bash
-514 doc search [OPTIONS] <QUERY>
+514 docs search [OPTIONS] <QUERY>
 ```
 
 ## Arguments
@@ -25,12 +25,12 @@ Use `514 doc search` to search documentation by title or description.
 ## Examples
 
 ```bash
-514 doc search "deployment"
+514 docs search "deployment"
 514 docs search "workflow"
 ```
 
 ## Related
 
-- [`514 doc`](/hosting/cli/doc)
-- [`514 doc list`](/hosting/cli/doc/list)
-- [`514 doc show`](/hosting/cli/doc/show)
+- [`514 docs`](/hosting/cli/doc)
+- [`514 docs list`](/hosting/cli/doc/list)
+- [`514 docs show`](/hosting/cli/doc/show)

--- a/apps/framework-docs-v2/content/hosting/cli/doc/show.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/doc/show.mdx
@@ -1,17 +1,17 @@
 ---
-title: doc show
+title: docs show
 description: Show a documentation page by slug.
 order: 2
 ---
 
-# 514 doc show
+# 514 docs show
 
-Use `514 doc show` to display a documentation page by slug.
+Use `514 docs show` to display a documentation page by slug.
 
 ## Usage
 
 ```bash
-514 doc show [OPTIONS] <SLUG>
+514 docs show [OPTIONS] <SLUG>
 ```
 
 ## Arguments
@@ -28,12 +28,12 @@ Additional command-specific options:
 ## Examples
 
 ```bash
-514 doc show moosestack/olap
+514 docs show moosestack/olap
 514 docs show guides/chat-in-your-app#overview --web
 ```
 
 ## Related
 
-- [`514 doc`](/hosting/cli/doc)
-- [`514 doc list`](/hosting/cli/doc/list)
-- [`514 doc search`](/hosting/cli/doc/search)
+- [`514 docs`](/hosting/cli/doc)
+- [`514 docs list`](/hosting/cli/doc/list)
+- [`514 docs search`](/hosting/cli/doc/search)

--- a/apps/framework-docs-v2/content/hosting/cli/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/index.mdx
@@ -23,22 +23,25 @@ Argument convention:
 - `auth`: Manage authentication.
 - `org`: Manage organizations.
 - `project`: Manage projects (`list`, `link`, `setup`).
-- `deployment`: Manage deployments (`list`).
-- `doc`: Browse and search documentation (`list`, `show`, `search`, `browse`).
+- `deployment`: Manage deployments (`list`, `redeploy`, `wait`).
+- `docs`: Browse and search documentation (`list`, `show`, `search`, `browse`).
 - `cli`: Manage installed CLIs (`update`).
 - `env`: Manage environment variables (`list`, `get`, `set`, `delete`).
-- `agent`: Agent-focused read-only command surface.
-- `api-endpoint`: Manage API endpoint resources for a deployment.
-- `stream`: Manage stream resources for a deployment.
-- `function`: Manage function resources for a deployment.
-- `stream-to-table-sync`: Manage stream-to-table sync resources for a deployment.
-- `stream-to-stream-sync`: Manage stream-to-stream sync resources for a deployment.
-- `table`: Manage table resources for a deployment.
-- `view`: Manage view resources for a deployment.
-- `web-app`: Manage web-app resources for a deployment.
-- `workflow`: Manage workflow resources for a deployment.
-- `sql-resource`: Manage SQL resources for a deployment.
-- `materialized-view`: Manage materialized view resources for a deployment.
+- `metrics`: Query metrics and analytics.
+- `logs`: Query application logs.
+- `agent`: Configure coding agent integrations (`init`, `remove`).
+- `clickhouse`: Run queries against ClickHouse.
+- `api-endpoint`: Manage API endpoint resources.
+- `stream`: Manage stream resources.
+- `function`: Manage function resources.
+- `stream-to-table-sync`: Manage stream-to-table sync resources.
+- `stream-to-stream-sync`: Manage stream-to-stream sync resources.
+- `table`: Manage table resources.
+- `view`: Manage view resources.
+- `web-app`: Manage web-app resources.
+- `workflow`: Manage workflow resources.
+- `sql-resource`: Manage SQL resources.
+- `materialized-view`: Manage materialized view resources.
 - `help`: Print help for the given command.
 
 ## Aliases
@@ -88,7 +91,7 @@ Resources following this pattern:
 514 agent deployment list --project my-org/my-project
 514 env list --project my-org/my-project
 514 env set API_KEY=sk-123 --project my-org/my-project
-514 doc search "deployment"
+514 docs search "deployment"
 514 cli update moose
 ```
 

--- a/apps/framework-docs-v2/content/hosting/cli/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/cli/index.mdx
@@ -29,7 +29,7 @@ Argument convention:
 - `env`: Manage environment variables (`list`, `get`, `set`, `delete`).
 - `metrics`: Query metrics and analytics.
 - `logs`: Query application logs.
-- `agent`: Configure coding agent integrations (`init`, `remove`).
+- `agent`: Configure coding agent integrations and inspect resources.
 - `clickhouse`: Run queries against ClickHouse.
 - `api-endpoint`: Manage API endpoint resources.
 - `stream`: Manage stream resources.

--- a/apps/framework-docs-v2/content/hosting/getting-started.mdx
+++ b/apps/framework-docs-v2/content/hosting/getting-started.mdx
@@ -16,7 +16,7 @@ Use:
 - [`514 project link`](/hosting/cli/projects/link) (`514 project link [project_ref]`)
 - [`514 project setup`](/hosting/cli/projects/setup)
 - [`514 deployment list`](/hosting/cli/deployment/list) (`514 deployment list --project <org>/<project>`)
-- [`514 doc`](/hosting/cli/doc)
+- [`514 docs`](/hosting/cli/doc)
 - [`514 cli update`](/hosting/cli/cli/update)
 - [Fiveonefour hosting to local setup](/hosting/workflow/fiveonefour-to-local-setup)
 - [Setup failures](/hosting/troubleshooting/setup-failures)

--- a/apps/framework-docs-v2/content/hosting/index.mdx
+++ b/apps/framework-docs-v2/content/hosting/index.mdx
@@ -42,7 +42,7 @@ Verify the installation:
 - [`514 project link`](/hosting/cli/projects/link) - Attach an existing repository to a hosted project (`514 project link [project_ref]`).
 - [`514 project setup`](/hosting/cli/projects/setup) - Bootstrap a local workspace from an existing cloud project.
 - [`514 deployment list`](/hosting/cli/deployment/list) - List deployments for a project (`514 deployment list --project <org>/<project>`).
-- [`514 doc`](/hosting/cli/doc) - Browse and search docs from the CLI.
+- [`514 docs`](/hosting/cli/doc) - Browse and search docs from the CLI.
 - [`514 cli update`](/hosting/cli/cli/update) - Update installed CLI binaries.
 
 ## Workflow

--- a/apps/framework-docs-v2/content/hosting/troubleshooting/setup-failures.mdx
+++ b/apps/framework-docs-v2/content/hosting/troubleshooting/setup-failures.mdx
@@ -99,7 +99,7 @@ git push -u origin <branch-name>
 
 Recovery routes:
 - Repository branch rules in GitHub
-- Boreal project page for deployment status
+- 514 hosting project page for deployment status
 
 ## Related
 

--- a/apps/framework-docs-v2/content/moosestack/apis/auth.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/auth.mdx
@@ -251,11 +251,11 @@ Admin endpoints use API key authentication exclusively (configured separately fr
 
 ```bash
 # Option 1: CLI parameter
-moose remote plan --token your_plain_text_token
+moose plan --token your_plain_text_token
 
 # Option 2: Environment variable
 export MOOSE_ADMIN_TOKEN='your_plain_text_token'
-moose remote plan
+moose plan
 
 # Option 3: Config file
 # In moose.config.toml:

--- a/apps/framework-docs-v2/content/moosestack/configuration/project-settings.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/project-settings.mdx
@@ -33,5 +33,5 @@ language = "Typescript"
 |:----|:-------------|:-----|:--------|:------------|
 | `language` | `MOOSE_LANGUAGE` | String | "Typescript" | The programming language used for your data models and flows. |
 | `source_dir` | `MOOSE_SOURCE_DIR` | String | "app" | The directory containing your Moose application code. |
-| `load_infra` | `MOOSE_LOAD_INFRA` | Boolean | true | If `true`, `moose dev` spins up local Docker containers using the settings in [Infrastructure](/moosestack/configuration/infrastructure). If `false`, no containers are created, allowing you to connect to external infra. |
+| `load_infra` | `MOOSE_LOAD_INFRA` | Boolean | true | If `true`, `moose dev` starts local infrastructure using the settings in [Infrastructure](/moosestack/configuration/infrastructure). If `false`, no infrastructure is started, allowing you to connect to external services. |
 | `supported_old_versions` | N/A | Map | {} | Mapping of older project versions to their paths for backward compatibility. |

--- a/apps/framework-docs-v2/content/moosestack/engines/s3queue.mdx
+++ b/apps/framework-docs-v2/content/moosestack/engines/s3queue.mdx
@@ -106,7 +106,7 @@ secure_s3_events = OlapTable[S3Event]("s3_events", OlapConfig(
 ```bash filename="Terminal" copy
 export AWS_ACCESS_KEY_ID="AKIA..."
 export AWS_SECRET_ACCESS_KEY="your-secret-key"
-moose prod up
+moose prod
 ```
 
 **Benefits:**

--- a/apps/framework-docs-v2/content/moosestack/getting-started/from-clickhouse.mdx
+++ b/apps/framework-docs-v2/content/moosestack/getting-started/from-clickhouse.mdx
@@ -401,7 +401,7 @@ Seeded 'local_db' from 'remote_db'
 **Troubleshooting:**
 - Tables that don't exist on remote are automatically skipped with warnings
 - Use `--table <name>` to seed a specific table that exists in both databases
-- Check `moose ls table` to see your local tables
+- Check `moose ls --type tables` to see your local tables
 </Callout>
 
 <br />

--- a/apps/framework-docs-v2/content/moosestack/migrate/apply-planned-migrations-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/apply-planned-migrations-cli.mdx
@@ -33,6 +33,8 @@ moose migrate --clickhouse-url <CONNECTION_STRING>
 | Option | Description | Required |
 | :--- | :--- | :--- |
 | `--clickhouse-url` | The full connection string to the target ClickHouse database (e.g., `clickhouse://user:pass@host:9440/db`). | Yes |
+| `--redis-url` | Redis connection URL for state storage. Required when `state_config.storage = "redis"` in `moose.config.toml`. | No |
+| `--validate` | Validate migration files without executing them. Checks delta sequence consistency and detects semantic conflicts. Does not require ClickHouse or Redis. | No |
 
 ## Execution Lifecycle
 

--- a/apps/framework-docs-v2/content/moosestack/migrate/planned-migrations.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/planned-migrations.mdx
@@ -142,7 +142,7 @@ If you are using planned migrations for a breaking OLAP table change, see [Schem
 Drift occurs when the target database's schema changes between the time you generate a plan and the time you apply it.
 
 **How it works:**
-1. `moose generate` writes the current DB state to `remote_state.json`.
+1. `moose generate migration` writes the current DB state to `remote_state.json`.
 2. `moose migrate` (serverless) or `moose prod` (server runtime) compares `remote_state.json` with the *current* DB state.
 3. If they differ (hash mismatch), the migration **aborts**.
 

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -125,7 +125,7 @@ Start a local development environment with hot reload and automatic infrastructu
 moose dev [--mcp] [--no-infra] [--dockerless] [--timestamps] [--timing] [--log-payloads] [--yes-all] [--yes-destructive] [--yes-rename]
 ```
 - `--mcp`: Enable or disable the MCP server (default: true). Provides AI-assisted development tools at `http://localhost:4000/mcp`. See [MCP Server documentation](/moosestack/moosedev-mcp).
-- `--no-infra`: Skip starting Docker containers for infrastructure
+- `--no-infra`: Skip starting local infrastructure
 - `--dockerless`: Use native binaries for ClickHouse and Temporal instead of Docker
 - `--timestamps`: Show HH:MM:SS.mmm timestamps on all output lines
 - `--timing`: Show elapsed time for operations (e.g., "completed in 234ms")

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -44,8 +44,8 @@ moose harness init <name> <template> [--location <location>] [--agent <agent>] [
 - Zero-arg `moose harness init` starts the interactive wizard.
 - Arg-driven mode is non-interactive: if you pass flags or positionals, omitted values fall back to defaults.
 - `--agent`: Target specific coding agents instead of auto-detecting (repeatable)
-- `--name <name>`: Project name (use instead of positional arg to avoid ambiguity)
-- `--template <template>`: Template name (use instead of positional arg to avoid ambiguity)
+- `--name <name>`: Explicit project name. Use this when the name would otherwise conflict with a subcommand like `schema`.
+- `--template <template>`: Explicit template name. Use this with `--name` when positional parsing would be ambiguous.
 - `--from-remote <connection-string>`: Initialize from a remote ClickHouse database
 - `--lsp`: Install and configure MooseStack LSP (default)
 - `--no-lsp`: Skip MooseStack LSP installation/configuration
@@ -334,7 +334,7 @@ moose migrate [--clickhouse-url <url>] [--redis-url <url>] [--validate]
 ```
 - `--clickhouse-url`: ClickHouse connection URL
 - `--redis-url`: Redis connection URL for state storage
-- `--validate`: Validate migration files without executing them
+- `--validate`: Validate migration files without executing them. Checks delta sequence consistency and detects semantic conflicts. Does not require ClickHouse or Redis.
 
 ### Generate Dockerfile
 Generate a Dockerfile without building Docker images.

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -12,42 +12,29 @@ order: 1
 bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose
 ```
 
-## Core Commands
+## Global Flags
+
+These flags apply to all commands:
+
+- `--backtrace`: Print backtraces for all errors (same as RUST_LIB_BACKTRACE=1)
+- `-d, --debug`: Turn debugging information on
+
+## Setup
 
 ### Init
-Initializes a new Moose project.
+Initialize a new project.
 ```bash
 moose init <name> [template] [--location <location>] [--from-remote [<connection-string>]] [--custom-dockerfile] [--no-fail-already-exists]
 ```
 - `<name>`: Name of your app or service
-- `[template]`: Optional template to use for the project. Run `moose template list` to see the catalog.
-- `--location`: Optional location for your app or service
-- `--from-remote`: Optionally bootstrap the project from a remote ClickHouse database
-- `--custom-dockerfile`: Generate a custom Dockerfile at the project root for later customization
-- `--no-fail-already-exists`: Skip the directory existence check
-
-If you omit `template`, the CLI prompts you to pick one interactively.
-
-#### List Templates
-Lists available templates for project initialization.
-```bash
-moose template list
-```
-
-For editor integrations and other automation, you can request machine-readable output:
-
-```bash
-moose template list --json
-```
-
-The JSON payload is versioned for backwards-compatible tooling. It includes:
-
-- `schema_version`: version of the JSON response schema
-- `template_version`: version of the template manifest being listed
-- `templates`: visible templates available for initialization
+- `[template]`: Template to use. Run `moose template list` to see the catalog. Omit to pick interactively.
+- `--location, -l`: Location for your app or service
+- `--from-remote`: Initialize from a remote database
+- `--custom-dockerfile`: Generate a custom Dockerfile at project root
+- `--no-fail-already-exists`: Allow init in an existing directory
 
 ### Harness Init
-Initializes a Moose project and sets up the developer harness in one flow.
+Initialize a project and set up the developer harness in one flow.
 
 ```bash
 moose harness init
@@ -55,37 +42,42 @@ moose harness init <name> <template> [--location <location>] [--agent <agent>] [
 ```
 
 - Zero-arg `moose harness init` starts the interactive wizard.
-  Template selection is presented as a validated numbered list, so typos are caught before initialization continues.
-- `moose harness init` scaffolds a project and configures the harness in one flow. For existing projects, use `514 agent init` to install shared skills without rerunning project initialization.
-- MooseStack MCP is configured through the `moose mcp` stdio proxy where the target coding agent supports local stdio servers, avoiding a hard-coded `localhost:4000/mcp` dependency in those agent configs.
-- Arg-driven mode is non-interactive: if you pass flags or positionals, omitted optional values fall back to defaults instead of prompting. MooseStack LSP installation defaults to on.
-- `--agent`: Repeat to target specific coding agents. Omit to auto-detect supported agents.
-- `--name <name>`: Explicitly set the project name when it would otherwise collide with a harness subcommand such as `schema`.
-- `--template <template>`: Explicitly set the template. Combine with `--name` for collision-safe invocations like `moose harness init --name schema --template typescript`.
-- `--from-remote <connection-string>`: Bootstrap the project from a remote ClickHouse cluster.
-- `--lsp`: Install and configure the MooseStack LSP where supported. This is the default behavior.
-- `--no-lsp`: Skip MooseStack LSP installation and configuration explicitly.
-- `--branch <name>`: Install harness skills from a specific `agent-skills` Git branch instead of `main`.
-- `--no-fail-already-exists`: Reuse an existing target directory instead of treating it as an error.
-- `--custom-dockerfile`: Generate a customizable Dockerfile at the scaffolded project root.
-- `--input <path>`: Read structured JSON input from a file. Use `--input -` to read JSON from stdin.
+- Arg-driven mode is non-interactive: if you pass flags or positionals, omitted values fall back to defaults.
+- `--agent`: Target specific coding agents instead of auto-detecting (repeatable)
+- `--name <name>`: Project name (use instead of positional arg to avoid ambiguity)
+- `--template <template>`: Template name (use instead of positional arg to avoid ambiguity)
+- `--from-remote <connection-string>`: Initialize from a remote ClickHouse database
+- `--lsp`: Install and configure MooseStack LSP (default)
+- `--no-lsp`: Skip MooseStack LSP installation/configuration
+- `--branch <name>`: Git branch of the agent-skills repo to install from (default: main)
+- `--no-fail-already-exists`: Allow init in an existing directory
+- `--custom-dockerfile`: Generate a custom Dockerfile at project root
+- `--input <path>`: Read structured JSON input from a file, or use `-` for stdin
 
-For automation and editor integrations, you can inspect the versioned input contract:
+For automation, inspect the versioned input contract:
 
 ```bash
 moose harness init schema --json
 ```
 
-Additional examples:
+Examples:
 
 ```bash
-moose harness init my-app typescript --branch nico/eng-2598 --agent codex
-moose harness init my-app typescript --no-lsp --agent none
-moose harness init my-app typescript --no-fail-already-exists --custom-dockerfile
+moose harness init my-app typescript --agent codex
+moose harness init --name schema --template typescript --agent none
+moose harness init my-app python-empty --location ./sandbox
+moose harness init --input request.json
+cat request.json | moose harness init --input -
 ```
 
-### Component
-Lists available components you can add to your project.
+### Template List
+List available templates for project initialization.
+```bash
+moose template list [--json]
+```
+
+### Component List
+List available components you can add to your project.
 
 > **Note:** This command is experimental. Component APIs and available components may change in future releases.
 
@@ -94,7 +86,7 @@ moose component list
 ```
 
 ### Add
-Adds a pre-built component to an existing project. Downloads the component files from a registry. Some components also install dependencies; others copy a self-contained package and print the manual follow-up steps.
+Add a pre-built component to an existing project.
 
 > **Note:** This command is experimental. Component APIs and available components may change in future releases.
 
@@ -104,344 +96,279 @@ moose add <component> [--dir <path>] [--overwrite] [--yes]
 
 **Components:**
 
-```bash
-# Add an MCP server to a Moose project
-moose add mcp-server [--dir <moose-project-dir>]
-
-# Add a chat UI to a Next.js app
-moose add chat [--dir <nextjs-app-dir>]
-
-# Add a standalone benchmark package to a new directory
-mkdir query-benchmarks
-moose add benchmark --dir ./query-benchmarks
-```
+- `mcp-server`: MCP server with ClickHouse query tools at /tools
+- `chat`: AI chat panel for Next.js (requires an MCP server)
+- `benchmark`: Query benchmark package for a TypeScript Moose project
 
 **Flags:**
 - `--dir, -d`: Target directory (defaults to current directory)
 - `--overwrite`: Replace files that already exist
-- `--yes, -y`: Skip confirmation prompt (useful for scripting or LLM-driven workflows)
+- `--yes, -y`: Skip confirmation prompts
 
-**Example:**
+**Examples:**
 ```bash
-# From a monorepo root with moose/ and web/ packages
-moose add mcp-server --dir moose
-moose add chat --dir web
-mkdir query-benchmarks && moose add benchmark --dir query-benchmarks
+moose add mcp-server --dir packages/moosestack-service
+moose add chat --dir packages/web-app
+moose add benchmark --dir moose
 ```
 
-After installing, follow the printed "Next steps" to wire up environment variables and start the services.
-
-The `benchmark` component scaffolds a standalone benchmark package into the directory specified by `--dir`. Dependencies are installed automatically. After scaffolding, edit `benchmark.config.ts` to import your compiled query model from your Moose project, define the base query and scenarios, run `moose build` in your Moose project, then run the benchmark scripts (`npm test`, `npm run bench`).
-
-### Build
-Builds your Moose project.
-```bash
-moose build [--docker] [--amd64] [--arm64]
-```
-- `--docker`: Generate a Dockerfile and build Docker image(s)
-- `--amd64`: Build for AMD64 architecture
-- `--arm64`: Build for ARM64 architecture
+## Develop
 
 ### Dev
-Starts a local development environment with hot reload and automatic infrastructure management.
+Start a local development environment with hot reload and automatic infrastructure management.
 
 **Prerequisites:** Install project dependencies before running `moose dev`:
 - **TypeScript**: `npm install` or `pnpm install`
 - **Python**: `pip install -r requirements.txt`
 
 ```bash
-moose dev [--mcp] [--no-infra] [--timestamps] [--timing] [--log-payloads] [--yes-all] [--yes-destructive] [--yes-rename]
+moose dev [--mcp] [--no-infra] [--dockerless] [--timestamps] [--timing] [--log-payloads] [--yes-all] [--yes-destructive] [--yes-rename]
 ```
-- `--mcp`: Enable or disable the MCP (Model Context Protocol) server (default: true). The MCP server provides AI-assisted development tools at `http://localhost:4000/mcp`. See [MCP Server documentation](/moosestack/moosedev-mcp) for details.
-- `--no-infra`: Skip starting docker containers for infrastructure
-- `--timestamps`: Show HH:MM:SS.mmm timestamps on all output lines (default: false)
-- `--timing`: Show elapsed time for operations, e.g., "finished in 234ms" or "finished in 2s 300ms" (default: false)
-- `--log-payloads`: Log payloads for debugging data flow (see PAYLOAD prefixed lines in `moose logs --tail`)
-- `--yes-all`: Skip all confirmation prompts (renames and destructive operations). Equivalent to passing both `--yes-destructive` and `--yes-rename`. Can also be set via `MOOSE_ACCEPT_ALL=1`.
-- `--yes-destructive`: Skip the interactive confirmation prompt for destructive operations (table, column, view, and materialized-view removals). Useful for CI/CD or when you intentionally want to accept all destructive schema changes. Can also be set via `MOOSE_ACCEPT_DESTRUCTIVE=1`.
-- `--yes-rename`: Skip the interactive confirmation prompt for detected column renames, accepting them as genuine renames. Can also be set via `MOOSE_ACCEPT_RENAME=1`.
+- `--mcp`: Enable or disable the MCP server (default: true). Provides AI-assisted development tools at `http://localhost:4000/mcp`. See [MCP Server documentation](/moosestack/moosedev-mcp).
+- `--no-infra`: Skip starting Docker containers for infrastructure
+- `--dockerless`: Use native binaries for ClickHouse and Temporal instead of Docker
+- `--timestamps`: Show HH:MM:SS.mmm timestamps on all output lines
+- `--timing`: Show elapsed time for operations (e.g., "completed in 234ms")
+- `--log-payloads`: Log payloads at ingest API and streaming functions for debugging
+- `--yes-all`: Skip all confirmation prompts. Can also be set via `MOOSE_ACCEPT_ALL=1`.
+- `--yes-destructive`: Auto-approve destructive operations. Can also be set via `MOOSE_ACCEPT_DESTRUCTIVE=1`.
+- `--yes-rename`: Auto-approve column renames. Can also be set via `MOOSE_ACCEPT_RENAME=1`.
 
-When debugging slow hot reloads, use `--timing` to identify which operation is the bottleneck; use `--timestamps` to correlate events across runs.
-
-**Running in Background:**
-For AI assistants or when you need to run other commands in the same terminal:
-
+**Running in background:**
 ```bash
 nohup moose dev &
 ```
 
-**Example with timing flags:**
+### Build
+Build your Moose project.
 ```bash
-# Basic dev mode
-moose dev
-
-# With timestamps for debugging
-moose dev --timestamps
-
-# With performance timing
-moose dev --timing
-
-# Both together for detailed monitoring
-moose dev --timestamps --timing
+moose build [--docker] [--amd64] [--arm64]
 ```
-
-**Sample output with `--timing`:**
-```
-Planning finished in 145ms
-Validation finished in 23ms
-Execution finished in 1s 200ms
-Persist State finished in 45ms
-OpenAPI Gen finished in 89ms
-```
-
-**Sample output with `--timestamps`:**
-```
-14:23:45.123 Planning started
-14:23:45.268 Planning completed
-14:23:45.291 Validation started
-14:23:45.314 Validation completed
-14:23:45.337 Execution started
-14:23:46.537 Execution completed
-```
-
-The development server includes:
-- Hot reload for code changes
-- Automatic Docker container management (ClickHouse, Redpanda, Temporal, Redis)
-- Built-in MCP server for AI assistant integration
-- Health monitoring and metrics endpoints
-
-### Prod
-Starts Moose in production mode for cloud deployments.
-```bash
-moose prod
-```
+- `--docker, -d`: Build for Docker
+- `--amd64`: Build for amd64 architecture
+- `--arm64`: Build for arm64 architecture
 
 ### Check
-Checks the project for non-runtime errors.
+Check the project for non-runtime errors.
 ```bash
 moose check [--write-infra-map]
 ```
+- `--write-infra-map`: Write the infrastructure map to disk
 
 ### Clean
-Clears temporary data and stops development infrastructure.
+Clear temporary data and stop development infrastructure.
 ```bash
 moose clean
 ```
 
-### Seed (ClickHouse)
-Seed your local ClickHouse from a remote ClickHouse instance.
+### Prod
+Start a production environment.
 ```bash
-moose seed clickhouse [--connection-string <CONNECTION_STRING>] [--table <name>] [--limit <n> | --all] [--order-by <clause>] [--report=true|false]
+moose prod [--start-include-dependencies]
 ```
-- `--connection-string`: Remote ClickHouse connection string. If omitted, the CLI uses `MOOSE_SEED_CLICKHOUSE_URL`.
-- `--table`: Seed only the specified table (default: all Moose tables).
-- `--limit`: Copy up to N rows (mutually exclusive with `--all`). When omitted, defaults to 1000. Large limits are automatically batched.
-- `--all`: Copy entire table(s) in batches, ignoring all limits (mutually exclusive with `--limit`).
-- `--order-by`: ORDER BY clause for the query (e.g., `--order-by 'timestamp DESC'`).
-- `--report`: Report row counts after seeding (default: `true`). Counts shown for default database only; use `--report=false` to skip.
+- `--start-include-dependencies`: Include and manage dependencies (ClickHouse, Redpanda, etc.) using Docker containers
 
-**Connection String Format:**
-The connection string must use ClickHouse native protocol:
+### MCP
+Run an MCP proxy server for AI agents. Provides a stdio interface that proxies to the Moose dev server's MCP endpoint.
 ```bash
-# ClickHouse native protocol (secure connection)
-clickhouse://username:password@host:9440/database
+moose mcp [--host <host>] [--port <port>]
 ```
+- `--host`: Host of the dev server to proxy to (auto-detected from project config if omitted)
+- `--port`: Port of the dev server to proxy to (auto-detected from project config if omitted)
 
-**Important:** 
-- The data transfer uses ClickHouse's native TCP protocol via `remoteSecure()` function. The remote ClickHouse server must have the native TCP port accessible (typically port 9440 for secure connections).
-- **Smart table matching**: The command automatically validates tables between local and remote databases. Tables that don't exist on the remote are gracefully skipped with warnings.
-- Use `--table <name>` to seed a specific table that exists in both local and remote databases.
+## Data
 
-**User Experience:**
-- Progress indicator shows seeding status with spinner
-- Tables that don't exist on remote are automatically skipped with clear warnings
-- Final summary shows successful and skipped tables
-- Clean, streamlined output focused on results
-
-Notes:
-- Seeding is batched automatically for large datasets; Ctrl+C finishes the current batch gracefully.
-- Use env var fallback:
+### Query
+Execute SQL queries against ClickHouse.
 ```bash
-export MOOSE_SEED_CLICKHOUSE_URL='clickhouse://username:password@host:9440/database'
+moose query [<query>] [-f <file>] [-l <limit>] [-c <language>] [-p]
 ```
+- `<query>`: SQL query string (optional if using `--file` or stdin)
+- `-f, --file <PATH>`: Read query from file
+- `-l, --limit <NUM>`: Maximum rows to return (default: 10000)
+- `-c, --format-query <LANGUAGE>`: Format query as code literal (`python`|`typescript`). Skips execution.
+- `-p, --prettify`: Prettify SQL before formatting (requires `--format-query`)
 
-### Truncate
-Truncate tables or delete the last N rows from local ClickHouse tables.
+**Examples:**
 ```bash
-moose truncate [TABLE[,TABLE...]] [--all] [--rows <n>]
-```
-- `TABLE[,TABLE...]`: One or more table names (comma-separated). Omit to use `--all`.
-- `--all`: Apply to all non-view tables in the current database (mutually exclusive with listing tables).
-- `--rows <n>`: Delete the last N rows per table; omit to remove all rows (TRUNCATE).
-
-Notes:
-- For `--rows`, the command uses the table ORDER BY when available; otherwise it falls back to a timestamp heuristic.
-
-## Monitoring Commands
-
-### Logs
-View Moose logs.
-```bash
-moose logs [--tail] [--filter <search_string>]
-```
-- `--tail`: Follow logs in real-time
-- `--filter`: Filter logs by specific string
-
-### Ps
-View Moose processes.
-```bash
-moose ps
+moose query "SELECT count(*) FROM users"
+moose query -f queries/analysis.sql
+cat query.sql | moose query
+moose query -c python -p "SELECT id, name FROM users WHERE active = 1 ORDER BY name"
 ```
 
-### Ls
-View Moose primitives & infrastructure.
-```bash
-moose ls [--limit <n>] [--version <version>] [--streaming] [--type <type>] [--name <name>] [--json]
-```
-- `--limit`: Limit output (default: 10)
-- `--version`: View specific version
-- `--streaming`: View streaming topics
-- `--type`: Filter by infrastructure type (tables, streams, ingestion, sql_resource, consumption)
-- `--name`: Filter by name
-- `--json`: Output in JSON format
-
-### Metrics
-View live metrics from your Moose application.
-```bash
-moose metrics
-```
+**Requirements:** Requires `moose dev` to be running. Returns results as newline-delimited JSON.
 
 ### Peek
 View data from a table or stream.
 ```bash
-moose peek <name> [--limit <n>] [--file <path>] [-t|--table] [-s|--stream]
+moose peek <name> [-l <limit>] [-f <path>] [-t|--table] [-s|--stream]
 ```
 - `<name>`: Name of the table or stream to peek
-- `--limit`: Number of rows to view (default: 5)
-- `--file`: Output to a file
-- `-t, --table`: View data from a table (default if neither flag specified)
+- `-l, --limit`: Number of rows to view (default: 5)
+- `-f, --file`: Output to a file
+- `-t, --table`: View data from a table
 - `-s, --stream`: View data from a stream/topic
 
-### Query
-Execute arbitrary SQL queries against your ClickHouse database during development.
+### Seed
+Seed your local ClickHouse from a remote ClickHouse instance.
 ```bash
-# Direct query
-moose query "SELECT count(*) FROM users"
-
-# From file
-moose query -f queries/analysis.sql
-
-# From stdin
-cat query.sql | moose query
-
-# With limit
-moose query "SELECT * FROM events" --limit 100
+moose seed clickhouse [--clickhouse-url <URL>] [--table <name>] [--limit <n> | --all] [--order-by <clause>] [--report]
 ```
-- `<query>`: SQL query string to execute (optional if using --file or stdin)
-- `-f, --file <PATH>`: Read query from file
-- `-l, --limit <NUM>`: Maximum rows to return (default: 10000)
+- `--clickhouse-url`: Remote ClickHouse connection URL. Alias: `--connection-string`. Falls back to `MOOSE_SEED_CLICKHOUSE_URL` env var.
+- `--table`: Only seed a specific table
+- `--limit`: Maximum rows to copy per table (mutually exclusive with `--all`)
+- `--all`: Copy all rows, ignoring limit (mutually exclusive with `--limit`)
+- `--order-by`: ORDER BY clause for the seed query
+- `--report`: Show row counts after seeding (default: true)
 
-**Requirements:**
-- Requires `moose dev` to be running
-- Executes queries against your development ClickHouse instance
+### Truncate
+Truncate tables or delete the last N rows.
+```bash
+moose truncate [TABLE[,TABLE...]] [--all] [--rows <n>]
+```
+- `TABLE[,TABLE...]`: One or more table names (comma-separated). Omit to use `--all`.
+- `--all`: Apply to all non-view tables in the current database
+- `--rows <n>`: Number of most recent rows to delete per table. Omit to delete all rows (TRUNCATE).
 
-**Output:**
-- Returns results as newline-delimited JSON
-- One JSON object per row
-- Row count summary at end
+### Refresh
+Integrate tables from a remote Moose instance.
+```bash
+moose refresh [--url <url>] [--token <token>]
+```
+- `--url`: Remote Moose instance URL (default: http://localhost:4000)
+- `--token`: API token for the remote Moose instance
 
-#### Formatting Queries for Code
+### DB Pull
+Import external database schemas. Refreshes `EXTERNALLY_MANAGED` table definitions from a remote ClickHouse instance.
+```bash
+moose db pull [--clickhouse-url <URL>] [--file-path <path>]
+```
+- `--clickhouse-url`: ClickHouse connection URL (e.g., `clickhouse://user:pass@host:port/database`)
+- `--file-path`: Output file for external table definitions (defaults to `app/externalModels.ts` or `app/external_models.py`)
 
-Use the `-c/--format-query` flag to format SQL queries as code literals instead of executing them:
+See the full guide: [DB Pull](/moosestack/olap/db-pull)
+
+### Kafka Pull
+Discover topics from a Kafka/Redpanda cluster and optionally fetch JSON Schemas from Schema Registry to generate typed external models.
 
 ```bash
-# Format as Python (raw string)
-moose query -c python "SELECT * FROM users WHERE email REGEXP '[a-z]+'"
-# Output:
-# r"""
-# SELECT * FROM users WHERE email REGEXP '[a-z]+'
-# """
+moose kafka pull <bootstrap> [--path <PATH>] [--include <glob>] [--exclude <glob>] [--schema-registry <URL>]
+```
+- `<bootstrap>`: Kafka bootstrap servers (e.g., `localhost:19092`)
+- `--path`: Output directory for generated files
+- `--include`: Include pattern (glob, default: `*`)
+- `--exclude`: Exclude pattern (glob, default: `{__consumer_offsets,_schemas}`)
+- `--schema-registry`: Schema Registry base URL (e.g., `http://localhost:8081`)
 
-# Format as TypeScript (template literal)
-moose query -c typescript "SELECT * FROM events"
-# Output:
-# `
-# SELECT * FROM events
-# `
+## Workflows
 
-# Works with file input
-moose query -c python -f my_query.sql
+### Run
+```bash
+moose workflow run <name> [--input <json>]
+```
+- `<name>`: Name of the workflow to run
+- `--input, -i`: JSON input parameters for the workflow
 
-# Prettify SQL before formatting (adds line breaks and indentation)
-moose query -c python -p "SELECT id, name FROM users WHERE active = 1 ORDER BY name"
-# Output:
-# r"""
-# SELECT id, name
-# FROM users
-#     WHERE active = 1
-#     ORDER BY name
-# """
+### Resume
+```bash
+moose workflow resume <name> --from <task>
+```
+- `<name>`: Name of the workflow to resume
+- `--from`: Task to resume from
 
-# Use heredoc for multi-line SQL queries (no need to escape quotes)
-moose query -c python -p <<EOF
-SELECT
-    b.id,
-    b.name,
-    b.email,
-    COUNT(o.id) as order_count,
-    SUM(o.total) as total_spent
-FROM local.Bar b
-LEFT JOIN local.Orders o ON b.id = o.user_id
-WHERE b.status = 'active'
-    AND o.created_at > '2024-01-01'
-GROUP BY b.id, b.name, b.email
-HAVING COUNT(o.id) > 5
-ORDER BY total_spent DESC
-LIMIT 50
-EOF
-
-# Supported languages: python (py), typescript (ts)
-# Prettify flag: -p, --prettify (only works with --format-query)
+### List
+```bash
+moose workflow list [--json]
 ```
 
-**Use case:** Iterate on SQL queries in the CLI, then format and paste into your application code without manual escaping. Use `--prettify` to clean up messy one-line queries.
+### History
+```bash
+moose workflow history [--status <status>] [--limit <n>] [--json]
+```
+- `--status, -s`: Filter by status (running, completed, failed)
+- `--limit, -l`: Number of workflows shown (default: 10)
 
-## Generation Commands
+### Status
+```bash
+moose workflow status <name> [--id <run-id>] [--verbose] [--json]
+```
+- `<name>`: Name of the workflow
+- `--id`: Run ID (defaults to most recent)
+- `--verbose`: Verbose output
+
+### Cancel
+```bash
+moose workflow cancel <name>
+```
+
+### Pause / Unpause
+```bash
+moose workflow pause <name>
+moose workflow unpause <name>
+```
+
+## Deploy
+
+### Plan
+Preview infrastructure changes for next deployment.
+
+**For Moose Server deployments:**
+```bash
+moose plan [--url <url>] [--token <token>] [--json]
+```
+- `--url`: Remote Moose instance URL (default: http://localhost:4000)
+- `--token`: API token for the remote Moose instance
+- `--json`: Output plan as JSON
+
+**For serverless deployments:**
+```bash
+moose plan --clickhouse-url <url>
+```
+- `--clickhouse-url`: ClickHouse connection URL
+
+### Migrate
+Execute a migration plan against a remote ClickHouse database.
+```bash
+moose migrate [--clickhouse-url <url>] [--redis-url <url>] [--validate]
+```
+- `--clickhouse-url`: ClickHouse connection URL
+- `--redis-url`: Redis connection URL for state storage
+- `--validate`: Validate migration files without executing them
 
 ### Generate Dockerfile
-Generate a Dockerfile for your project without building Docker images.
+Generate a Dockerfile without building Docker images.
 ```bash
 moose generate dockerfile
 ```
-Requires `custom_dockerfile = true` in `moose.config.toml`. The generated Dockerfile is placed at `dockerfile_path` (default: `./Dockerfile`) and can be customized for your deployment needs.
+Requires `custom_dockerfile = true` in `moose.config.toml`.
 
 ### Generate Hash Token
-Generate authentication tokens for API access.
+Generate an API key hash and bearer token pair for authentication.
 ```bash
-moose generate hash-token
+moose generate hash-token [--json]
 ```
-Generates both a plain-text Bearer token and its corresponding hashed version for authentication.
 
-### Generate Migration Plan (OLAP)
+### Generate Migration
 Create an ordered ClickHouse DDL plan by comparing a remote instance with your local code.
 ```bash
-moose generate migration --url https://<remote-env> --token <api-token> --save
+moose generate migration [--url <url> --token <token> | --clickhouse-url <url>] [--redis-url <url>] [--save] [--yes-all] [--yes-destructive] [--yes-rename] [--no-auto-backfill-sql]
 ```
 
 **Connection options** (one required):
-- `--url <URL>` + `--token <TOKEN>`: Connect to a running Moose server
-- `--clickhouse-url <URL>`: Connect directly to ClickHouse (for serverless deployments). Also requires `--redis-url` when `state_config.storage = "redis"`.
+- `--url` + `--token`: Connect to a running Moose server
+- `--clickhouse-url`: Connect directly to ClickHouse (for serverless). Also requires `--redis-url` when `state_config.storage = "redis"`.
 
-All connection flags accept environment-variable fallbacks: `MOOSE_CLICKHOUSE_CONFIG__URL` for `--clickhouse-url` and `MOOSE_REDIS_CONFIG__URL` for `--redis-url`.
+All connection flags accept env var fallbacks: `MOOSE_CLICKHOUSE_CONFIG__URL` for `--clickhouse-url` and `MOOSE_REDIS_CONFIG__URL` for `--redis-url`.
 
 **Output options:**
-- `--save`: Write `./migrations/plan.yaml`, `remote_state.json`, and `local_infra_map.json`. Omit to output plan YAML to stdout.
+- `--save`: Save migration files to the `migrations/` directory. Omit to output plan YAML to stdout.
 
 **Confirmation flags:**
-- `--yes-all`: Skip all confirmation prompts (renames and destructive operations). Can also be set via `MOOSE_ACCEPT_ALL=1`.
-- `--yes-destructive`: Skip the confirmation prompt for destructive operations (table/column drops, view removals, table recreates). Can also be set via `MOOSE_ACCEPT_DESTRUCTIVE=1`.
-- `--yes-rename`: Skip the confirmation prompt for detected column renames, accepting them as genuine renames. Can also be set via `MOOSE_ACCEPT_RENAME=1`.
-- `--no-auto-backfill-sql`: Disable automatic backfill SQL generation for versioned tables.
+- `--yes-all`: Skip all confirmation prompts. Can also be set via `MOOSE_ACCEPT_ALL=1`.
+- `--yes-destructive`: Auto-approve destructive operations. Can also be set via `MOOSE_ACCEPT_DESTRUCTIVE=1`.
+- `--yes-rename`: Auto-approve column renames. Can also be set via `MOOSE_ACCEPT_RENAME=1`.
+- `--no-auto-backfill-sql`: Disable automatic backfill SQL generation
 
 Requires OLAP to be enabled in `moose.config.toml`:
 ```toml filename="moose.config.toml" copy
@@ -449,156 +376,62 @@ Requires OLAP to be enabled in `moose.config.toml`:
 olap = true
 ```
 
-### DB Pull (External Tables)
-Refresh `EXTERNALLY_MANAGED` table definitions from a remote ClickHouse instance.
+## Observe
+
+### Ls
+View Moose primitives and infrastructure.
 ```bash
-moose db pull --clickhouse-url <URL> [--file-path <OUTPUT_PATH>]
+moose ls [--type <type>] [--name <name>] [--json]
 ```
-- `--clickhouse-url`: ClickHouse URL (e.g., `clickhouse://user:pass@host:port/database` or `https://user:pass@host:port/database`). Native `clickhouse://` is auto-converted to HTTP(S). Include `?database=` or the CLI will query the current database.
-- `--file-path`: Optional override for the generated external models file (defaults to `app/externalModels.ts` or `app/external_models.py`).
+- `--type`: Filter by infrastructure type
+- `--name`: Filter by name (supports partial matching)
+- `--json`: Output in JSON format
 
-Notes:
-- Only tables marked `EXTERNALLY_MANAGED` in your code are refreshed.
-- The command writes a single external models file and overwrites the file on each run.
-- See the full guide: [DB Pull](/moosestack/olap/db-pull)
-
-### Kafka
-
-#### Pull external topics and schemas
-Discover topics from a Kafka/Redpanda cluster and optionally fetch JSON Schemas from Schema Registry to emit typed external models.
-
+### Ps
+View Moose processes.
 ```bash
-moose kafka pull <bootstrap> [--path <PATH>] [--include <glob>] [--exclude <glob>] [--schema-registry <URL>]
-```
-- `<bootstrap>`: Kafka bootstrap servers, e.g. `localhost:19092`
-- `--path`: Output directory for generated files. Defaults to `app/external-topics` (TS) or `app/external_topics` (Python).
-- `--include`: Include pattern (glob). Default: `*`
-- `--exclude`: Exclude pattern (glob). Default: `{__consumer_offsets,_schemas}`
-- `--schema-registry`: Base URL for Schema Registry, e.g. `http://localhost:8081`
-
-Notes:
-- JSON Schema is supported initially; Avro/Protobuf planned.
-- Generated files will be overwritten on subsequent runs.
-
-## Workflow Management
-
-### Workflow
-```bash
-moose workflow <command> [options]
+moose ps
 ```
 
-Available workflow commands:
-- `init <name> [--tasks <task-list>] [--task <task>...]`: Initialize a new workflow
-- `run <name> [--input <json>]`: Run a workflow
-- `resume <name> --from <task>`: Resume a workflow from a specific task
-- `list [--json]`: List registered workflows
-- `history [--status <status>] [--limit <n>] [--json]`: Show workflow history
-- `terminate <name>`: Terminate a workflow
-- `pause <name>`: Pause a workflow
-- `unpause <name>`: Unpause a workflow
-- `status <name> [--id <run-id>] [--verbose] [--json]`: Get workflow status
-
-## Help & Support Commands
-
-### Feedback
-Send feedback, report bugs, or join the Moose community.
+### Logs
+View Moose logs.
 ```bash
-moose feedback [message] [--email <email>] [--bug] [--community]
+moose logs [--tail] [--filter <search_string>]
+```
+- `-t, --tail`: Follow logs in real-time
+- `-f, --filter`: Filter logs by a specific string
+
+### Metrics
+Open the live metrics console.
+```bash
+moose metrics
 ```
 
-**Send feedback:**
-```bash
-# Send feedback (will prompt for optional email)
-moose feedback "loving the DX!"
-
-# Include email for follow-up
-moose feedback "great tool!" --email you@example.com
-```
-
-**Report a bug:**
-```bash
-# Open GitHub Issues with system info pre-filled
-moose feedback --bug "crash on startup"
-
-# Bug report without description
-moose feedback --bug
-```
-
-**Join the community:**
-```bash
-# Open Moose Slack community in your browser
-moose feedback --community
-```
-
-**Options:**
-- `[message]`: Your feedback message (required for feedback and bug reports)
-- `--email <email>`: Optional email address for follow-up on feedback
-- `--bug`: Open GitHub Issues for bug reporting with environment details
-- `--community`: Open Moose Slack community invite
-
-**Notes:**
-- Feedback requires telemetry to be enabled
-- Email is optional and only used if you want the team to follow up
-- Bug reports include CLI version, OS, architecture, and log file paths
-- If email is not provided via flag, you'll be prompted interactively (optional)
-
-## Planning and Deployment
-
-### Plan
-Display infrastructure changes for the next production deployment.
-
-**For Moose Server deployments:**
-```bash
-moose plan [--url <url>] [--token <token>]
-```
-- `--url`: Remote Moose instance URL (default: http://localhost:4000)
-- `--token`: API token for authentication
-
-**For Serverless deployments:**
-```bash
-moose plan --clickhouse-url <url>
-```
-- `--clickhouse-url`: ClickHouse connection URL (e.g., `clickhouse://user:pass@host:port/database`)
-
-### Refresh
-Integrate matching tables from a remote instance into the local project.
-```bash
-moose refresh [--url <url>] [--token <token>]
-```
-- `--url`: Remote Moose instance URL (default: http://localhost:4000)
-- `--token`: API token for authentication
-
-## Documentation & Feedback
+## Help
 
 ### Docs
-Fetch and display LLM-optimized documentation in the terminal.
+Browse and search documentation in the terminal.
 ```bash
 moose docs [<slug>] [-l <LANG>] [--raw] [--expand] [--web]
 ```
 - `<slug>`: Documentation page slug (e.g., `moosestack/olap`). Omit to show the table of contents. Slugs are case-insensitive.
-- `-l, --lang <LANG>`: Language for documentation: `typescript` (ts) or `python` (py). Auto-detected from your project language or saved preference.
+- `-l, --lang <LANG>`: Language: `typescript` (ts) or `python` (py). Auto-detected from your project.
 - `--raw`: Output raw content without formatting (for piping to other tools)
-- `--expand`: Show full expanded tree with all leaf pages and guide section headings
-- `--web`: Open documentation page in your web browser instead of printing
+- `--expand`: Show full expanded tree with all leaf pages
+- `--web`: Open documentation page in your web browser
 
-#### Subcommands
+**Subcommands:**
 
-- `moose docs browse [--web]`: Interactively browse and select a documentation page with a hierarchical drill-down picker
-- `moose docs search <query> [--expand]`: Search documentation by title or description. Use `--expand` to also search within page headings (H1/H2/H3) — slower, as it fetches all pages.
+- `moose docs browse [--web]`: Interactively browse and select a documentation page
+- `moose docs search <query> [--expand]`: Search documentation by title or description. Use `--expand` to also search within page headings.
 
-#### Guide Section Navigation
-
-Guide pages are large and support section navigation with `#anchor` syntax:
+**Guide section navigation:**
 ```bash
 moose docs guides/chat-in-your-app#overview
 moose docs guides/chat-in-your-app#setup
 ```
-If the section is not found, available sections are listed. When using `browse` on a guide page, a secondary section picker is shown.
 
-#### Use with AI Clients
-
-The `--raw` flag outputs unformatted markdown, making it easy to pipe documentation to AI clients for processing:
-
+**Use with AI clients:**
 ```bash
 moose docs --raw guides/chat-in-your-app#setup | claude "do this step, ask me any questions you need to execute"
 ```
@@ -606,12 +439,11 @@ moose docs --raw guides/chat-in-your-app#setup | claude "do this step, ask me an
 This pattern works with any AI client that accepts stdin, allowing you to get AI assistance on specific documentation sections.
 
 ### Feedback
-Submit feedback, report bugs, or join the community.
+Submit feedback or report issues.
 ```bash
-moose feedback [MESSAGE] [--bug] [--community]
+moose feedback [message] [--email <email>] [--bug] [--community]
 ```
-- `[MESSAGE]`: Feedback message (e.g., `moose feedback "loving the DX!"`)
+- `[message]`: Feedback message (e.g., `moose feedback "loving the DX!"`)
+- `--email`: Your email address for follow-up
 - `--bug`: Report a bug (opens GitHub Issues with system info and log paths)
 - `--community`: Join the Moose community on Slack
-
-This reference reflects the current state of the Moose CLI based on the source code in the framework-cli directory. The commands are organized by their primary functions and include all available options and flags.

--- a/apps/framework-docs-v2/content/moosestack/olap/model-table.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/model-table.mdx
@@ -1034,7 +1034,7 @@ secure_s3_events = OlapTable[S3Event]("s3_events", OlapConfig(
 ```bash filename="Terminal" copy
 export AWS_ACCESS_KEY_ID="AKIA..."
 export AWS_SECRET_ACCESS_KEY="your-secret-key"
-moose prod up
+moose prod
 ```
 
 **Benefits:**

--- a/examples/cdp-analytics/template.config.toml
+++ b/examples/cdp-analytics/template.config.toml
@@ -1,12 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "TypeScript monorepo with Express for serving analytical APIs, and a frontend with AI chat and MCP configured"
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/next-app-empty/README.md
+++ b/templates/next-app-empty/README.md
@@ -47,11 +47,11 @@ To learn more about Moose, take a look at the following resources:
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-## Deploy on Boreal
+## Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up](https://www.boreal.cloud/sign-up).
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 ## License
 

--- a/templates/next-app-empty/README.md
+++ b/templates/next-app-empty/README.md
@@ -51,7 +51,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 ## License
 

--- a/templates/next-app-empty/template.config.toml
+++ b/templates/next-app-empty/template.config.toml
@@ -1,12 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "A typescript MooseStack project with a NextJS frontend (empty)."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -36,11 +36,11 @@ To learn more about Moose, take a look at the following resources:
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-## Deploy on Boreal
+## Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up](https://www.boreal.cloud/sign-up).
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 ## License
 

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -40,7 +40,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 ## License
 

--- a/templates/python-empty/template.config.toml
+++ b/templates/python-empty/template.config.toml
@@ -1,12 +1,11 @@
 language = "python" # Must be typescript or python
 description = "Empty python project."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/python-fastapi-client-only/README.md
+++ b/templates/python-fastapi-client-only/README.md
@@ -85,7 +85,7 @@ Join the Moose community [on Slack](https://join.slack.com/t/moose-community/sha
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 ## License
 

--- a/templates/python-fastapi-client-only/README.md
+++ b/templates/python-fastapi-client-only/README.md
@@ -81,11 +81,11 @@ app/
 
 Join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-## Deploy on Boreal
+## Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up](https://www.boreal.cloud/sign-up).
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 ## License
 

--- a/templates/python-fastapi-client-only/template.config.toml
+++ b/templates/python-fastapi-client-only/template.config.toml
@@ -1,12 +1,11 @@
 language = "python" # Must be typescript or python
 description = "FastAPI client-only project - uses MooseStack libraries without requiring the Moose runtime"
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/python-fastapi/README.md
+++ b/templates/python-fastapi/README.md
@@ -25,7 +25,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/python-fastapi/README.md
+++ b/templates/python-fastapi/README.md
@@ -21,11 +21,11 @@ Moose is beta software and is in active development. Multiple public companies a
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/python-fastapi/template.config.toml
+++ b/templates/python-fastapi/template.config.toml
@@ -1,12 +1,11 @@
 language = "python" # Must be typescript or python
 description = "Python MooseStack project with embedded FastAPI for serving analytical APIs."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/python-tests/README.md
+++ b/templates/python-tests/README.md
@@ -60,7 +60,7 @@ The engine test file demonstrates proper configuration for each engine type usin
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 ## License
 

--- a/templates/python-tests/README.md
+++ b/templates/python-tests/README.md
@@ -56,11 +56,11 @@ This template includes comprehensive tests for all supported ClickHouse engines 
 
 The engine test file demonstrates proper configuration for each engine type using the new engine configuration classes to ensure compatibility and correct table creation.
 
-## Deploy on Boreal
+## Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up](https://www.boreal.cloud/sign-up).
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 ## License
 

--- a/templates/python-tests/template.config.toml
+++ b/templates/python-tests/template.config.toml
@@ -1,12 +1,11 @@
 language = "python" # Must be typescript or python
 description = "Test-only template: copy of default Python project for e2e tests"
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/python-webapp/README.md
+++ b/templates/python-webapp/README.md
@@ -23,11 +23,11 @@ Moose is beta software and is in active development. Multiple public companies a
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/python-webapp/README.md
+++ b/templates/python-webapp/README.md
@@ -27,7 +27,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/python-webapp/template.config.toml
+++ b/templates/python-webapp/template.config.toml
@@ -1,12 +1,11 @@
 language = "python"
 description = "Python MooseStack project with web application endpoints."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -36,11 +36,11 @@ To learn more about Moose, take a look at the following resources:
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-## Deploy on Boreal
+## Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up](https://www.boreal.cloud/sign-up).
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 ## License
 

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -40,7 +40,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 ## License
 

--- a/templates/python/template.config.toml
+++ b/templates/python/template.config.toml
@@ -1,12 +1,11 @@
 language = "python" # Must be typescript or python
 description = "Default Python project, seeded with foobar example components."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-empty/README.md
+++ b/templates/typescript-empty/README.md
@@ -25,7 +25,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/typescript-empty/README.md
+++ b/templates/typescript-empty/README.md
@@ -21,11 +21,11 @@ Moose is beta software and is in active development. Multiple public companies a
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/typescript-empty/template.config.toml
+++ b/templates/typescript-empty/template.config.toml
@@ -1,11 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "Blank TypeScript MooseStack project."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-Boreal is the fastest way to deploy your MooseStack app, built by the MooseStack team.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-express/README.md
+++ b/templates/typescript-express/README.md
@@ -25,7 +25,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/typescript-express/README.md
+++ b/templates/typescript-express/README.md
@@ -21,11 +21,11 @@ Moose is beta software and is in active development. Multiple public companies a
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/typescript-express/template.config.toml
+++ b/templates/typescript-express/template.config.toml
@@ -1,11 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "Build a ClickHouse-backed analytical API with Express and TypeScript."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-Boreal is the fastest way to deploy your MooseStack app, built by the MooseStack team.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-fastify/README.md
+++ b/templates/typescript-fastify/README.md
@@ -25,7 +25,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/typescript-fastify/README.md
+++ b/templates/typescript-fastify/README.md
@@ -21,11 +21,11 @@ Moose is beta software and is in active development. Multiple public companies a
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/typescript-fastify/template.config.toml
+++ b/templates/typescript-fastify/template.config.toml
@@ -1,11 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "Build a ClickHouse-backed analytical API with Fastify and TypeScript."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-Boreal is the fastest way to deploy your MooseStack app, built by the MooseStack team.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-mcp/template.config.toml
+++ b/templates/typescript-mcp/template.config.toml
@@ -1,11 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "TypeScript monorepo for exposing ClickHouse analytics to AI apps via MCP."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-Boreal is the fastest way to deploy your MooseStack app, built by the MooseStack team.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-migrate-test/template.config.toml
+++ b/templates/typescript-migrate-test/template.config.toml
@@ -1,12 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "Empty typescript project."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-rls-test/template.config.toml
+++ b/templates/typescript-rls-test/template.config.toml
@@ -1,12 +1,11 @@
 language = "typescript"
 description = "Test-only template for row-level security E2E tests."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript-tests/README.md
+++ b/templates/typescript-tests/README.md
@@ -41,11 +41,11 @@ This template includes comprehensive tests for all supported ClickHouse engines 
 
 The engine test file demonstrates proper configuration for each engine type to ensure compatibility and correct table creation.
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/typescript-tests/README.md
+++ b/templates/typescript-tests/README.md
@@ -45,7 +45,7 @@ The engine test file demonstrates proper configuration for each engine type to e
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/typescript-tests/template.config.toml
+++ b/templates/typescript-tests/template.config.toml
@@ -1,12 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "Test-only template: copy of Default TypeScript project for e2e tests"
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 

--- a/templates/typescript/README.md
+++ b/templates/typescript/README.md
@@ -25,7 +25,7 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
+https://fiveonefour.boreal.cloud
 
 # Contributing
 

--- a/templates/typescript/README.md
+++ b/templates/typescript/README.md
@@ -21,11 +21,11 @@ Moose is beta software and is in active development. Multiple public companies a
 
 You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+# Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up for a free trial](https://fiveonefour.boreal.cloud/sign-up).
 
 # Contributing
 

--- a/templates/typescript/template.config.toml
+++ b/templates/typescript/template.config.toml
@@ -1,12 +1,11 @@
 language = "typescript" # Must be typescript or python
 description = "Default TypeScript project, seeded with foobar example components."
 post_install_print = """
-Deploy on Boreal
+Deploy with 514 Hosting
 
-The easiest way to deploy your MooseStack Applications is to use Boreal
-from the creators of MooseStack.
+514 Hosting is a branch-native control plane for cloud OLAP workloads.
 
-https://boreal.cloud
+https://fiveonefour.boreal.cloud
 
 ---------------------------------------------------------
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CLI help/flag descriptions and documentation/template copy with no behavioral or API logic modifications.
> 
> **Overview**
> Updates the `moose` CLI help text to be shorter and more consistent (command/flag descriptions, examples, and wording), including minor tweaks like dropping redundant flag help on `--backtrace`.
> 
> Refreshes documentation and templates to match the updated CLI wording and branding (e.g., `doc` → `docs` in 514 hosting CLI docs, revised command examples, and “Boreal” → “514 Hosting” deployment messaging/URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5635afaf0d8e723d6786e502cf44351ff8b030a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->