### PR TITLE
docs: document debug logging for failed SQL statements

### DIFF
--- a/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
@@ -111,17 +111,9 @@ All logs appear in Moose logs and can be viewed using `moose logs --tail`.
 
 ## Debugging SQL Queries
 
-When a ClickHouse SQL query fails, Moose logs the error status and message at `error` level. To also see the full SQL statement that failed, enable debug-level logging:
+When a ClickHouse SQL query fails, Moose logs the error status and message at `error` level. To also see the full SQL statement that failed:
 
-```bash
-MOOSE_LOGGER__LEVEL=Debug moose dev
-```
-
-Then search the logs for the failing statement:
-
-```bash
-moose logs --filter "Failed SQL"
-```
+{{ include "shared/debugging-failed-sql.mdx" }}
 
 See the [Troubleshooting guide](/moosestack/help/troubleshooting#issue-debugging-failed-clickhouse-queries) for more details.
 

--- a/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
@@ -109,6 +109,22 @@ This logs payloads at three key points with searchable prefixes:
 
 All logs appear in Moose logs and can be viewed using `moose logs --tail`.
 
+## Debugging SQL Queries
+
+When a ClickHouse SQL query fails, Moose logs the error status and message at `error` level. To also see the full SQL statement that failed, enable debug-level logging:
+
+```bash
+MOOSE_LOGGER__LEVEL=Debug moose dev
+```
+
+Then search the logs for the failing statement:
+
+```bash
+moose logs --filter "Failed SQL"
+```
+
+See the [Troubleshooting guide](/moosestack/help/troubleshooting#issue-debugging-failed-clickhouse-queries) for more details.
+
 ## Docker Infrastructure Extensions
 
 Extend the default Moose development infrastructure by creating a specific override file in your project root.

--- a/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
@@ -113,7 +113,7 @@ All logs appear in Moose logs and can be viewed using `moose logs --tail`.
 
 When a ClickHouse SQL query fails, Moose logs the error status and message at `error` level. To also see the full SQL statement that failed:
 
-{{ include "shared/debugging-failed-sql.mdx" }}
+:::include /shared/debugging-failed-sql.mdx
 
 See the [Troubleshooting guide](/moosestack/help/troubleshooting#issue-debugging-failed-clickhouse-queries) for more details.
 

--- a/apps/framework-docs-v2/content/moosestack/help/troubleshooting.mdx
+++ b/apps/framework-docs-v2/content/moosestack/help/troubleshooting.mdx
@@ -221,6 +221,28 @@ native_port = 9000
      </LanguageTabContent>
    </LanguageTabs>
 
+### Issue: Debugging failed ClickHouse queries
+
+When a ClickHouse SQL query fails, Moose logs the HTTP status and error message at the `error` log level by default. To also see the **full SQL statement** that failed — useful for reproducing the error or inspecting generated queries — enable debug-level logging:
+
+```bash
+MOOSE_LOGGER__LEVEL=Debug moose dev
+```
+
+Then filter the logs for the failing statement:
+
+```bash
+moose logs --filter "Failed SQL"
+```
+
+To see logs directly in the terminal instead of the log file, also set:
+
+```bash
+MOOSE_LOGGER__STDOUT=true MOOSE_LOGGER__LEVEL=Debug moose dev
+```
+
+The failed SQL appears alongside the error body, so you can copy and run the statement directly against ClickHouse to inspect or debug it.
+
 ## Deployment Issues
 
 ### Issue: Deployment fails

--- a/apps/framework-docs-v2/content/moosestack/help/troubleshooting.mdx
+++ b/apps/framework-docs-v2/content/moosestack/help/troubleshooting.mdx
@@ -225,15 +225,7 @@ native_port = 9000
 
 When a ClickHouse SQL query fails, Moose logs the HTTP status and error message at the `error` log level by default. To also see the **full SQL statement** that failed — useful for reproducing the error or inspecting generated queries — enable debug-level logging:
 
-```bash
-MOOSE_LOGGER__LEVEL=Debug moose dev
-```
-
-Then filter the logs for the failing statement:
-
-```bash
-moose logs --filter "Failed SQL"
-```
+{{ include "shared/debugging-failed-sql.mdx" }}
 
 To see logs directly in the terminal instead of the log file, also set:
 

--- a/apps/framework-docs-v2/content/moosestack/help/troubleshooting.mdx
+++ b/apps/framework-docs-v2/content/moosestack/help/troubleshooting.mdx
@@ -225,7 +225,7 @@ native_port = 9000
 
 When a ClickHouse SQL query fails, Moose logs the HTTP status and error message at the `error` log level by default. To also see the **full SQL statement** that failed — useful for reproducing the error or inspecting generated queries — enable debug-level logging:
 
-{{ include "shared/debugging-failed-sql.mdx" }}
+:::include /shared/debugging-failed-sql.mdx
 
 To see logs directly in the terminal instead of the log file, also set:
 

--- a/apps/framework-docs-v2/content/shared/debugging-failed-sql.mdx
+++ b/apps/framework-docs-v2/content/shared/debugging-failed-sql.mdx
@@ -1,0 +1,11 @@
+Enable debug-level logging to see the full SQL statement in the logs:
+
+```bash
+MOOSE_LOGGER__LEVEL=Debug moose dev
+```
+
+Then filter the logs for the failing statement:
+
+```bash
+moose logs --filter "Failed SQL"
+```


### PR DESCRIPTION
## Summary
- Added a "Debugging failed ClickHouse queries" section to the troubleshooting guide explaining how to enable debug-level logging (`MOOSE_LOGGER__LEVEL=Debug`) to see the full SQL statement when a query fails
- Added a "Debugging SQL Queries" section to the dev environment config page with a cross-link to the troubleshooting guide
- Documents the feature added in #3996

Relates to ENG-2746 for follow-up work to surface the SQL directly in the console.

## Test plan
- [ ] Verify troubleshooting page renders correctly at `/moosestack/help/troubleshooting`
- [ ] Verify dev environment config page renders correctly at `/moosestack/configuration/dev-environment`
- [ ] Confirm anchor link from dev-environment page to troubleshooting section works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it adds guidance and shared includes without modifying runtime code paths.
> 
> **Overview**
> Documents how to debug *failed ClickHouse SQL queries* by enabling `MOOSE_LOGGER__LEVEL=Debug` and filtering logs for "Failed SQL", via a new shared snippet `shared/debugging-failed-sql.mdx`.
> 
> Adds a new troubleshooting section covering what gets logged by default, an optional `MOOSE_LOGGER__STDOUT=true` tip for terminal output, and links this guidance from the dev environment page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d785f2f0eacd212722d9dccb40fc7151488cfb77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->