### PR TITLE
feat: hash validation and drift forensics for delta migrations

### DIFF
--- a/apps/framework-cli/src/cli/routines/migrate.rs
+++ b/apps/framework-cli/src/cli/routines/migrate.rs
@@ -745,16 +745,45 @@ pub async fn execute_migration_deltas(
     let is_dev = !project.is_production;
 
     for file in &unapplied {
-        // Validate parent state hash before applying
-        let current_hash = map.olap_hash();
-        if file.parent_state_hash != current_hash {
-            tracing::warn!(
-                "Migration '{}' parent_state_hash mismatch: expected '{}..', got '{}..'. \
-                 This migration may have been generated against a different base state.",
-                file.id,
-                &file.parent_state_hash[..12.min(file.parent_state_hash.len())],
-                &current_hash[..12.min(current_hash.len())],
+        // Validate parent state hash before applying — fail rather than apply
+        // against stale state, which could silently corrupt the database.
+        if let Err(e) = file.validate_parent_hash(&map.olap_hash()) {
+            println!(
+                "\n❌ Migration '{}' cannot be applied: database state has diverged from\n\
+                 what this migration was generated against.\n",
+                file.id
             );
+
+            // Best-effort forensics: diff the fold of applied migrations (what the
+            // log says should be in the DB) against the live map (what is in the DB).
+            // If reconstruction fails we swallow the error — the hash mismatch is
+            // still the authoritative failure; drift is just explanatory.
+            match history.reconstruct_olap_map_for_applied(default_database, &applied) {
+                Ok(expected_map) => {
+                    let drift =
+                        crate::framework::core::migration_file::compute_drift(&expected_map, &map);
+                    if !drift.is_empty() {
+                        println!("Detected drift between migration log and database:");
+                        println!();
+                        print!("{}", drift);
+                        println!();
+                    }
+                }
+                Err(reconstruct_err) => {
+                    tracing::debug!(
+                        "Could not reconstruct expected state for drift analysis: {}",
+                        reconstruct_err
+                    );
+                }
+            }
+
+            println!("This could happen if:");
+            println!("  • Another developer applied migrations to this database");
+            println!("  • Manual DDL was run against the database");
+            println!("  • This migration is stale\n");
+            println!("To resolve, regenerate the migration against the current database state:");
+            println!("  moose generate migration --clickhouse-url <url>\n");
+            return Err(e.into());
         }
 
         println!(

--- a/apps/framework-cli/src/cli/routines/migrate.rs
+++ b/apps/framework-cli/src/cli/routines/migrate.rs
@@ -4,6 +4,7 @@ use crate::cli::display::Message;
 use crate::cli::routines::RoutineFailure;
 use crate::framework::core::infrastructure::table::Table;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
+use crate::framework::core::migration_file::MigrationFile;
 use crate::framework::core::migration_plan::MigrationPlan;
 use crate::framework::core::plan::{reconcile_with_reality, ReconciliationFilter};
 use crate::framework::core::state_storage::{StateStorage, StateStorageBuilder};
@@ -677,6 +678,110 @@ fn report_partial_failure(succeeded_count: usize, total_count: usize) {
     println!("  4. Run migrate again");
 }
 
+/// Format a detailed partial-failure report when a migration file's DDL
+/// execution fails partway through its deltas.
+///
+/// Unlike the legacy plan.yaml path (single flat list of ops), delta files
+/// are structured: file → ordered deltas → atomic DDL ops. When a delta fails
+/// partway through a file, the database is in an intermediate state the
+/// migration log does not reflect. ClickHouse DDL has no transactional
+/// rollback, so naively re-running `moose migrate` will usually fail on the
+/// already-succeeded deltas ("table already exists", etc.) — the user has to
+/// recover deliberately.
+///
+/// Returns a multi-line string (the caller prints). Output lists:
+///   - which migration + delta position failed
+///   - the deltas in this file that succeeded (DDL executed)
+///   - the failed delta
+///   - the deltas that were not attempted
+///   - a warning against a naive re-run
+///   - recovery options
+fn format_partial_delta_failure(file: &MigrationFile, failed_delta_idx: usize) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    let total = file.deltas.len();
+    let failed_position = failed_delta_idx + 1;
+
+    writeln!(
+        out,
+        "\n❌ Migration '{}' failed at delta {}/{}",
+        file.id, failed_position, total
+    )
+    .unwrap();
+
+    writeln!(out, "\nPartial state of this migration:").unwrap();
+
+    if failed_delta_idx > 0 {
+        writeln!(
+            out,
+            "\n  Succeeded (DDL executed, fold applied to in-memory map):"
+        )
+        .unwrap();
+        for (i, delta) in file.deltas[..failed_delta_idx].iter().enumerate() {
+            writeln!(out, "    ✓ [{}/{}] {}", i + 1, total, delta.summary()).unwrap();
+        }
+    } else {
+        writeln!(out, "\n  No deltas completed before the failure.").unwrap();
+    }
+
+    writeln!(out, "\n  Failed:").unwrap();
+    writeln!(
+        out,
+        "    ✗ [{}/{}] {}",
+        failed_position,
+        total,
+        file.deltas[failed_delta_idx].summary()
+    )
+    .unwrap();
+
+    let remaining = total - failed_delta_idx - 1;
+    if remaining > 0 {
+        writeln!(out, "\n  Not attempted:").unwrap();
+        for (offset, delta) in file.deltas[failed_delta_idx + 1..].iter().enumerate() {
+            writeln!(
+                out,
+                "    · [{}/{}] {}",
+                failed_delta_idx + offset + 2,
+                total,
+                delta.summary()
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(
+        out,
+        "\n⚠️  '{}' is NOT recorded as applied, but its first {} delta(s) have already\n\
+         been executed against the database. Re-running `moose migrate` as-is will try\n\
+         to re-apply them, which typically fails with errors like \"table already exists\"\n\
+         or \"column already exists\". ClickHouse DDL has no transactional rollback —\n\
+         partial failures require deliberate recovery.",
+        file.id, failed_delta_idx
+    )
+    .unwrap();
+
+    writeln!(out, "\n📋 Recovery options:").unwrap();
+    writeln!(
+        out,
+        "\n  1. Revert the succeeded deltas manually in ClickHouse (bringing the database\n\
+         back to the state before '{}'), fix the cause of the failure, then re-run\n\
+         `moose migrate`.",
+        file.id
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "\n  2. Fix the underlying issue, manually apply the remaining deltas in ClickHouse\n\
+         to complete the migration, then mark '{}' as applied in state storage so future\n\
+         runs skip it. (Advanced; use only if you can't cleanly revert.)",
+        file.id
+    )
+    .unwrap();
+
+    out
+}
+
 /// Execute migration from delta files (MigrationHistory).
 ///
 /// Loads MigrationHistory from the migrations directory, filters to unapplied
@@ -807,12 +912,7 @@ pub async fn execute_migration_deltas(
                 )
                 .await
                 {
-                    println!(
-                        "\n❌ Failed at delta {}/{} in migration '{}'",
-                        idx + 1,
-                        file.deltas.len(),
-                        file.id
-                    );
+                    print!("{}", format_partial_delta_failure(file, idx));
                     return Err(e.into());
                 }
             }
@@ -1721,5 +1821,102 @@ mod tests {
             err.contains("another_bad_cluster"),
             "Error should mention the invalid cluster: {err}"
         );
+    }
+
+    #[test]
+    fn test_format_partial_delta_failure_shows_applied_failed_and_remaining() {
+        use crate::framework::core::infra_delta::InfraDelta;
+        use crate::framework::core::migration_file::MigrationFile;
+
+        let t1 = create_test_table("tbl_one");
+        let t2 = create_test_table("tbl_two");
+        let t3 = create_test_table("tbl_three");
+
+        let file = MigrationFile {
+            id: "20260406_150000_multi_delta".to_string(),
+            description: "multi-delta migration".to_string(),
+            parent_state_hash: "abc".to_string(),
+            deltas: vec![
+                InfraDelta::CreateTable { table: t1 },
+                InfraDelta::CreateTable { table: t2 },
+                InfraDelta::CreateTable { table: t3 },
+            ],
+            created_at: chrono::Utc::now(),
+        };
+
+        // Middle delta failed (index 1 = "delta 2 of 3")
+        let output = format_partial_delta_failure(&file, 1);
+
+        // Identifies the failing migration and position
+        assert!(
+            output.contains("20260406_150000_multi_delta"),
+            "output should include migration ID:\n{output}"
+        );
+        assert!(
+            output.contains("2/3"),
+            "output should show failed delta position (2/3):\n{output}"
+        );
+
+        // Summarizes what was executed before the failure (tbl_one, delta 1)
+        assert!(
+            output.contains("tbl_one"),
+            "output should include the succeeded delta's table:\n{output}"
+        );
+        // Summarizes the failed delta (tbl_two)
+        assert!(
+            output.contains("tbl_two"),
+            "output should include the failed delta's table:\n{output}"
+        );
+        // Summarizes the not-attempted delta (tbl_three)
+        assert!(
+            output.contains("tbl_three"),
+            "output should include the not-attempted delta's table:\n{output}"
+        );
+
+        // Warns about re-running (so users don't naively retry)
+        let lower = output.to_lowercase();
+        assert!(
+            lower.contains("re-run")
+                || lower.contains("rerun")
+                || lower.contains("retry")
+                || lower.contains("re-apply"),
+            "output should warn about the dangers of naive re-run:\n{output}"
+        );
+
+        // Provides recovery guidance
+        assert!(
+            lower.contains("recovery") || lower.contains("next steps"),
+            "output should include recovery guidance:\n{output}"
+        );
+    }
+
+    #[test]
+    fn test_format_partial_delta_failure_first_delta_no_succeeded_section() {
+        use crate::framework::core::infra_delta::InfraDelta;
+        use crate::framework::core::migration_file::MigrationFile;
+
+        let file = MigrationFile {
+            id: "20260406_160000_first_fails".to_string(),
+            description: "first delta fails".to_string(),
+            parent_state_hash: "abc".to_string(),
+            deltas: vec![
+                InfraDelta::CreateTable {
+                    table: create_test_table("only_one"),
+                },
+                InfraDelta::CreateTable {
+                    table: create_test_table("only_two"),
+                },
+            ],
+            created_at: chrono::Utc::now(),
+        };
+
+        // First delta (index 0) failed — nothing succeeded
+        let output = format_partial_delta_failure(&file, 0);
+
+        assert!(output.contains("1/2"), "should show 1/2:\n{output}");
+        // The failed delta's table is present
+        assert!(output.contains("only_one"));
+        // The not-attempted delta's table is present
+        assert!(output.contains("only_two"));
     }
 }

--- a/apps/framework-cli/src/cli/routines/migrate.rs
+++ b/apps/framework-cli/src/cli/routines/migrate.rs
@@ -750,16 +750,26 @@ fn format_partial_delta_failure(file: &MigrationFile, failed_delta_idx: usize) -
         }
     }
 
-    writeln!(
-        out,
-        "\n⚠️  '{}' is NOT recorded as applied, but its first {} delta(s) have already\n\
-         been executed against the database. Re-running `moose migrate` as-is will try\n\
-         to re-apply them, which typically fails with errors like \"table already exists\"\n\
-         or \"column already exists\". ClickHouse DDL has no transactional rollback —\n\
-         partial failures require deliberate recovery.",
-        file.id, failed_delta_idx
-    )
-    .unwrap();
+    if failed_delta_idx > 0 {
+        writeln!(
+            out,
+            "\n⚠️  '{}' is NOT recorded as applied, but its first {} delta(s) have already\n\
+             been executed against the database. Re-running `moose migrate` as-is will try\n\
+             to re-apply them, which typically fails with errors like \"table already exists\"\n\
+             or \"column already exists\". ClickHouse DDL has no transactional rollback —\n\
+             partial failures require deliberate recovery.",
+            file.id, failed_delta_idx
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            out,
+            "\n⚠️  '{}' is NOT recorded as applied. The very first delta failed, so no\n\
+             DDL was executed. Fix the underlying issue and re-run `moose migrate`.",
+            file.id
+        )
+        .unwrap();
+    }
 
     writeln!(out, "\n📋 Recovery options:").unwrap();
     writeln!(
@@ -811,7 +821,9 @@ pub async fn execute_migration_deltas(
     }
 
     // Filter to unapplied migrations only
-    let applied = state_storage.load_applied_migrations().await?;
+    // `applied` is kept in sync as we record each successful file, so drift
+    // forensics on a later hash-mismatch include all prior successes from this run.
+    let mut applied = state_storage.load_applied_migrations().await?;
     let unapplied: Vec<_> = history
         .files
         .iter()
@@ -923,8 +935,10 @@ pub async fn execute_migration_deltas(
                 .map_err(|e| anyhow::anyhow!("Failed to apply delta to map: {}", e))?;
         }
 
-        // Record this migration as applied
+        // Record this migration as applied (both in remote storage and local list
+        // so drift forensics for a later hash-mismatch include this file's changes).
         state_storage.store_applied_migration(&file.id).await?;
+        applied.push(file.id.clone());
         println!("  ✓ Migration '{}' applied successfully", file.id);
     }
 
@@ -1918,5 +1932,17 @@ mod tests {
         assert!(output.contains("only_one"));
         // The not-attempted delta's table is present
         assert!(output.contains("only_two"));
+
+        // When first delta fails, message should say safe to re-run (no DDL executed)
+        let lower = output.to_lowercase();
+        assert!(
+            lower.contains("no") && lower.contains("first delta failed"),
+            "first-delta failure should say no DDL was executed:\n{output}"
+        );
+        // Should NOT mention "0 delta(s)"
+        assert!(
+            !output.contains("0 delta(s)"),
+            "should not say '0 delta(s)' when first delta fails:\n{output}"
+        );
     }
 }

--- a/apps/framework-cli/src/framework/core/migration_file.rs
+++ b/apps/framework-cli/src/framework/core/migration_file.rs
@@ -79,6 +79,142 @@ pub enum MigrationHistoryError {
     },
 }
 
