### PR TITLE
Fix kafka_clickhouse_sync consumer changing have a different name

### DIFF
--- a/apps/devkafka/src/groups.rs
+++ b/apps/devkafka/src/groups.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use bytes::Bytes;
 use kafka_protocol::messages::{GroupId, TopicName};
 use kafka_protocol::protocol::StrBytes;
+use tokio::sync::watch;
 
 /// Consumer group lifecycle state, following the Kafka protocol state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,11 +55,18 @@ pub struct ConsumerGroup {
     pub protocol_name: Option<StrBytes>,
     pub leader_id: Option<StrBytes>,
     pub members: HashMap<StrBytes, GroupMember>,
+    pub rebalance_started_at: Option<Instant>,
+    pub last_join_at: Option<Instant>,
+    pub rebalance_timeout_ms: i32,
+    pub joined_members: HashSet<StrBytes>,
+    state_epoch: u64,
+    pub state_updates: watch::Sender<u64>,
 }
 
 impl ConsumerGroup {
     /// Create an empty consumer group with the given ID.
     pub fn new(group_id: GroupId) -> Self {
+        let (state_updates, _) = watch::channel(0);
         Self {
             group_id,
             state: GroupState::Empty,
@@ -67,7 +75,18 @@ impl ConsumerGroup {
             protocol_name: None,
             leader_id: None,
             members: HashMap::new(),
+            rebalance_started_at: None,
+            last_join_at: None,
+            rebalance_timeout_ms: 0,
+            joined_members: HashSet::new(),
+            state_epoch: 0,
+            state_updates,
         }
+    }
+
+    fn notify_state_change(&mut self) {
+        self.state_epoch += 1;
+        let _ = self.state_updates.send_replace(self.state_epoch);
     }
 
     /// Select a partition assignment protocol supported by all members.
@@ -92,7 +111,7 @@ impl ConsumerGroup {
     }
 
     /// Remove a member from the group, re-electing the leader if necessary.
-    pub fn remove_member(&mut self, member_id: &StrBytes) {
+    pub fn remove_member(&mut self, member_id: &StrBytes, now: Instant) {
         self.members.remove(member_id);
         if self.leader_id.as_ref() == Some(member_id) {
             self.leader_id = self.members.keys().next().cloned();
@@ -103,9 +122,124 @@ impl ConsumerGroup {
             self.leader_id = None;
             self.protocol_type = None;
             self.protocol_name = None;
+            self.rebalance_started_at = None;
+            self.last_join_at = None;
+            self.rebalance_timeout_ms = 0;
+            self.joined_members.clear();
         } else {
             self.state = GroupState::PreparingRebalance;
+            self.rebalance_started_at = Some(now);
+            self.last_join_at = Some(now);
+            self.rebalance_timeout_ms = self
+                .members
+                .values()
+                .map(|member| member.rebalance_timeout_ms.max(1000))
+                .max()
+                .unwrap_or(1000);
+            self.joined_members.remove(member_id);
         }
+        self.notify_state_change();
+    }
+
+    pub fn prepare_rebalance(&mut self, now: Instant, rebalance_timeout_ms: i32) {
+        let rebalance_timeout_ms = rebalance_timeout_ms.max(1000);
+        if self.state != GroupState::PreparingRebalance {
+            self.rebalance_started_at = Some(now);
+            self.rebalance_timeout_ms = rebalance_timeout_ms;
+            self.joined_members.clear();
+        } else {
+            self.rebalance_timeout_ms = self.rebalance_timeout_ms.max(rebalance_timeout_ms);
+        }
+
+        self.state = GroupState::PreparingRebalance;
+        self.last_join_at = Some(now);
+        self.notify_state_change();
+    }
+
+    pub fn note_member_joined(&mut self, member_id: &StrBytes, now: Instant) {
+        self.joined_members.insert(member_id.clone());
+        self.last_join_at = Some(now);
+        self.notify_state_change();
+    }
+
+    pub fn should_finalize_rebalance(
+        &self,
+        now: Instant,
+        quiet_period: std::time::Duration,
+    ) -> bool {
+        if self.state != GroupState::PreparingRebalance {
+            return false;
+        }
+
+        let all_members_joined =
+            !self.members.is_empty() && self.joined_members.len() == self.members.len();
+
+        let quiet_elapsed = self
+            .last_join_at
+            .map(|last_join_at| now.duration_since(last_join_at) >= quiet_period)
+            .unwrap_or(false);
+
+        let timed_out = self
+            .rebalance_started_at
+            .map(|rebalance_started_at| {
+                now.duration_since(rebalance_started_at).as_millis()
+                    >= self.rebalance_timeout_ms.max(0) as u128
+            })
+            .unwrap_or(false);
+
+        (all_members_joined && quiet_elapsed) || timed_out
+    }
+
+    pub fn rebalance_wait_duration(
+        &self,
+        now: Instant,
+        quiet_period: std::time::Duration,
+    ) -> std::time::Duration {
+        let until_quiet = self
+            .last_join_at
+            .map(|last_join_at| {
+                quiet_period.saturating_sub(now.saturating_duration_since(last_join_at))
+            })
+            .unwrap_or_default();
+
+        let until_timeout = self
+            .rebalance_started_at
+            .map(|rebalance_started_at| {
+                std::time::Duration::from_millis(self.rebalance_timeout_ms.max(0) as u64)
+                    .saturating_sub(now.saturating_duration_since(rebalance_started_at))
+            })
+            .unwrap_or_default();
+
+        match (until_quiet.is_zero(), until_timeout.is_zero()) {
+            (true, true) => std::time::Duration::from_millis(0),
+            (true, false) => until_timeout,
+            (false, true) => until_quiet,
+            (false, false) => until_quiet.min(until_timeout),
+        }
+    }
+
+    pub fn finalize_rebalance(&mut self) {
+        if self.leader_id.is_none()
+            || !self
+                .members
+                .contains_key(self.leader_id.as_ref().expect("leader_id checked above"))
+        {
+            self.leader_id = self.members.keys().next().cloned();
+        }
+
+        self.protocol_name = self.choose_protocol();
+        self.generation_id += 1;
+        self.state = GroupState::CompletingRebalance;
+        self.rebalance_started_at = None;
+        self.last_join_at = None;
+        self.joined_members.clear();
+        self.notify_state_change();
+    }
+
+    pub fn mark_stable(&mut self) {
+        self.state = GroupState::Stable;
+        self.joined_members.clear();
+        self.notify_state_change();
     }
 
     /// Remove members whose last heartbeat exceeds their session timeout.
@@ -127,7 +261,7 @@ impl ConsumerGroup {
                 reason,
                 "Reaping expired member"
             );
-            self.remove_member(&member_id);
+            self.remove_member(&member_id, now);
         }
     }
 }

--- a/apps/devkafka/src/handlers/heartbeat.rs
+++ b/apps/devkafka/src/handlers/heartbeat.rs
@@ -23,6 +23,11 @@ pub async fn handle(
         }
     };
 
