### PR TITLE
Pin rust version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,18 +17,6 @@ updates:
       workspace-major:
         update-types: ["major"]
 
-  # =============================================================================
-  # Rust
-  # =============================================================================
-  - package-ecosystem: "rust-toolchain"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
-    labels:
-      - "rust"
-      - "toolchain"
-
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -36,7 +36,6 @@ jobs:
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           target: x86_64-unknown-linux-gnu
 
       - name: Install Protoc (Needed for Temporal)

--- a/.github/workflows/test-framework-cli.yaml
+++ b/.github/workflows/test-framework-cli.yaml
@@ -116,7 +116,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -173,7 +172,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -288,7 +286,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           cache-shared-key: ${{ runner.os }}-${{ runner.arch }}-rust
           cache-on-failure: true
@@ -370,7 +367,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -446,7 +442,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -509,7 +504,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -589,7 +583,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -655,7 +648,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -715,7 +707,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -783,7 +774,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -839,7 +829,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically
           # This allows cache sharing across all Linux/macOS jobs in this workflow
@@ -903,7 +892,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           cache-shared-key: ${{ runner.os }}-${{ runner.arch }}-rust
           cache-on-failure: true
@@ -957,7 +945,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           cache-shared-key: ${{ runner.os }}-${{ runner.arch }}-rust
           cache-on-failure: true
@@ -1010,7 +997,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache: true
           cache-shared-key: ${{ runner.os }}-${{ runner.arch }}-rust
           cache-on-failure: true
@@ -1056,7 +1042,6 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           components: rustfmt, clippy
           cache: true
           # Simplified key: OS + arch is sufficient, Cargo.lock hash is added automatically

--- a/apps/framework-cli-e2e/test/templates.test.ts
+++ b/apps/framework-cli-e2e/test/templates.test.ts
@@ -3043,6 +3043,8 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
       describe("DLQ with namespace prefixing", function () {
         const NAMESPACE = "testns";
         const NS_APP_NAME = `${config.appName}-ns`;
+        const NS_PROXY_PORT =
+          config.language === "typescript" ? "4091" : "4101";
         let nsProjectDir: string;
         let nsDevProcess: ChildProcess | null = null;
 
@@ -3079,10 +3081,17 @@ const createTemplateTestSuite = (config: TemplateTestConfig) => {
             );
           }
 
-          const devEnv = {
-            ...buildDevEnv(config.language, nsProjectDir),
-            MOOSE_REDPANDA_CONFIG__NAMESPACE: NAMESPACE,
-          };
+          const devEnv = buildMooseDevEnv({
+            language: config.language,
+            projectDir: nsProjectDir,
+            extraEnv: {
+              TEST_AWS_ACCESS_KEY_ID: "test-access-key-id",
+              TEST_AWS_SECRET_ACCESS_KEY: "test-secret-access-key",
+              MOOSE_AUTHENTICATION__ADMIN_API_KEY: TEST_ADMIN_API_KEY_HASH,
+              MOOSE_HTTP_SERVER_CONFIG__PROXY_PORT: NS_PROXY_PORT,
+              MOOSE_REDPANDA_CONFIG__NAMESPACE: NAMESPACE,
+            },
+          });
 
           nsDevProcess = startMooseDev({
             cliPath: CLI_PATH,

--- a/apps/framework-cli-e2e/test/utils/process-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/process-utils.ts
@@ -124,6 +124,8 @@ export const waitForServerStart = async (
     let serverStarted = false;
     let timeoutId: any = null;
     let pingInterval: any = null;
+    const storedStdout: string[] = [];
+    const storedStderr: string[] = [];
 
     const cleanup = () => {
       if (pingInterval) {
@@ -139,14 +141,13 @@ export const waitForServerStart = async (
       devProcess.off("exit", onExit);
     };
 
-    const storedStdout: any[] = [];
     const onStdout = async (data: any) => {
       const output = data.toString();
       if (!output.match(/^\n[⢹⢺⢼⣸⣇⡧⡗⡏] Starting local infrastructure$/)) {
         log.debug("Moose server output", { output: output.trim() });
-        if (!serverStarted) {
-          storedStdout.push(output);
-        }
+      }
+      if (!serverStarted) {
+        storedStdout.push(output);
       }
 
       if (!serverStarted && output.includes(startupMessage)) {
@@ -158,18 +159,27 @@ export const waitForServerStart = async (
     };
 
     const onStderr = (data: any) => {
-      log.warn("Moose server stderr", { stderr: data.toString() });
+      const stderr = data.toString();
+      log.warn("Moose server stderr", { stderr });
+      if (!serverStarted) {
+        storedStderr.push(stderr);
+      }
     };
 
     const onExit = (code: number | null) => {
       log.debug(`Moose process exited`, { exitCode: code });
       if (!serverStarted) {
         cleanup();
-        try {
-          console.log("Moose server output:");
-          storedStdout.forEach((data) => console.log(data));
-        } catch {}
-        reject(new Error(`Moose process exited with code ${code}`));
+        const stdout = storedStdout.join("");
+        const stderr = storedStderr.join("");
+        const details = [
+          `Moose process exited with code ${code}`,
+          stdout ? `stdout:\n${stdout}` : null,
+          stderr ? `stderr:\n${stderr}` : null,
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+        reject(new Error(details));
       } else {
         cleanup();
       }

--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761532837,
-        "narHash": "sha256-78mCSQgC/a6/0vWYrvE/g9E3gGsJLyBBGtmHe3ZOLG4=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4f5f89f1cfd8553b1285a4a0879ea1b2b05ad286",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -43,14 +43,8 @@
           # Safe-chain wrapper for malware protection
           safeChain = inputs.safe-chain-nix.lib.${system}.safeChain;
 
-          # Rust toolchain
-          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-            extensions = [
-              "rust-src"
-              "clippy"
-              "rustfmt"
-            ];
-          };
+          # Rust toolchain pinned from rust-toolchain.toml
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
           # Node.js with PNPM (wrapped with safe-chain for malware protection)
           nodejs = safeChain.wrapNode pkgs.nodejs_20;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.94"
+channel = "1.94.0"
+components = ["rust-src", "clippy", "rustfmt"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches toolchain selection in CI and Nix, so a mis-pin or mismatch could break builds/tests across environments; code changes are limited to test harness error/reporting behavior.
> 
> **Overview**
> Pins Rust to `1.94.0` in `rust-toolchain.toml` (including `rust-src`, `clippy`, `rustfmt`) and updates Nix (`flake.nix` + `flake.lock`) to derive the toolchain from that file instead of `stable.latest`.
> 
> Simplifies GitHub Actions Rust setup by removing explicit `toolchain: stable` config and drops Dependabot `rust-toolchain` updates, relying on the repo toolchain file instead.
> 
> Improves E2E harness reliability by setting a language-specific proxy port for namespace DLQ tests and enhancing `waitForServerStart` to include captured stdout/stderr in errors when the dev process exits early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa0f9c8997dc1790a5e5e7d3de518cc202f2348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->