+/// Differences in a single category of OLAP resources (tables, views, etc.)
+/// between an expected state and the actual database state.
+///
+/// "Extra" = in actual but not expected (drifted in — someone added it outside the migration log).
+/// "Missing" = in expected but not actual (drifted out — someone removed it outside the migration log).
+/// "Changed" = in both but with schema differences.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DriftCategory {
+    pub extra: Vec<String>,
+    pub missing: Vec<String>,
+    pub changed: Vec<String>,
+}
+
+impl DriftCategory {
+    pub fn is_empty(&self) -> bool {
+        self.extra.is_empty() && self.missing.is_empty() && self.changed.is_empty()
+    }
+}
+
+/// Forensic report of the divergence between an expected infrastructure map
+/// (typically the fold of applied migrations) and the actual live map.
+///
+/// Produced when `validate_parent_hash` fails, so the user can see exactly
+/// which tables/views/etc. drifted rather than just a hash mismatch.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DriftReport {
+    pub tables: DriftCategory,
+    pub views: DriftCategory,
+    pub materialized_views: DriftCategory,
+    pub dmv1_views: DriftCategory,
+    pub select_row_policies: DriftCategory,
+    pub sql_resources: DriftCategory,
+}
+
+impl DriftReport {
+    pub fn is_empty(&self) -> bool {
+        self.tables.is_empty()
+            && self.views.is_empty()
+            && self.materialized_views.is_empty()
+            && self.dmv1_views.is_empty()
+            && self.select_row_policies.is_empty()
+            && self.sql_resources.is_empty()
+    }
+}
+
+impl std::fmt::Display for DriftReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write_drift_category(f, "Tables", &self.tables)?;
+        write_drift_category(f, "Views", &self.views)?;
+        write_drift_category(f, "Materialized views", &self.materialized_views)?;
+        write_drift_category(f, "DMv1 views", &self.dmv1_views)?;
+        write_drift_category(f, "Row policies", &self.select_row_policies)?;
+        write_drift_category(f, "SQL resources", &self.sql_resources)?;
+        Ok(())
+    }
+}
+
+fn write_drift_category(
+    f: &mut std::fmt::Formatter<'_>,
+    label: &str,
+    cat: &DriftCategory,
+) -> std::fmt::Result {
+    if cat.is_empty() {
+        return Ok(());
+    }
+    writeln!(f, "{}:", label)?;
+    for item in &cat.extra {
+        writeln!(
+            f,
+            "  + {} (present in database but not in migration log)",
+            item
+        )?;
+    }
+    for item in &cat.missing {
+        writeln!(
+            f,
+            "  - {} (in migration log but missing from database)",
+            item
+        )?;
+    }
+    for item in &cat.changed {
+        writeln!(f, "  ~ {} (schema differs from migration log)", item)?;
+    }
+    Ok(())
+}
+
+/// Compute a drift report between an expected infrastructure map (typically
+/// the fold of applied migrations) and the actual live map.
+pub fn compute_drift(expected: &InfrastructureMap, actual: &InfrastructureMap) -> DriftReport {
+    DriftReport {
+        tables: diff_map(&expected.tables, &actual.tables),
+        views: diff_map(&expected.views, &actual.views),
+        materialized_views: diff_map(&expected.materialized_views, &actual.materialized_views),
+        dmv1_views: diff_map(&expected.dmv1_views, &actual.dmv1_views),
+        select_row_policies: diff_map(&expected.select_row_policies, &actual.select_row_policies),
+        sql_resources: diff_map(&expected.sql_resources, &actual.sql_resources),
+    }
+}
+
+/// Key-by-key diff of two HashMaps: categorize keys as extra (only in actual),
+/// missing (only in expected), or changed (in both but values differ).
+fn diff_map<T: PartialEq>(
+    expected: &HashMap<String, T>,
+    actual: &HashMap<String, T>,
+) -> DriftCategory {
+    let mut extra = Vec::new();
+    let mut missing = Vec::new();
+    let mut changed = Vec::new();
+
+    for (key, actual_val) in actual {
+        match expected.get(key) {
+            None => extra.push(key.clone()),
+            Some(expected_val) => {
+                if expected_val != actual_val {
+                    changed.push(key.clone());
+                }
+            }
+        }
+    }
+    for key in expected.keys() {
+        if !actual.contains_key(key) {
+            missing.push(key.clone());
+        }
+    }
+
+    extra.sort();
+    missing.sort();
+    changed.sort();
+
+    DriftCategory {
+        extra,
+        missing,
+        changed,
+    }
+}
+
 /// A semantic conflict detected between two branches' migration files.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MigrationConflict {
