### PR TITLE
Add checksums for dockerless dependency binaries

### DIFF
--- a/apps/framework-cli/src/utilities/native_infra/binary_manager.rs
+++ b/apps/framework-cli/src/utilities/native_infra/binary_manager.rs
@@ -1,10 +1,13 @@
 use super::errors::NativeInfraError;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
 /// Downloads, caches, and verifies native binaries for local dev infrastructure.
 ///
 /// Cache layout: `~/.moose/binaries/{name}/{version}/{platform}-{arch}/`
+const CHECKSUM_MARKER_FILE: &str = ".artifact-sha256";
+
 pub struct BinaryManager {
     cache_root: PathBuf,
 }
@@ -33,6 +36,7 @@ impl BinaryManager {
         version: &str,
         url: &str,
         archive_binary_path: Option<&str>,
+        expected_sha256: &str,
     ) -> Result<PathBuf, NativeInfraError> {
         let (platform, arch) = detect_platform()?;
         let cache_dir = self
@@ -45,8 +49,22 @@ impl BinaryManager {
         let binary_path = cache_dir.join(binary_name);
 
         if binary_path.exists() {
-            info!("Using cached {} binary at {}", name, binary_path.display());
-            return Ok(binary_path);
+            if cache_is_valid(
+                &binary_path,
+                &cache_dir,
+                archive_binary_path,
+                expected_sha256,
+            )? {
+                info!("Using cached {} binary at {}", name, binary_path.display());
+                return Ok(binary_path);
+            }
+
+            warn!(
+                "Cached {} binary at {} failed checksum validation, re-downloading",
+                name,
+                binary_path.display()
+            );
+            remove_path_if_exists(&cache_dir)?;
         }
 
         std::fs::create_dir_all(&cache_dir).map_err(|e| NativeInfraError::CreateDir {
@@ -57,14 +75,16 @@ impl BinaryManager {
         info!("Downloading {} v{} from {}", name, version, url);
 
         let bytes = download_with_retry(url, 3)?;
+        verify_download_checksum(name, version, url, &bytes, expected_sha256)?;
 
         if archive_binary_path.is_some() {
             // Extract .tar.gz archive
             extract_tar_gz(&bytes, &cache_dir)?;
+            write_checksum_marker(&cache_dir, expected_sha256)?;
         } else {
             // Single binary — write directly
-            std::fs::write(&binary_path, &bytes).map_err(|e| NativeInfraError::Extract {
-                dest: binary_path.clone(),
+            std::fs::write(&binary_path, &bytes).map_err(|e| NativeInfraError::WriteFile {
+                path: binary_path.clone(),
                 source: e,
             })?;
         }
@@ -87,6 +107,103 @@ impl BinaryManager {
 
         Ok(binary_path)
     }
+}
+
+fn verify_download_checksum(
+    name: &str,
+    version: &str,
+    url: &str,
+    bytes: &[u8],
+    expected_sha256: &str,
+) -> Result<(), NativeInfraError> {
+    let actual_sha256 = sha256_hex(bytes);
+
+    if actual_sha256 == expected_sha256 {
+        return Ok(());
+    }
+
+    Err(NativeInfraError::ChecksumMismatch {
+        name: name.to_string(),
+        version: version.to_string(),
+        url: url.to_string(),
+        expected_sha256: expected_sha256.to_string(),
+        actual_sha256,
+    })
+}
+
+fn cache_is_valid(
+    binary_path: &Path,
+    cache_dir: &Path,
+    archive_binary_path: Option<&str>,
+    expected_sha256: &str,
+) -> Result<bool, NativeInfraError> {
+    if archive_binary_path.is_some() {
+        let marker_path = checksum_marker_path(cache_dir);
+        if !marker_path.exists() {
+            return Ok(false);
+        }
+
+        let marker_contents =
+            std::fs::read_to_string(&marker_path).map_err(|e| NativeInfraError::ReadFile {
+                path: marker_path.clone(),
+                source: e,
+            })?;
+        return Ok(marker_contents.trim() == expected_sha256);
+    }
+
+    let actual_sha256 = sha256_file(binary_path)?;
+    Ok(actual_sha256 == expected_sha256)
+}
+
+fn checksum_marker_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join(CHECKSUM_MARKER_FILE)
+}
+
+fn write_checksum_marker(cache_dir: &Path, expected_sha256: &str) -> Result<(), NativeInfraError> {
+    let marker_path = checksum_marker_path(cache_dir);
+    std::fs::write(&marker_path, expected_sha256).map_err(|e| NativeInfraError::WriteFile {
+        path: marker_path,
+        source: e,
+    })
+}
+
+fn remove_path_if_exists(path: &Path) -> Result<(), NativeInfraError> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let metadata = std::fs::metadata(path).map_err(|e| NativeInfraError::ReadFile {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path).map_err(|e| NativeInfraError::RemovePath {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    } else {
+        std::fs::remove_file(path).map_err(|e| NativeInfraError::RemovePath {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String, NativeInfraError> {
+    let bytes = std::fs::read(path).map_err(|e| NativeInfraError::ReadFile {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    Ok(sha256_hex(&bytes))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
 }
 
 /// Downloads a file with retry and exponential backoff.
@@ -206,6 +323,7 @@ fn set_executable(path: &Path) -> Result<(), NativeInfraError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_detect_platform_succeeds() {
@@ -231,5 +349,106 @@ mod tests {
             cache_dir.to_string_lossy().ends_with(&expected_suffix),
             "Cache dir should follow binaries/name/version/platform-arch pattern"
         );
+    }
+
+    #[test]
+    fn test_verify_download_checksum_accepts_matching_sha256() {
+        let bytes = b"moose";
+        let expected = sha256_hex(bytes);
+
+        let result = verify_download_checksum(
+            "clickhouse",
+            "1.0.0",
+            "https://example.com/bin",
+            bytes,
+            &expected,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_download_checksum_rejects_mismatched_sha256() {
+        let err = verify_download_checksum(
+            "clickhouse",
+            "1.0.0",
+            "https://example.com/bin",
+            b"moose",
+            "deadbeef",
+        )
+        .unwrap_err();
+
+        match err {
+            NativeInfraError::ChecksumMismatch {
+                expected_sha256,
+                actual_sha256,
+                ..
+            } => {
+                assert_eq!(expected_sha256, "deadbeef");
+                assert_eq!(actual_sha256, sha256_hex(b"moose"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_cache_is_valid_for_single_binary() {
+        let dir = tempdir().unwrap();
+        let binary_path = dir.path().join("clickhouse");
+        let bytes = b"native-binary";
+        std::fs::write(&binary_path, bytes).unwrap();
+
+        let is_valid = cache_is_valid(&binary_path, dir.path(), None, &sha256_hex(bytes)).unwrap();
+
+        assert!(is_valid);
+    }
+
+    #[test]
+    fn test_cache_is_invalid_for_single_binary_with_wrong_checksum() {
+        let dir = tempdir().unwrap();
+        let binary_path = dir.path().join("clickhouse");
+        std::fs::write(&binary_path, b"native-binary").unwrap();
+
+        let is_valid = cache_is_valid(&binary_path, dir.path(), None, "deadbeef").unwrap();
+
+        assert!(!is_valid);
+    }
+
+    #[test]
+    fn test_cache_is_valid_for_archive_when_marker_matches() {
+        let dir = tempdir().unwrap();
+        let binary_path = dir.path().join("temporal");
+        std::fs::write(&binary_path, b"extracted-binary").unwrap();
+        write_checksum_marker(dir.path(), "expected-sha").unwrap();
+
+        let is_valid =
+            cache_is_valid(&binary_path, dir.path(), Some("temporal"), "expected-sha").unwrap();
+
+        assert!(is_valid);
+    }
+
+    #[test]
+    fn test_cache_is_invalid_for_archive_when_marker_missing() {
+        let dir = tempdir().unwrap();
+        let binary_path = dir.path().join("temporal");
+        std::fs::write(&binary_path, b"extracted-binary").unwrap();
+
+        let is_valid =
+            cache_is_valid(&binary_path, dir.path(), Some("temporal"), "expected-sha").unwrap();
+
+        assert!(!is_valid);
+    }
+
+    #[test]
+    fn test_cache_is_invalid_for_archive_when_marker_mismatches() {
+        let dir = tempdir().unwrap();
+        let binary_path = dir.path().join("temporal");
+        std::fs::write(&binary_path, b"extracted-binary").unwrap();
+        write_checksum_marker(dir.path(), "wrong-sha").unwrap();
+
+        let is_valid =
+            cache_is_valid(&binary_path, dir.path(), Some("temporal"), "expected-sha").unwrap();
+
+        assert!(!is_valid);
     }
 }

--- a/apps/framework-cli/src/utilities/native_infra/clickhouse.rs
+++ b/apps/framework-cli/src/utilities/native_infra/clickhouse.rs
@@ -11,12 +11,13 @@ const NATIVE_CH_DIR: &str = "native_infra/clickhouse";
 
 /// Ensure the ClickHouse binary is cached and return its path.
 pub fn ensure_binary(manager: &BinaryManager) -> Result<PathBuf, NativeInfraError> {
-    let (url, archive_path) = clickhouse_download_url();
+    let (url, archive_path, expected_sha256) = clickhouse_download_metadata();
     manager.ensure_binary(
         "clickhouse",
         CLICKHOUSE_BINARY_VERSION,
         &url,
         archive_path.as_deref(),
+        expected_sha256,
     )
 }
 
@@ -311,7 +312,7 @@ pub fn pid_file_path(project: &Project) -> PathBuf {
 /// standalone binary so `archive_binary_path` is `None`. On Linux, only
 /// `.tgz` packages are available, so we return the path to the binary
 /// inside the archive.
-fn clickhouse_download_url() -> (String, Option<String>) {
+fn clickhouse_download_metadata() -> (String, Option<String>, &'static str) {
     let ver = CLICKHOUSE_BINARY_VERSION;
     // Strip the "-lts" suffix for the tarball internal directory name.
     // Release tag is e.g. "25.8.18.1-lts" but the directory inside the
@@ -322,23 +323,46 @@ fn clickhouse_download_url() -> (String, Option<String>) {
         (
             format!("https://github.com/ClickHouse/ClickHouse/releases/download/v{ver}/clickhouse-macos-aarch64"),
             None,
+            "f67f862233334db679f712724544ab9d74ca647e5bf2643d49812844bb64a3a3",
         )
     } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
         (
             format!("https://github.com/ClickHouse/ClickHouse/releases/download/v{ver}/clickhouse-macos"),
             None,
+            "1a5705936b663d354fcffeea2702ffa1e4b09b7324251324b7a5b9aa073212a9",
         )
     } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
         (
             format!("https://github.com/ClickHouse/ClickHouse/releases/download/v{ver}/clickhouse-common-static-{ver_short}-arm64.tgz"),
             Some(format!("clickhouse-common-static-{ver_short}/usr/bin/clickhouse")),
+            "b6c5e9f3a65c501f54850a29a04a8d9db37b3f289588a2b49ae72e7045d23cbe",
         )
     } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
         (
             format!("https://github.com/ClickHouse/ClickHouse/releases/download/v{ver}/clickhouse-common-static-{ver_short}-amd64.tgz"),
             Some(format!("clickhouse-common-static-{ver_short}/usr/bin/clickhouse")),
+            "5a554962c62074707e9890fff0e52e7aba003e084e03ad4dccba0609c7fd4173",
         )
     } else {
         unreachable!("unsupported platform should be caught by detect_platform()")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clickhouse_download_metadata_uses_expected_checksum_shape() {
+        let (url, archive_path, checksum) = clickhouse_download_metadata();
+
+        assert!(url.contains(CLICKHOUSE_BINARY_VERSION));
+        assert_eq!(checksum.len(), 64);
+
+        if cfg!(target_os = "linux") {
+            assert!(archive_path.is_some());
+        } else {
+            assert!(archive_path.is_none());
+        }
     }
 }

--- a/apps/framework-cli/src/utilities/native_infra/errors.rs
+++ b/apps/framework-cli/src/utilities/native_infra/errors.rs
@@ -28,8 +28,40 @@ pub enum NativeInfraError {
         source: std::io::Error,
     },
 
+    #[error("failed to read file {path}")]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to write file {path}")]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to remove path {path}")]
+    RemovePath {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("binary not found at expected path {path}")]
     BinaryNotFound { path: PathBuf },
+
+    #[error(
+        "checksum verification failed for {name} v{version} from {url}: expected {expected_sha256}, got {actual_sha256}"
+    )]
+    ChecksumMismatch {
+        name: String,
+        version: String,
+        url: String,
+        expected_sha256: String,
+        actual_sha256: String,
+    },
 
     #[error("failed to set executable permissions on {path}")]
     Chmod {

--- a/apps/framework-cli/src/utilities/native_infra/temporal.rs
+++ b/apps/framework-cli/src/utilities/native_infra/temporal.rs
@@ -10,8 +10,14 @@ const NATIVE_TEMPORAL_DIR: &str = "native_infra/temporal";
 
 /// Ensure the Temporal CLI binary is cached and return its path.
 pub fn ensure_binary(manager: &BinaryManager) -> Result<PathBuf, NativeInfraError> {
-    let url = temporal_download_url();
-    manager.ensure_binary("temporal", TEMPORAL_CLI_VERSION, &url, Some("temporal"))
+    let (url, expected_sha256) = temporal_download_metadata();
+    manager.ensure_binary(
+        "temporal",
+        TEMPORAL_CLI_VERSION,
+        &url,
+        Some("temporal"),
+        expected_sha256,
+    )
 }
 
 /// Start the Temporal dev server as a child process.
@@ -91,30 +97,54 @@ pub fn pid_file_path(project: &Project) -> PathBuf {
         .join("temporal.pid")
 }
 
-/// Construct the platform-specific download URL for Temporal CLI.
-fn temporal_download_url() -> String {
-    let (platform, arch) = if cfg!(target_os = "macos") {
+/// Construct the platform-specific download URL and checksum for Temporal CLI.
+fn temporal_download_metadata() -> (String, &'static str) {
+    let (platform, arch, expected_sha256) = if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            (
+                "darwin",
+                "arm64",
+                "7bb0a9badbe5e29284fbf3337ead34bde9d1ce44f07d07ebe3199c52ae1ecf9b",
+            )
+        } else {
+            (
+                "darwin",
+                "amd64",
+                "bf98e085504ed1e9dace3b65177885aff6ccc18576c8c45fd824e6da010718f4",
+            )
+        }
+    } else if cfg!(target_arch = "aarch64") {
         (
-            "darwin",
-            if cfg!(target_arch = "aarch64") {
-                "arm64"
-            } else {
-                "amd64"
-            },
+            "linux",
+            "arm64",
+            "eaa8cf16c5ea5551cd1ee83dd7aa24ce6e9789bfed113a7a2a2dcd7be2a99767",
         )
     } else {
         (
             "linux",
-            if cfg!(target_arch = "aarch64") {
-                "arm64"
-            } else {
-                "amd64"
-            },
+            "amd64",
+            "ca03976fb948b7084f4075dab55afb65915713498577ea68b483a14e3dfcd74e",
         )
     };
 
-    format!(
-        "https://temporal.download/cli/archive/v{ver}?platform={platform}&arch={arch}",
-        ver = TEMPORAL_CLI_VERSION,
+    (
+        format!(
+            "https://temporal.download/cli/archive/v{ver}?platform={platform}&arch={arch}",
+            ver = TEMPORAL_CLI_VERSION,
+        ),
+        expected_sha256,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_temporal_download_metadata_uses_expected_checksum_shape() {
+        let (url, checksum) = temporal_download_metadata();
+
+        assert!(url.contains(TEMPORAL_CLI_VERSION));
+        assert_eq!(checksum.len(), 64);
+    }
 }


### PR DESCRIPTION
This adds a checksum check for the binaries downloaded for dockerless
moose. This ensure that the binary that is downloaded is the expected
one and prevents a lot of security issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds mandatory SHA-256 verification and cache invalidation for downloaded native infra binaries; mistakes in pinned checksums or cache marker handling could break local setup on specific platforms.
> 
> **Overview**
> Adds SHA-256 integrity verification to `BinaryManager::ensure_binary` for dockerless/native infra downloads, rejecting mismatched artifacts and re-downloading when a cached binary fails validation.
> 
> Updates ClickHouse and Temporal download helpers to return **platform-specific pinned checksums** and threads the `expected_sha256` through the download flow (including an `.artifact-sha256` marker for extracted archives). Error handling is expanded with new file read/write/remove variants plus a `ChecksumMismatch` error, and unit tests are added for checksum and cache validation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd98903a8fb3fbcf53e6a82c740115aeca596b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->