+    if group.state != crate::groups::GroupState::Stable {
+        response.error_code = error::REBALANCE_IN_PROGRESS;
+        return response;
+    }
+
     if request.generation_id != group.generation_id {
         response.error_code = error::ILLEGAL_GENERATION;
         return response;

--- a/apps/devkafka/src/handlers/join_group.rs
+++ b/apps/devkafka/src/handlers/join_group.rs
@@ -9,97 +9,13 @@ use crate::broker::Broker;
 use crate::error;
 use crate::groups::{GroupMember, GroupState};
 
-/// Handle JoinGroup requests: generate member IDs, negotiate a common protocol,
-/// elect a leader, and advance the group generation.
-pub async fn handle(
-    broker: &Broker,
-    request: JoinGroupRequest,
-    _api_version: i16,
+const JOIN_GROUP_QUIET_PERIOD_MS: u64 = 75;
+
+fn build_join_group_response(
+    group: &crate::groups::ConsumerGroup,
+    member_id: &StrBytes,
 ) -> JoinGroupResponse {
     let mut response = JoinGroupResponse::default();
-    let mut coordinator = broker.groups.write().await;
-
-    let group = coordinator.get_or_create_group(request.group_id.clone());
-
-    // Eagerly reap expired members before processing the join. Without this,
-    // a dead leader lingers for up to session_timeout + reaper_interval. The
-    // joining member wouldn't be elected leader and would receive an empty
-    // partition assignment from SyncGroup, stalling consumption.
-    let now = std::time::Instant::now();
-    group.reap_expired_members(now, "join_group");
-
-    // Generate or reuse member_id
-    let member_id = if request.member_id.is_empty() {
-        StrBytes::from_string(format!("member-{}", uuid::Uuid::new_v4()))
-    } else {
-        request.member_id.clone()
-    };
-
-    // Build protocols list
-    let protocols: Vec<(StrBytes, Bytes)> = request
-        .protocols
-        .iter()
-        .map(|p| (p.name.clone(), p.metadata.clone()))
-        .collect();
-
-    // Clamp session timeout to at least 1s to prevent negative values from
-    // wrapping to huge u128 values in the member reaper.
-    let session_timeout = request.session_timeout_ms.max(1000);
-    let rebalance_timeout = if request.rebalance_timeout_ms > 0 {
-        request.rebalance_timeout_ms
-    } else {
-        session_timeout
-    };
-
-    // Add/update member
-    let member = GroupMember {
-        member_id: member_id.clone(),
-        client_id: StrBytes::from_static_str(""),
-        client_host: StrBytes::from_static_str(""),
-        protocol_type: request.protocol_type.clone(),
-        protocols,
-        assignment: Bytes::new(),
-        session_timeout_ms: session_timeout,
-        rebalance_timeout_ms: rebalance_timeout,
-        last_heartbeat: Instant::now(),
-    };
-    group.members.insert(member_id.clone(), member);
-
-    // Set protocol type
-    group.protocol_type = Some(request.protocol_type.clone());
-
-    // Validate that all members share a common protocol. If not, roll back.
-    if group.members.len() > 1 && group.choose_protocol().is_none() {
-        group.remove_member(&member_id);
-        response.error_code = error::INCONSISTENT_GROUP_PROTOCOL;
-        return response;
-    }
-
-    // Elect leader if needed, or re-elect if the current leader is no longer a member
-    // (e.g. it was reaped above but the leader_id wasn't cleared).
-    if group.leader_id.is_none()
-        || !group.members.contains_key(
-            group
-                .leader_id
-                .as_ref()
-                .map_or(&member_id, |leader_id| leader_id),
-        )
-    {
-        group.leader_id = Some(member_id.clone());
-    }
-
-    // Choose protocol
-    group.protocol_name = group.choose_protocol();
-
-    // Advance generation only once per rebalance round. If the group is already
-    // in CompletingRebalance (i.e. another member already triggered the bump in
-    // this round), keep the same generation so all members see a consistent value.
-    if group.state != GroupState::CompletingRebalance {
-        group.generation_id += 1;
-        group.state = GroupState::CompletingRebalance;
-    }
-
-    // Build response
     response.error_code = error::NONE;
     response.generation_id = group.generation_id;
     response.protocol_type = group.protocol_type.clone();
@@ -107,14 +23,16 @@ pub async fn handle(
     response.leader = group.leader_id.clone().unwrap_or_default();
     response.member_id = member_id.clone();
 
-    // If this member is the leader, include all members
-    if group.leader_id.as_ref() == Some(&member_id) {
-        for (mid, m) in &group.members {
+    if group.leader_id.as_ref() == Some(member_id) {
+        for (mid, member) in &group.members {
             let mut member_resp = JoinGroupResponseMember::default();
             member_resp.member_id = mid.clone();
-            // Find metadata for chosen protocol
-            if let Some(proto_name) = &group.protocol_name {
-                if let Some((_, metadata)) = m.protocols.iter().find(|(n, _)| n == proto_name) {
+            if let Some(protocol_name) = &group.protocol_name {
+                if let Some((_, metadata)) = member
+                    .protocols
+                    .iter()
+                    .find(|(name, _)| name == protocol_name)
+                {
                     member_resp.metadata = metadata.clone();
                 }
             }
@@ -122,13 +40,139 @@ pub async fn handle(
         }
     }
 
-    tracing::info!(
-        group = %request.group_id.0,
-        member = %member_id,
-        generation = group.generation_id,
-        leader = ?group.leader_id,
-        "Member joined group"
-    );
-
     response
+}
+
+/// Handle JoinGroup requests: generate member IDs, negotiate a common protocol,
+/// elect a leader, and advance the group generation.
+pub async fn handle(
+    broker: &Broker,
+    request: JoinGroupRequest,
+    _api_version: i16,
+) -> JoinGroupResponse {
+    let now = std::time::Instant::now();
+    let member_id;
+    let mut updates;
+
+    {
+        let mut coordinator = broker.groups.write().await;
+        let group = coordinator.get_or_create_group(request.group_id.clone());
+
+        // Eagerly reap expired members before processing the join. Without this,
+        // a dead leader lingers for up to session_timeout + reaper_interval. The
+        // joining member wouldn't be elected leader and would receive an empty
+        // partition assignment from SyncGroup, stalling consumption.
+        group.reap_expired_members(now, "join_group");
+
+        member_id = if request.member_id.is_empty() {
+            StrBytes::from_string(format!("member-{}", uuid::Uuid::new_v4()))
+        } else {
+            request.member_id.clone()
+        };
+
+        let protocols: Vec<(StrBytes, Bytes)> = request
+            .protocols
+            .iter()
+            .map(|p| (p.name.clone(), p.metadata.clone()))
+            .collect();
+
+        let session_timeout = request.session_timeout_ms.max(1000);
+        let rebalance_timeout = if request.rebalance_timeout_ms > 0 {
+            request.rebalance_timeout_ms
+        } else {
+            session_timeout
+        };
+
+        let member = GroupMember {
+            member_id: member_id.clone(),
+            client_id: StrBytes::from_static_str(""),
+            client_host: StrBytes::from_static_str(""),
+            protocol_type: request.protocol_type.clone(),
+            protocols,
+            assignment: Bytes::new(),
+            session_timeout_ms: session_timeout,
+            rebalance_timeout_ms: rebalance_timeout,
+            last_heartbeat: Instant::now(),
+        };
+
+        if let Some(existing_protocol_type) = &group.protocol_type {
+            if existing_protocol_type != &request.protocol_type {
+                let mut response = JoinGroupResponse::default();
+                response.error_code = error::INCONSISTENT_GROUP_PROTOCOL;
+                return response;
+            }
+        }
+
+        let previous_member = group.members.insert(member_id.clone(), member);
+
+        if group.members.len() > 1 && group.choose_protocol().is_none() {
+            if let Some(previous_member) = previous_member {
+                group.members.insert(member_id.clone(), previous_member);
+            } else {
+                group.members.remove(&member_id);
+            }
+            let mut response = JoinGroupResponse::default();
+            response.error_code = error::INCONSISTENT_GROUP_PROTOCOL;
+            return response;
+        }
+
+        group.protocol_type = Some(request.protocol_type.clone());
+
+        if group.leader_id.is_none()
+            || !group.members.contains_key(
+                group
+                    .leader_id
+                    .as_ref()
+                    .map_or(&member_id, |leader_id| leader_id),
+            )
+        {
+            group.leader_id = Some(member_id.clone());
+        }
+
+        group.prepare_rebalance(now, rebalance_timeout);
+        group.note_member_joined(&member_id, now);
+        updates = group.state_updates.subscribe();
+    }
+
+    let quiet_period = std::time::Duration::from_millis(JOIN_GROUP_QUIET_PERIOD_MS);
+
+    loop {
+        let wait_duration = {
+            let mut coordinator = broker.groups.write().await;
+            let group = match coordinator.groups.get_mut(&request.group_id) {
+                Some(group) => group,
+                None => {
+                    let mut response = JoinGroupResponse::default();
+                    response.error_code = error::NOT_COORDINATOR;
+                    return response;
+                }
+            };
+
+            if !group.members.contains_key(&member_id) {
+                let mut response = JoinGroupResponse::default();
+                response.error_code = error::UNKNOWN_MEMBER_ID;
+                return response;
+            }
+
+            let now = Instant::now();
+            if group.should_finalize_rebalance(now, quiet_period) {
+                group.finalize_rebalance();
+            }
+
+            if group.state == GroupState::CompletingRebalance {
+                tracing::info!(
+                    group = %request.group_id.0,
+                    member = %member_id,
+                    generation = group.generation_id,
+                    leader = ?group.leader_id,
+                    "Member joined group"
+                );
+                return build_join_group_response(group, &member_id);
+            }
+
+            group.rebalance_wait_duration(now, quiet_period)
+        };
+
+        let _ = tokio::time::timeout(wait_duration, updates.changed()).await;
+    }
 }

--- a/apps/devkafka/src/handlers/leave_group.rs
+++ b/apps/devkafka/src/handlers/leave_group.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use kafka_protocol::messages::leave_group_response::{LeaveGroupResponse, MemberResponse};
 use kafka_protocol::messages::LeaveGroupRequest;
 
@@ -27,7 +29,7 @@ pub async fn handle(
             let mut member_resp = MemberResponse::default();
             member_resp.member_id = member.member_id.clone();
             if group.members.contains_key(&member.member_id) {
-                group.remove_member(&member.member_id);
+                group.remove_member(&member.member_id, Instant::now());
                 member_resp.error_code = error::NONE;
                 tracing::info!(group = %request.group_id.0, member = %member.member_id, "Member left group");
             } else {
@@ -37,7 +39,7 @@ pub async fn handle(
         }
         response.error_code = error::NONE;
     } else if group.members.contains_key(&request.member_id) {
-        group.remove_member(&request.member_id);
+        group.remove_member(&request.member_id, Instant::now());
         response.error_code = error::NONE;
         tracing::info!(group = %request.group_id.0, member = %request.member_id, "Member left group");
     } else {

--- a/apps/devkafka/src/handlers/sync_group.rs
+++ b/apps/devkafka/src/handlers/sync_group.rs
@@ -5,6 +5,20 @@ use crate::broker::Broker;
 use crate::error;
 use crate::groups::GroupState;
 
+fn build_sync_group_response(
+    group: &crate::groups::ConsumerGroup,
+    member_id: &kafka_protocol::protocol::StrBytes,
+) -> SyncGroupResponse {
+    let mut response = SyncGroupResponse::default();
+    response.error_code = error::NONE;
+    response.protocol_type = group.protocol_type.clone();
+    response.protocol_name = group.protocol_name.clone();
+    if let Some(member) = group.members.get(member_id) {
+        response.assignment = member.assignment.clone();
+    }
+    response
+}
+
 /// Handle SyncGroup requests, distributing partition assignments from the leader
 /// to all group members.
 pub async fn handle(
@@ -12,45 +26,99 @@ pub async fn handle(
     request: SyncGroupRequest,
     _api_version: i16,
 ) -> SyncGroupResponse {
-    let mut response = SyncGroupResponse::default();
-    let mut coordinator = broker.groups.write().await;
+    let deadline = {
+        let coordinator = broker.groups.read().await;
+        let group = match coordinator.groups.get(&request.group_id) {
+            Some(group) => group,
+            None => {
+                let mut response = SyncGroupResponse::default();
+                response.error_code = error::NOT_COORDINATOR;
+                return response;
+            }
+        };
 
-    let group = match coordinator.groups.get_mut(&request.group_id) {
-        Some(g) => g,
-        None => {
-            response.error_code = error::NOT_COORDINATOR;
+        let member = match group.members.get(&request.member_id) {
+            Some(member) => member,
+            None => {
+                let mut response = SyncGroupResponse::default();
+                response.error_code = error::UNKNOWN_MEMBER_ID;
+                return response;
+            }
+        };
+
+        if request.generation_id != group.generation_id {
+            let mut response = SyncGroupResponse::default();
+            response.error_code = error::ILLEGAL_GENERATION;
             return response;
+        }
+
+        std::time::Instant::now()
+            + std::time::Duration::from_millis(member.rebalance_timeout_ms.max(1000) as u64)
+    };
+
+    let mut updates = {
+        let coordinator = broker.groups.read().await;
+        match coordinator.groups.get(&request.group_id) {
+            Some(group) => group.state_updates.subscribe(),
+            None => {
+                let mut response = SyncGroupResponse::default();
+                response.error_code = error::NOT_COORDINATOR;
+                return response;
+            }
         }
     };
 
-    if !group.members.contains_key(&request.member_id) {
-        response.error_code = error::UNKNOWN_MEMBER_ID;
-        return response;
-    }
+    loop {
+        let wait_duration = {
+            let mut coordinator = broker.groups.write().await;
+            let group = match coordinator.groups.get_mut(&request.group_id) {
+                Some(group) => group,
+                None => {
+                    let mut response = SyncGroupResponse::default();
+                    response.error_code = error::NOT_COORDINATOR;
+                    return response;
+                }
+            };
 
-    if request.generation_id != group.generation_id {
-        response.error_code = error::ILLEGAL_GENERATION;
-        return response;
-    }
-
-    // If the requester is the leader, store assignments for all members
-    if group.leader_id.as_ref() == Some(&request.member_id) {
-        for assignment in &request.assignments {
-            if let Some(member) = group.members.get_mut(&assignment.member_id) {
-                member.assignment = assignment.assignment.clone();
+            if !group.members.contains_key(&request.member_id) {
+                let mut response = SyncGroupResponse::default();
+                response.error_code = error::UNKNOWN_MEMBER_ID;
+                return response;
             }
-        }
-        group.state = GroupState::Stable;
+
+            if request.generation_id != group.generation_id {
+                let mut response = SyncGroupResponse::default();
+                response.error_code = error::ILLEGAL_GENERATION;
+                return response;
+            }
+
+            if group.leader_id.as_ref() == Some(&request.member_id) {
+                for member in group.members.values_mut() {
+                    member.assignment = Default::default();
+                }
+                for assignment in &request.assignments {
+                    if let Some(member) = group.members.get_mut(&assignment.member_id) {
+                        member.assignment = assignment.assignment.clone();
+                    }
+                }
+                group.mark_stable();
+                return build_sync_group_response(group, &request.member_id);
+            }
+
+            if group.state == GroupState::Stable {
+                return build_sync_group_response(group, &request.member_id);
+            }
+
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                let mut response = SyncGroupResponse::default();
+                response.error_code = error::REBALANCE_IN_PROGRESS;
+                return response;
+            }
+
+            deadline.saturating_duration_since(now)
+        };
+
+        let _ = tokio::time::timeout(wait_duration, updates.changed()).await;
     }
-
-    // Return this member's assignment
-    if let Some(member) = group.members.get(&request.member_id) {
-        response.assignment = member.assignment.clone();
-    }
-
-    response.error_code = 0;
-    response.protocol_type = group.protocol_type.clone();
-    response.protocol_name = group.protocol_name.clone();
-
-    response
 }

--- a/apps/devkafka/tests/consumer_groups.rs
+++ b/apps/devkafka/tests/consumer_groups.rs
@@ -9,6 +9,8 @@ mod raw_protocol;
 use bytes::Bytes;
 use kafka_protocol::messages::describe_groups_request::DescribeGroupsRequest;
 use kafka_protocol::messages::describe_groups_response::DescribeGroupsResponse;
+use kafka_protocol::messages::heartbeat_request::HeartbeatRequest;
+use kafka_protocol::messages::heartbeat_response::HeartbeatResponse;
 use kafka_protocol::messages::join_group_request::{JoinGroupRequest, JoinGroupRequestProtocol};
 use kafka_protocol::messages::join_group_response::JoinGroupResponse;
 use kafka_protocol::messages::list_groups_request::ListGroupsRequest;
@@ -67,6 +69,84 @@ async fn create_consumer_group(
     assert_eq!(sg_resp.error_code, 0, "SyncGroup should succeed");
 
     (member_id, generation_id)
+}
+
+async fn send_join_group(stream: &mut TcpStream, group_id: &str, correlation_id: i32) {
+    let mut request = JoinGroupRequest::default();
+    request.group_id = StrBytes::from_string(group_id.to_string()).into();
+    request.protocol_type = StrBytes::from_string("consumer".to_string());
+    request.session_timeout_ms = 30_000;
+    request.rebalance_timeout_ms = 30_000;
+
+    let mut protocol = JoinGroupRequestProtocol::default();
+    protocol.name = StrBytes::from_string("range".to_string());
+    protocol.metadata = Bytes::from_static(&[0, 0, 0, 0]);
+    request.protocols.push(protocol);
+
+    send_request(stream, ApiKey::JoinGroup, 7, correlation_id, &request).await;
+}
+
+async fn read_join_group(stream: &mut TcpStream) -> JoinGroupResponse {
+    let (_, mut body) = read_response(stream, ApiKey::JoinGroup, 7).await;
+    JoinGroupResponse::decode(&mut body, 7).unwrap()
+}
+
+async fn send_sync_group(
+    stream: &mut TcpStream,
+    group_id: &str,
+    member_id: &StrBytes,
+    generation_id: i32,
+    assignments: &[(StrBytes, Bytes)],
+    correlation_id: i32,
+) {
+    let mut request = SyncGroupRequest::default();
+    request.group_id = StrBytes::from_string(group_id.to_string()).into();
+    request.member_id = member_id.clone();
+    request.generation_id = generation_id;
+
+    for (assignment_member_id, assignment_bytes) in assignments {
+        let mut assignment = SyncGroupRequestAssignment::default();
+        assignment.member_id = assignment_member_id.clone();
+        assignment.assignment = assignment_bytes.clone();
+        request.assignments.push(assignment);
+    }
+
+    send_request(stream, ApiKey::SyncGroup, 5, correlation_id, &request).await;
+}
+
+async fn read_sync_group(stream: &mut TcpStream) -> SyncGroupResponse {
+    let (_, mut body) = read_response(stream, ApiKey::SyncGroup, 5).await;
+    SyncGroupResponse::decode(&mut body, 5).unwrap()
+}
+
+async fn send_heartbeat(
+    stream: &mut TcpStream,
+    group_id: &str,
+    member_id: &StrBytes,
+    generation_id: i32,
+    correlation_id: i32,
+) {
+    let mut request = HeartbeatRequest::default();
+    request.group_id = StrBytes::from_string(group_id.to_string()).into();
+    request.member_id = member_id.clone();
+    request.generation_id = generation_id;
+
+    send_request(stream, ApiKey::Heartbeat, 4, correlation_id, &request).await;
+}
+
+async fn read_heartbeat(stream: &mut TcpStream) -> HeartbeatResponse {
+    let (_, mut body) = read_response(stream, ApiKey::Heartbeat, 4).await;
+    HeartbeatResponse::decode(&mut body, 4).unwrap()
+}
+
+async fn assert_stream_not_readable_within(stream: &TcpStream, duration: std::time::Duration) {
+    let mut buf = [0u8; 1];
+    let readiness = tokio::time::timeout(duration, stream.peek(&mut buf)).await;
+    assert!(
+        readiness.is_err(),
+        "stream unexpectedly became readable within {:?}",
+        duration,
+    );
 }
 
 /// Helper to extract &str from StrBytes for unambiguous comparisons.
@@ -319,6 +399,225 @@ async fn full_group_lifecycle_list_and_describe() {
         state == "Empty" || state == "Dead",
         "Group should be Empty or Dead after LeaveGroup, got: {state}",
     );
+}
+
+#[tokio::test]
+async fn join_group_waits_for_peers_before_finalizing_generation() {
+    let tb = TestBroker::start().await;
+    let mut leader_stream = tb.connect().await;
+    let mut follower_stream = tb.connect().await;
+
+    send_join_group(&mut leader_stream, "barrier-group", 1).await;
+    assert_stream_not_readable_within(&leader_stream, std::time::Duration::from_millis(40)).await;
+
+    send_join_group(&mut follower_stream, "barrier-group", 2).await;
+
+    let leader_response = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_join_group(&mut leader_stream),
+    )
+    .await
+    .expect("leader JoinGroup should eventually resolve");
+    let follower_response = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_join_group(&mut follower_stream),
+    )
+    .await
+    .expect("follower JoinGroup should eventually resolve");
+
+    assert_eq!(leader_response.error_code, 0);
+    assert_eq!(follower_response.error_code, 0);
+    assert_eq!(
+        leader_response.generation_id,
+        follower_response.generation_id
+    );
+    assert_eq!(leader_response.members.len(), 2);
+    assert_eq!(leader_response.member_id, leader_response.leader);
+    assert_eq!(follower_response.leader, leader_response.leader);
+    assert!(
+        leader_response
+            .members
+            .iter()
+            .any(|member| member.member_id == follower_response.member_id),
+        "leader must see follower metadata before SyncGroup",
+    );
+}
+
+#[tokio::test]
+async fn rebalance_waits_for_existing_members_to_rejoin_before_finalizing() {
+    let tb = TestBroker::start().await;
+    let mut leader_stream = tb.connect().await;
+    let mut follower_stream = tb.connect().await;
+    let mut newcomer_stream = tb.connect().await;
+
+    send_join_group(&mut leader_stream, "staggered-group", 1).await;
+    send_join_group(&mut follower_stream, "staggered-group", 2).await;
+
+    let leader_join = read_join_group(&mut leader_stream).await;
+    let follower_join = read_join_group(&mut follower_stream).await;
+    assert_eq!(leader_join.generation_id, follower_join.generation_id);
+
+    send_sync_group(
+        &mut leader_stream,
+        "staggered-group",
+        &leader_join.member_id,
+        leader_join.generation_id,
+        &[
+            (leader_join.member_id.clone(), Bytes::from_static(&[1])),
+            (follower_join.member_id.clone(), Bytes::from_static(&[2])),
+        ],
+        3,
+    )
+    .await;
+    send_sync_group(
+        &mut follower_stream,
+        "staggered-group",
+        &follower_join.member_id,
+        follower_join.generation_id,
+        &[],
+        4,
+    )
+    .await;
+    let _ = read_sync_group(&mut leader_stream).await;
+    let _ = read_sync_group(&mut follower_stream).await;
+
+    send_join_group(&mut newcomer_stream, "staggered-group", 5).await;
+    assert_stream_not_readable_within(&newcomer_stream, std::time::Duration::from_millis(150))
+        .await;
+
+    send_heartbeat(
+        &mut leader_stream,
+        "staggered-group",
+        &leader_join.member_id,
+        leader_join.generation_id,
+        6,
+    )
+    .await;
+    let heartbeat = read_heartbeat(&mut leader_stream).await;
+    assert_eq!(heartbeat.error_code, 27);
+
+    send_request_join_group_with_member(
+        &mut leader_stream,
+        "staggered-group",
+        &leader_join.member_id,
+        7,
+    )
+    .await;
+    assert_stream_not_readable_within(&leader_stream, std::time::Duration::from_millis(150)).await;
+    assert_stream_not_readable_within(&newcomer_stream, std::time::Duration::from_millis(150))
+        .await;
+
+    send_request_join_group_with_member(
+        &mut follower_stream,
+        "staggered-group",
+        &follower_join.member_id,
+        8,
+    )
+    .await;
+
+    let leader_rejoin = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_join_group(&mut leader_stream),
+    )
+    .await
+    .expect("leader should rejoin once all known members have joined");
+    let follower_rejoin = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_join_group(&mut follower_stream),
+    )
+    .await
+    .expect("follower should rejoin once all known members have joined");
+    let newcomer_join = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_join_group(&mut newcomer_stream),
+    )
+    .await
+    .expect("new member should join once all known members have joined");
+
+    assert_eq!(leader_rejoin.generation_id, follower_rejoin.generation_id);
+    assert_eq!(leader_rejoin.generation_id, newcomer_join.generation_id);
+    assert_eq!(leader_rejoin.members.len(), 3);
+}
+
+async fn send_request_join_group_with_member(
+    stream: &mut TcpStream,
+    group_id: &str,
+    member_id: &StrBytes,
+    correlation_id: i32,
+) {
+    let mut request = JoinGroupRequest::default();
+    request.group_id = StrBytes::from_string(group_id.to_string()).into();
+    request.member_id = member_id.clone();
+    request.protocol_type = StrBytes::from_string("consumer".to_string());
+    request.session_timeout_ms = 30_000;
+    request.rebalance_timeout_ms = 30_000;
+
+    let mut protocol = JoinGroupRequestProtocol::default();
+    protocol.name = StrBytes::from_string("range".to_string());
+    protocol.metadata = Bytes::from_static(&[0, 0, 0, 0]);
+    request.protocols.push(protocol);
+
+    send_request(stream, ApiKey::JoinGroup, 7, correlation_id, &request).await;
+}
+
+#[tokio::test]
+async fn sync_group_waits_for_leader_assignment_before_releasing_followers() {
+    let tb = TestBroker::start().await;
+    let mut leader_stream = tb.connect().await;
+    let mut follower_stream = tb.connect().await;
+
+    send_join_group(&mut leader_stream, "sync-barrier-group", 1).await;
+    send_join_group(&mut follower_stream, "sync-barrier-group", 2).await;
+
+    let leader_join = read_join_group(&mut leader_stream).await;
+    let follower_join = read_join_group(&mut follower_stream).await;
+    assert_eq!(leader_join.members.len(), 2);
+    assert_eq!(leader_join.generation_id, follower_join.generation_id);
+
+    send_sync_group(
+        &mut follower_stream,
+        "sync-barrier-group",
+        &follower_join.member_id,
+        follower_join.generation_id,
+        &[],
+        3,
+    )
+    .await;
+
+    assert_stream_not_readable_within(&follower_stream, std::time::Duration::from_millis(40)).await;
+
+    let leader_assignment = Bytes::from_static(&[1, 2, 3]);
+    let follower_assignment = Bytes::from_static(&[4, 5, 6]);
+    send_sync_group(
+        &mut leader_stream,
+        "sync-barrier-group",
+        &leader_join.member_id,
+        leader_join.generation_id,
+        &[
+            (leader_join.member_id.clone(), leader_assignment.clone()),
+            (follower_join.member_id.clone(), follower_assignment.clone()),
+        ],
+        4,
+    )
+    .await;
+
+    let leader_sync = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_sync_group(&mut leader_stream),
+    )
+    .await
+    .expect("leader SyncGroup should complete after assignment");
+    let follower_sync = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        read_sync_group(&mut follower_stream),
+    )
+    .await
+    .expect("follower SyncGroup should complete after leader assignment");
+
+    assert_eq!(leader_sync.error_code, 0);
+    assert_eq!(follower_sync.error_code, 0);
+    assert_eq!(leader_sync.assignment, leader_assignment);
+    assert_eq!(follower_sync.assignment, follower_assignment);
 }
 
 /// ListGroups v0 round-trip (minimum supported version).

--- a/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
+++ b/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
@@ -589,11 +589,7 @@ async fn sync_kafka_to_clickhouse(
         source_topic_name
     );
 
-    // Use a per-topic consumer group ID so each sync process is the sole member
-    // of its group. This avoids issues with consumer group coordination in
-    // lightweight Kafka implementations (e.g. devkafka) that don't implement a
-    // full JoinGroup synchronization barrier.
-    let group_id = format!("{TABLE_SYNC_GROUP_ID}_{source_topic_name}");
+    let group_id = TABLE_SYNC_GROUP_ID.to_string();
     let subscriber: Arc<StreamConsumer> = Arc::new(create_subscriber(
         &kafka_config,
         &group_id,


### PR DESCRIPTION
There was a regression earlier this week where we renamed the
clickhouse_sync consumer group to a different name. This was done
because of a missing feature in devkafka and completely missed in review
by humans. This change is to implement the missing feature in kafka and
revert the change in moose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core consumer-group coordination semantics (blocking JoinGroup/SyncGroup until rebalance completion and gating Heartbeat), which can affect client liveness and timing behavior if the new barriers or timeouts are incorrect.
> 
> **Overview**
> Implements a more Kafka-like consumer group rebalance barrier in `devkafka` by tracking join/rehash progress and broadcasting state changes via `watch`, so `JoinGroup` waits until all known members have joined (or timeout) before bumping generation and returning.
> 
> Updates `SyncGroup` so followers block until the leader provides assignments and the group becomes `Stable`, and updates `Heartbeat` to return `REBALANCE_IN_PROGRESS` unless the group is `Stable`; member removal now triggers rebalance timing/state resets consistently.
> 
> Adds integration tests covering the new join/sync blocking behavior and rebalance flows, and reverts `kafka_clickhouse_sync` to use the shared `clickhouse_sync` consumer group ID instead of per-topic groups now that the barrier exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c3c7a9f0f5528e2a5b4fd6b2d331bcd091580d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->