@@ -125,6 +261,24 @@ impl MigrationFile {
     /// Deserialize a migration file from YAML.
     pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
         serde_yaml::from_str(yaml)
+    }
+
+    /// Validate that this migration file's `parent_state_hash` matches the given actual hash.
+    ///
+    /// Used by `moose migrate` to ensure a migration is applied only against the same
+    /// base state it was generated against. A mismatch indicates the live database has
+    /// diverged (e.g., migrations from another branch were applied, manual DDL was run,
+    /// or this migration is stale) and applying this file anyway could silently corrupt
+    /// state — so callers must treat a mismatch as a hard error.
+    pub fn validate_parent_hash(&self, actual_hash: &str) -> Result<(), MigrationHistoryError> {
+        if self.parent_state_hash != actual_hash {
+            return Err(MigrationHistoryError::HashMismatch {
+                migration_id: self.id.clone(),
+                expected: self.parent_state_hash.clone(),
+                actual: actual_hash.to_string(),
+            });
+        }
+        Ok(())
     }
 
     /// Returns a list of all table IDs touched by deltas in this file.
@@ -235,6 +389,27 @@ impl MigrationHistory {
         }
 
         Ok(map)
+    }
+
+    /// Fold only the migration files whose IDs appear in `applied_ids`, preserving file order.
+    ///
+    /// Used when a hash mismatch is detected during `moose migrate` to reconstruct
+    /// what the database *should* look like according to the applied migration log,
+    /// so the caller can diff it against the live database and show forensics.
+    pub fn reconstruct_olap_map_for_applied(
+        &self,
+        default_database: &str,
+        applied_ids: &[String],
+    ) -> Result<InfrastructureMap, MigrationHistoryError> {
+        let subset = Self {
+            files: self
+                .files
+                .iter()
+                .filter(|f| applied_ids.iter().any(|id| id == &f.id))
+                .cloned()
+                .collect(),
+        };
+        subset.reconstruct_olap_map(default_database)
     }
 
     /// Detect semantic conflicts between two sets of migration files.
