### PR TITLE
Add global binary cache for dockerless binaries

### DIFF
--- a/apps/framework-cli-e2e/test/dockerless-binary-cache.test.ts
+++ b/apps/framework-cli-e2e/test/dockerless-binary-cache.test.ts
@@ -1,0 +1,162 @@
+import { expect } from "chai";
+import { ChildProcess, execFileSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { TIMEOUTS } from "./constants";
+import {
+  createTempTestDirectory,
+  logger,
+  removeTestProject,
+  setupTypeScriptProject,
+  startMooseDev,
+  stopDevProcess,
+} from "./utils";
+
+const CLI_PATH = path.resolve(__dirname, "../../../target/debug/moose-cli");
+const MOOSE_LIB_PATH = path.resolve(
+  __dirname,
+  "../../../packages/ts-moose-lib",
+);
+
+const testLogger = logger.scope("dockerless-binary-cache");
+
+function createMinimalRuntimePath(binDir: string): void {
+  const runtimeBins = [
+    process.execPath,
+    "/bin/sh",
+    "/bin/bash",
+    resolveBinaryPath("npm"),
+    resolveBinaryPath("npx"),
+    resolveBinaryPath("pnpm"),
+  ].filter((candidate) => fs.existsSync(candidate));
+
+  for (const sourcePath of runtimeBins) {
+    fs.symlinkSync(sourcePath, path.join(binDir, path.basename(sourcePath)));
+  }
+}
+
+function resolveBinaryPath(command: string): string {
+  try {
+    return execFileSync("which", [command], { encoding: "utf8" }).trim();
+  } catch {
+    return path.join("/missing", command);
+  }
+}
+
+async function waitForClickHouseBinary(
+  binariesRoot: string,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const clickhouseRoot = path.join(binariesRoot, "clickhouse");
+    if (fs.existsSync(clickhouseRoot)) {
+      const clickhouseVersions = fs.readdirSync(clickhouseRoot);
+      if (clickhouseVersions.length > 0) {
+        const platformRoot = path.join(clickhouseRoot, clickhouseVersions[0]);
+        const platformDirs = fs.readdirSync(platformRoot);
+        if (platformDirs.length > 0) {
+          const clickhouseBinaryPath = path.join(
+            platformRoot,
+            platformDirs[0],
+            "clickhouse",
+          );
+          if (fs.existsSync(clickhouseBinaryPath)) {
+            return clickhouseBinaryPath;
+          }
+        }
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Timed out waiting for clickhouse binary to appear under ${binariesRoot}`,
+  );
+}
+
+describe("Dockerless Binary Cache", function () {
+  this.timeout(300_000);
+
+  let projectDir: string;
+  let cacheHomeDir: string;
+  let pathBinDir: string;
+  let devProcess: ChildProcess | null = null;
+
+  before(async function () {
+    projectDir = createTempTestDirectory("dockerless-cache", {
+      logger: testLogger,
+    });
+    cacheHomeDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "moose-e2e-cache-home-"),
+    );
+    pathBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "moose-e2e-bin-"));
+
+    createMinimalRuntimePath(pathBinDir);
+
+    await setupTypeScriptProject(
+      projectDir,
+      "typescript",
+      CLI_PATH,
+      MOOSE_LIB_PATH,
+      "dockerless-cache-app",
+      "npm",
+      {
+        env: {
+          ...process.env,
+          HOME: cacheHomeDir,
+        },
+        logger: testLogger,
+      },
+    );
+  });
+
+  after(async function () {
+    this.timeout(TIMEOUTS.CLEANUP_MS);
+
+    if (devProcess) {
+      await stopDevProcess(devProcess, { logger: testLogger });
+      devProcess = null;
+    }
+
+    removeTestProject(projectDir, { logger: testLogger });
+    removeTestProject(cacheHomeDir, { logger: testLogger });
+    removeTestProject(pathBinDir, { logger: testLogger });
+  });
+
+  afterEach(async function () {
+    if (devProcess) {
+      await stopDevProcess(devProcess, { logger: testLogger });
+      devProcess = null;
+    }
+  });
+
+  it("uses the shared home cache without relying on PATH-installed binaries", async function () {
+    devProcess = startMooseDev({
+      cliPath: CLI_PATH,
+      cwd: projectDir,
+      projectDir,
+      logger: testLogger,
+      extraEnv: {
+        HOME: cacheHomeDir,
+        PATH: pathBinDir,
+      },
+    }).devProcess;
+
+    const binariesRoot = path.join(cacheHomeDir, ".moose", "binaries");
+    const clickhouseBinaryPath = await waitForClickHouseBinary(
+      binariesRoot,
+      TIMEOUTS.SERVER_STARTUP_MS,
+    );
+
+    expect(devProcess.exitCode).to.equal(null);
+    expect(fs.existsSync(path.join(pathBinDir, "clickhouse"))).to.equal(false);
+    expect(fs.existsSync(path.join(pathBinDir, "temporal"))).to.equal(false);
+    expect(fs.existsSync(binariesRoot)).to.equal(true);
+    expect(fs.existsSync(clickhouseBinaryPath)).to.equal(true);
+  });
+});

--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -61,6 +61,7 @@ import {
   verifyWebAppQuery,
   verifyWebAppPostEndpoint,
   buildMooseDevEnv,
+  getTestPorts,
   cleanupTestSuite,
   getCleanupOptionsForMode,
   isDockerlessMode,
@@ -87,6 +88,7 @@ import { createClient } from "@clickhouse/client";
 
 const testLogger = logger.scope("templates-test");
 const E2E_DEV_MODE = resolveE2eDevMode({ logger: testLogger });
+const DEFAULT_TEST_PORTS = getTestPorts(0);
 
 const execAsync = promisify(require("child_process").exec);
 const setTimeoutAsync = (ms: number) =>
@@ -274,6 +276,7 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
       this.timeout(TIMEOUTS.CLEANUP_MS);
       await cleanupTestSuite(devProcess, TEST_PROJECT_DIR, config.appName, {
         logPrefix: config.displayName,
+        ports: DEFAULT_TEST_PORTS,
         ...getCleanupOptionsForMode(E2E_DEV_MODE),
       });
     });
@@ -3048,7 +3051,7 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
 
           // Stop the main dev server and its native infra to free ports
           testLogger.info("Stopping main dev server for namespace DLQ test...");
-          await stopDevProcess(devProcess);
+          await stopDevProcess(devProcess, { ports: DEFAULT_TEST_PORTS });
 
           testLogger.info(
             "Initializing fresh project with namespace for DLQ test...",
@@ -3113,6 +3116,7 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
           this.timeout(TIMEOUTS.TEST_SETUP_MS);
           await cleanupTestSuite(nsDevProcess, nsProjectDir, NS_APP_NAME, {
             logPrefix: `${config.displayName} (namespace)`,
+            ports: DEFAULT_TEST_PORTS,
             ...getCleanupOptionsForMode(E2E_DEV_MODE),
           });
           // Namespace DLQ tests are the tail of this suite. The parent after()

--- a/apps/framework-cli-e2e/test/utils/port-config.ts
+++ b/apps/framework-cli-e2e/test/utils/port-config.ts
@@ -13,6 +13,8 @@ export interface TestPorts {
   httpPort: number;
   /** Moose management / console server */
   managementPort: number;
+  /** Consumption API proxy server */
+  proxyPort: number;
   /** ClickHouse HTTP port */
   clickhouseHttpPort: number;
   /** ClickHouse native TCP port */
@@ -51,6 +53,7 @@ export interface ServerEndpointsConfig {
 const BASE_PORTS: TestPorts = {
   httpPort: 4000,
   managementPort: 5001,
+  proxyPort: 4001,
   clickhouseHttpPort: 18123,
   clickhouseNativePort: 19000,
   keeperPort: 9181,
@@ -70,6 +73,7 @@ export function getTestPorts(offset: number): TestPorts {
   return {
     httpPort: BASE_PORTS.httpPort + offset,
     managementPort: BASE_PORTS.managementPort + offset,
+    proxyPort: BASE_PORTS.proxyPort + offset,
     clickhouseHttpPort: BASE_PORTS.clickhouseHttpPort + offset,
     clickhouseNativePort: BASE_PORTS.clickhouseNativePort + offset,
     keeperPort: BASE_PORTS.keeperPort + offset,
@@ -88,6 +92,7 @@ export function buildPortEnv(ports: TestPorts): Record<string, string> {
   return {
     MOOSE_HTTP_SERVER_CONFIG__PORT: `${ports.httpPort}`,
     MOOSE_HTTP_SERVER_CONFIG__MANAGEMENT_PORT: `${ports.managementPort}`,
+    MOOSE_HTTP_SERVER_CONFIG__PROXY_PORT: `${ports.proxyPort}`,
     MOOSE_CLICKHOUSE_CONFIG__HOST_PORT: `${ports.clickhouseHttpPort}`,
     MOOSE_CLICKHOUSE_CONFIG__NATIVE_PORT: `${ports.clickhouseNativePort}`,
     MOOSE_CLICKHOUSE_CONFIG__KEEPER_PORT: `${ports.keeperPort}`,

--- a/apps/framework-cli-e2e/test/utils/process-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/process-utils.ts
@@ -252,16 +252,16 @@ export const killRemainingProcesses = async (
 ): Promise<void> => {
   const log = options.logger ?? processLogger;
 
-  // Default infrastructure ports used when no override is provided.
-  const defaultPorts = [18123, 19000, 9181, 9234, 19092, 16379, 7233];
+  // Default ports for a single dev server instance when no override is provided.
+  const defaultPorts = [
+    4000, 4001, 5001, 18123, 19000, 9181, 9234, 19092, 16379, 7233,
+  ];
   const rawPorts =
     Array.isArray(options.ports) ? options.ports
     : options.ports ? Object.values(options.ports)
     : defaultPorts;
   const portsToKill = [...new Set(rawPorts)];
-  const portsToWait = portsToKill.filter((port) =>
-    [18123, 19000, 9181, 9234, 19092, 16379, 7233].includes(port),
-  );
+  const portsToWait = portsToKill;
 
   // Kill processes holding the specified ports.
   try {

--- a/apps/framework-cli-e2e/test/utils/project-setup.ts
+++ b/apps/framework-cli-e2e/test/utils/project-setup.ts
@@ -7,6 +7,7 @@ import { logger, ScopedLogger } from "./logger";
 const projectSetupLogger = logger.scope("utils:project-setup");
 
 export interface ProjectSetupOptions {
+  env?: NodeJS.ProcessEnv;
   logger?: ScopedLogger;
   onInitComplete?: (result: { stdout: string; stderr: string }) => void;
 }
@@ -92,12 +93,17 @@ export const setupTypeScriptProject = async (
   options: ProjectSetupOptions = {},
 ): Promise<void> => {
   const log = options.logger ?? projectSetupLogger;
+  const env = {
+    ...process.env,
+    ...options.env,
+  };
 
   // Initialize project
   log.info(`Initializing TypeScript project with ${templateName} template`);
   try {
     const result = await execAsync(
       `"${cliPath}" init ${appName} ${templateName} --location "${projectDir}"`,
+      { env },
     );
     log.debug("CLI init stdout", { stdout: result.stdout });
     if (result.stderr) {
@@ -126,6 +132,7 @@ export const setupTypeScriptProject = async (
     const installCmd = spawn(packageManager, ["install"], {
       stdio: "inherit",
       cwd: projectDir,
+      env,
     });
     installCmd.on("close", (code) => {
       log.debug(`${packageManager} install completed`, { exitCode: code });
@@ -150,12 +157,17 @@ export const setupPythonProject = async (
   options: ProjectSetupOptions = {},
 ): Promise<void> => {
   const log = options.logger ?? projectSetupLogger;
+  const env = {
+    ...process.env,
+    ...options.env,
+  };
 
   // Initialize project
   log.info(`Initializing Python project with ${templateName} template`);
   try {
     const result = await execAsync(
       `"${cliPath}" init ${appName} ${templateName} --location "${projectDir}"`,
+      { env },
     );
     log.debug("CLI init stdout", { stdout: result.stdout });
     if (result.stderr) {
@@ -174,9 +186,7 @@ export const setupPythonProject = async (
     const venvCmd = spawn(setupCmd, ["-m", "venv", ".venv"], {
       stdio: "inherit",
       cwd: projectDir,
-      env: {
-        ...process.env,
-      },
+      env,
     });
     venvCmd.on("close", async (code) => {
       if (code !== 0) {
@@ -185,9 +195,9 @@ export const setupPythonProject = async (
       }
 
       const withVenv = {
-        ...process.env,
+        ...env,
         VIRTUAL_ENV: path.join(projectDir, ".venv"),
-        PATH: `${path.join(projectDir, ".venv", "bin")}:${process.env.PATH}`,
+        PATH: `${path.join(projectDir, ".venv", "bin")}:${env.PATH}`,
       };
 
       // First install project dependencies from requirements.txt

--- a/apps/framework-cli/src/utilities/native_infra/binary_manager.rs
+++ b/apps/framework-cli/src/utilities/native_infra/binary_manager.rs
@@ -38,15 +38,8 @@ impl BinaryManager {
         archive_binary_path: Option<&str>,
         expected_sha256: &str,
     ) -> Result<PathBuf, NativeInfraError> {
-        let (platform, arch) = detect_platform()?;
-        let cache_dir = self
-            .cache_root
-            .join(name)
-            .join(version)
-            .join(format!("{platform}-{arch}"));
-
-        let binary_name = archive_binary_path.unwrap_or(name);
-        let binary_path = cache_dir.join(binary_name);
+        let cache_dir = self.cache_dir(name, version)?;
+        let binary_path = self.binary_path(name, version, archive_binary_path)?;
 
         if binary_path.exists() {
             if cache_is_valid(
@@ -106,6 +99,25 @@ impl BinaryManager {
         );
 
         Ok(binary_path)
+    }
+
+    fn cache_dir(&self, name: &str, version: &str) -> Result<PathBuf, NativeInfraError> {
+        let (platform, arch) = detect_platform()?;
+        Ok(self
+            .cache_root
+            .join(name)
+            .join(version)
+            .join(format!("{platform}-{arch}")))
+    }
+
+    fn binary_path(
+        &self,
+        name: &str,
+        version: &str,
+        archive_binary_path: Option<&str>,
+    ) -> Result<PathBuf, NativeInfraError> {
+        let binary_name = archive_binary_path.unwrap_or(name);
+        Ok(self.cache_dir(name, version)?.join(binary_name))
     }
 }
 
@@ -323,6 +335,7 @@ fn set_executable(path: &Path) -> Result<(), NativeInfraError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utilities::constants::CLI_VERSION;
     use tempfile::tempdir;
 
     #[test]
@@ -340,11 +353,7 @@ mod tests {
         let manager = BinaryManager::new().unwrap();
         let (platform, arch) = detect_platform().unwrap();
         let expected_suffix = format!("binaries/clickhouse/25.0.0/{platform}-{arch}");
-        let cache_dir = manager
-            .cache_root
-            .join("clickhouse")
-            .join("25.0.0")
-            .join(format!("{platform}-{arch}"));
+        let cache_dir = manager.cache_dir("clickhouse", "25.0.0").unwrap();
         assert!(
             cache_dir.to_string_lossy().ends_with(&expected_suffix),
             "Cache dir should follow binaries/name/version/platform-arch pattern"
@@ -450,5 +459,31 @@ mod tests {
             cache_is_valid(&binary_path, dir.path(), Some("temporal"), "expected-sha").unwrap();
 
         assert!(!is_valid);
+    }
+
+    #[test]
+    fn test_binary_manager_uses_home_level_cache_root() {
+        let manager = BinaryManager::new().unwrap();
+        assert!(
+            manager
+                .cache_root
+                .to_string_lossy()
+                .ends_with(".moose/binaries"),
+            "Cache root should be the shared ~/.moose/binaries directory"
+        );
+    }
+
+    #[test]
+    fn test_binary_manager_does_not_namespace_cache_by_cli_version() {
+        let manager = BinaryManager::new().unwrap();
+        let binary_path = manager
+            .binary_path("clickhouse", "25.0.0", None)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert!(
+            !binary_path.contains(&format!("/{CLI_VERSION}/")),
+            "Binary cache path should be keyed by dependency binary version, not CLI version"
+        );
     }
 }


### PR DESCRIPTION
This moves the binary cache to the global .moose rather than per
project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where dockerless infra binaries are cached (now shared under `~/.moose/binaries`) and updates test harness cleanup/port management; regressions could surface as missing binaries, permission issues, or port cleanup flakiness in CI/local runs.
> 
> **Overview**
> **Dockerless native infra binaries now use a shared home-level cache** (`~/.moose/binaries/{name}/{version}/{platform}-{arch}`) instead of being project-scoped, with `BinaryManager` refactored to centralize cache path construction and new unit coverage to ensure the cache is not namespaced by CLI version.
> 
> **E2E harness updates** add a dedicated dockerless binary-cache test that runs with a minimal `PATH` and asserts binaries are fetched into the home cache, and adjust template suite teardown to pass explicit `TestPorts` (including a new `proxyPort`) so process cleanup/port killing targets the full set of ports used by a dev server.
> 
> **Project setup utilities** now accept an optional `env` override so tests can control `HOME`/environment during `init` and dependency installation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d510cd84c67c2c9ee99b12d665630c0910b9308e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->