@@ -715,5 +890,206 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&"test_db_events".to_string()));
         assert!(ids.contains(&"test_db_users".to_string()));
+    }
+
+    #[test]
+    fn test_validate_parent_hash_matches_returns_ok() {
+        let file = MigrationFile {
+            id: "20260406_150000_test".to_string(),
+            description: "test".to_string(),
+            parent_state_hash: "abc123".to_string(),
+            deltas: vec![],
+            created_at: Utc::now(),
+        };
+
+        assert!(file.validate_parent_hash("abc123").is_ok());
+    }
+
+    #[test]
+    fn test_compute_drift_identical_maps_is_empty() {
+        let table = make_test_table("events");
+        let mut map = InfrastructureMap {
+            default_database: TEST_DB.to_string(),
+            topics: HashMap::new(),
+            api_endpoints: HashMap::new(),
+            tables: HashMap::new(),
+            dmv1_views: HashMap::new(),
+            topic_to_table_sync_processes: HashMap::new(),
+            topic_to_topic_sync_processes: HashMap::new(),
+            function_processes: HashMap::new(),
+            consumption_api_web_server: ConsumptionApiWebServer {},
+            orchestration_workers: HashMap::new(),
+            sql_resources: HashMap::new(),
+            workflows: HashMap::new(),
+            web_apps: HashMap::new(),
+            materialized_views: HashMap::new(),
+            views: HashMap::new(),
+            select_row_policies: HashMap::new(),
+            moose_version: None,
+        };
+        map.tables.insert(table.id(TEST_DB), table);
+
+        let drift = compute_drift(&map, &map);
+
+        assert!(drift.is_empty());
+    }
+
+    #[test]
+    fn test_compute_drift_detects_extra_table_in_actual() {
+        let events = make_test_table("events");
+        let users = make_test_table("users");
+
+        let mut expected = empty_infra_map();
+        expected.tables.insert(events.id(TEST_DB), events.clone());
+
+        let mut actual = empty_infra_map();
+        actual.tables.insert(events.id(TEST_DB), events);
+        actual.tables.insert(users.id(TEST_DB), users);
+
+        let drift = compute_drift(&expected, &actual);
+
+        assert_eq!(drift.tables.extra, vec![format!("{}_users", TEST_DB)]);
+        assert!(drift.tables.missing.is_empty());
+        assert!(drift.tables.changed.is_empty());
+        assert!(!drift.is_empty());
+    }
+
+    #[test]
+    fn test_compute_drift_detects_missing_table_in_actual() {
+        let events = make_test_table("events");
+        let users = make_test_table("users");
+
+        let mut expected = empty_infra_map();
+        expected.tables.insert(events.id(TEST_DB), events.clone());
+        expected.tables.insert(users.id(TEST_DB), users);
+
+        let mut actual = empty_infra_map();
+        actual.tables.insert(events.id(TEST_DB), events);
+
+        let drift = compute_drift(&expected, &actual);
+
+        assert!(drift.tables.extra.is_empty());
+        assert_eq!(drift.tables.missing, vec![format!("{}_users", TEST_DB)]);
+        assert!(drift.tables.changed.is_empty());
+    }
+
+    #[test]
+    fn test_compute_drift_detects_changed_table() {
+        let events = make_test_table("events");
+        let mut events_modified = events.clone();
+        events_modified.columns.push(Column {
+            name: "new_col".to_string(),
+            data_type: ColumnType::String,
+            required: false,
+            unique: false,
+            primary_key: false,
+            default: None,
+            annotations: vec![],
+            comment: None,
+            ttl: None,
+            codec: None,
+            materialized: None,
+            alias: None,
+        });
+
+        let mut expected = empty_infra_map();
+        expected.tables.insert(events.id(TEST_DB), events);
+
+        let mut actual = empty_infra_map();
+        actual
+            .tables
+            .insert(events_modified.id(TEST_DB), events_modified);
+
+        let drift = compute_drift(&expected, &actual);
+
+        assert!(drift.tables.extra.is_empty());
+        assert!(drift.tables.missing.is_empty());
+        assert_eq!(drift.tables.changed, vec![format!("{}_events", TEST_DB)]);
+    }
+
+    #[test]
+    fn test_reconstruct_olap_map_for_applied_folds_only_listed_ids() {
+        let events = make_test_table("events");
+        let users = make_test_table("users");
+
+        let m1 = MigrationFile {
+            id: "20260406_100000_create_events".to_string(),
+            description: "events".to_string(),
+            parent_state_hash: "a".repeat(64),
+            deltas: vec![InfraDelta::CreateTable {
+                table: events.clone(),
+            }],
+            created_at: Utc::now(),
+        };
+        let m2 = MigrationFile {
+            id: "20260407_100000_create_users".to_string(),
+            description: "users".to_string(),
+            parent_state_hash: "b".repeat(64),
+            deltas: vec![InfraDelta::CreateTable {
+                table: users.clone(),
+            }],
+            created_at: Utc::now(),
+        };
+
+        let history = MigrationHistory {
+            files: vec![m1.clone(), m2],
+        };
+
+        // Only m1 is applied → resulting map should have events but NOT users
+        let applied_ids = vec![m1.id.clone()];
+        let map = history
+            .reconstruct_olap_map_for_applied(TEST_DB, &applied_ids)
+            .unwrap();
+
+        assert!(map.tables.contains_key(&events.id(TEST_DB)));
+        assert!(!map.tables.contains_key(&users.id(TEST_DB)));
+    }
+
+    fn empty_infra_map() -> InfrastructureMap {
+        InfrastructureMap {
+            default_database: TEST_DB.to_string(),
+            topics: HashMap::new(),
+            api_endpoints: HashMap::new(),
+            tables: HashMap::new(),
+            dmv1_views: HashMap::new(),
+            topic_to_table_sync_processes: HashMap::new(),
+            topic_to_topic_sync_processes: HashMap::new(),
+            function_processes: HashMap::new(),
+            consumption_api_web_server: ConsumptionApiWebServer {},
+            orchestration_workers: HashMap::new(),
+            sql_resources: HashMap::new(),
+            workflows: HashMap::new(),
+            web_apps: HashMap::new(),
+            materialized_views: HashMap::new(),
+            views: HashMap::new(),
+            select_row_policies: HashMap::new(),
+            moose_version: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_parent_hash_mismatch_returns_hash_mismatch_error() {
+        let file = MigrationFile {
+            id: "20260406_150000_test".to_string(),
+            description: "test".to_string(),
+            parent_state_hash: "expected_hash".to_string(),
+            deltas: vec![],
+            created_at: Utc::now(),
+        };
+
+        let result = file.validate_parent_hash("actual_different_hash");
+
+        match result {
+            Err(MigrationHistoryError::HashMismatch {
+                migration_id,
+                expected,
+                actual,
+            }) => {
+                assert_eq!(migration_id, "20260406_150000_test");
+                assert_eq!(expected, "expected_hash");
+                assert_eq!(actual, "actual_different_hash");
+            }
+            other => panic!("expected HashMismatch error, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
2 AI-generated PR descriptions + 1 human-generated:

## I am the human

### added

- compares the hash of expected vs reality
- bails out if no match
- if migration deltas fail, log what was executed so the user can correct or unwind

### deferred (may or may not actually do) w/ followup tickets

- auto-resume of applied deltas after a failure
- complex migration folding during migration generation

## Summary

- When `execute_migration_deltas` encounters a `parent_state_hash` mismatch (database state diverged from what a migration was generated against), it now **fails immediately** instead of `tracing::warn!` and continuing — preventing silent corruption in production.
- On hash mismatch, reconstructs the expected state by folding applied migrations and **computes a runtime drift report** showing exactly which tables/views/MVs/row policies are extra, missing, or changed — so the user sees *what* drifted, not just that something drifted.
- When a delta fails mid-file (partial DDL failure), prints a **structured partial-failure report** listing succeeded/failed/not-attempted deltas with explicit recovery guidance — because ClickHouse DDL has no transactional rollback and naive re-run will hit "already exists" errors.

Refs: ENG-2709

## What this does NOT include (intentionally)

- **Per-delta tracking for auto-resume** — tracked in ENG-2743 (sub-issue of ENG-2709). Current partial-failure recovery is manual but clearly guided.
- **Generation-side multi-file chain fix** — tracked in ENG-2742. `moose generate migration` doesn't fold existing migration files into its baseline, so multi-file branches produce invalid chains. This PR's strict hash check surfaces that clearly; fixing generation is a separate concern.
- **E2E tests** — tracked in ENG-2717.

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] 15 migration_file tests pass (8 pre-existing + 7 new)
- [ ] 24 migrate tests pass (22 pre-existing + 2 new)
- [ ] Verify hash-mismatch produces drift report (manual with `features.migrate_with_deltas = true`)
- [ ] Verify partial DDL failure produces structured recovery guidance


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes migration execution behavior to hard-fail on `parent_state_hash` mismatches and adds new drift/partial-failure reporting, which can block previously-allowed runs and affects production migration workflows.
> 
> **Overview**
> **Delta-based migrations are now stricter and more diagnosable.** `execute_migration_deltas` now *fails fast* when a migration file’s `parent_state_hash` doesn’t match the current OLAP map hash (instead of warning and continuing).
> 
> On hash mismatch, the CLI reconstructs the expected OLAP state from the applied migration log and prints a **drift report** (extra/missing/changed tables, views, materialized views, DMv1 views, row policies, and SQL resources). On mid-file delta failures, it prints a **structured partial-execution report** (succeeded/failed/not-attempted deltas) with explicit recovery guidance, and keeps the in-memory `applied` list updated as migrations succeed to improve later forensics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b929212c28241bc2a218b829e79d765330eb7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->