### PR TITLE
Nicolas/update moose templates latest

### DIFF
--- a/templates/_versions.toml
+++ b/templates/_versions.toml
@@ -1,3 +1,3 @@
 [versions]
-moose-lib = "0.6.505"
-moose-cli = "0.6.505"
+moose-lib = "0.6.516"
+moose-cli = "0.6.516"

--- a/templates/_versions.toml
+++ b/templates/_versions.toml
@@ -1,3 +1,3 @@
 [versions]
-moose-lib = "0.6.516"
-moose-cli = "0.6.516"
+moose-lib = "0.6.517"
+moose-cli = "0.6.517"

--- a/templates/next-app-empty/moose/package-lock.json
+++ b/templates/next-app-empty/moose/package-lock.json
@@ -8,12 +8,12 @@
       "name": "moose",
       "version": "0.0",
       "dependencies": {
-        "@514labs/moose-lib": "0.6.505",
+        "@514labs/moose-lib": "0.6.516",
         "ts-patch": "^3.3.0",
         "typia": "^9.6.1"
       },
       "devDependencies": {
-        "@514labs/moose-cli": "0.6.505",
+        "@514labs/moose-cli": "0.6.516",
         "@types/node": "^20.12.12"
       }
     },
@@ -33,41 +33,68 @@
       }
     },
     "node_modules/@514labs/moose-cli": {
-      "version": "0.6.505",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.505.tgz",
-      "integrity": "sha512-18g/7+g/fV7GQNiQ00mGxy+/++xsBMpD68cd4bU5IWoo+VxFF3u6AKwnNNWti3KTXDESKQDceMiBevagU1dLOg==",
+      "version": "0.6.516",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.516.tgz",
+      "integrity": "sha512-lymUQqmTVINZ2rQCsZwlox4IckQvGmcWS14BaBGj4uYLHK5sE60j1rSvJ5szcWMbNgJ2nY6taD3vY/RDBDFrgw==",
       "dev": true,
       "bin": {
         "moose": "dist/index.js",
         "moose-cli": "dist/index.js"
       },
       "optionalDependencies": {
-        "@514labs/moose-cli-darwin-arm64": "0.6.505",
-        "@514labs/moose-cli-darwin-x64": "0.6.505",
-        "@514labs/moose-cli-linux-arm64": "0.6.505",
-        "@514labs/moose-cli-linux-x64": "0.6.505"
+        "@514labs/moose-cli-darwin-arm64": "0.6.516",
+        "@514labs/moose-cli-darwin-x64": "0.6.516",
+        "@514labs/moose-cli-linux-arm64": "0.6.516",
+        "@514labs/moose-cli-linux-x64": "0.6.516"
       }
     },
-    "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-darwin-arm64": {
+    "node_modules/@514labs/moose-cli-darwin-arm64": {
+      "version": "0.6.516",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-darwin-arm64/-/moose-cli-darwin-arm64-0.6.516.tgz",
+      "integrity": "sha512-YIFSNFiThYucqk7McKJIZZSNZSgCvdoguB2SIAjcwAhgVnXJBYLUfCQx9PX+5ZoPbLTjOEoiq6JYZ1BqKpaCsg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "optional": true
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@514labs/moose-cli-linux-arm64": {
+      "version": "0.6.516",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-arm64/-/moose-cli-linux-arm64-0.6.516.tgz",
+      "integrity": "sha512-+RcZC512mKeXQzw/lGKQKmUxnk3e66MbETlhxM3zfgLtM0KVRqOSuOhbPPOGNYtfHsLBklHtZA6nzqjPWq00CQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@514labs/moose-cli-linux-x64": {
+      "version": "0.6.516",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-x64/-/moose-cli-linux-x64-0.6.516.tgz",
+      "integrity": "sha512-yJaRk6EgCQqMgqU0/gTsM7loy9c5VD3MPjc63qvZHOlSbv2EUvvJQJkA8LcHveJSb97GMTP6wCSe4sRyzYL19A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-darwin-x64": {
       "dev": true,
       "optional": true
     },
-    "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-linux-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@514labs/moose-cli/node_modules/@514labs/moose-cli-linux-x64": {
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@514labs/moose-lib": {
-      "version": "0.6.505",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.505.tgz",
-      "integrity": "sha512-dCO8daqsECgSxIG1GVHCISlvP41nbYvNKQ0fusZX0FzJppl6wNEe/ih7sKq3MpF7UvWuuRn71BmzS01MzDiJiA==",
+      "version": "0.6.516",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.516.tgz",
+      "integrity": "sha512-L+qshwSb1spJRW3ERVsDwZQqMcpw/uoSHI32BhFu/xjT8oZxp8QoVhS4gJSxIXRE2zs9B9QfDAT/0fqlorvjaA==",
       "dependencies": {
         "@514labs/kafka-javascript": "1.7.1-patch",
         "@clickhouse/client": "1.8.1",

--- a/templates/next-app-empty/moose/package-lock.json
+++ b/templates/next-app-empty/moose/package-lock.json
@@ -8,12 +8,12 @@
       "name": "moose",
       "version": "0.0",
       "dependencies": {
-        "@514labs/moose-lib": "0.6.516",
+        "@514labs/moose-lib": "0.6.517",
         "ts-patch": "^3.3.0",
         "typia": "^9.6.1"
       },
       "devDependencies": {
-        "@514labs/moose-cli": "0.6.516",
+        "@514labs/moose-cli": "0.6.517",
         "@types/node": "^20.12.12"
       }
     },
@@ -33,25 +33,25 @@
       }
     },
     "node_modules/@514labs/moose-cli": {
-      "version": "0.6.516",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.516.tgz",
-      "integrity": "sha512-lymUQqmTVINZ2rQCsZwlox4IckQvGmcWS14BaBGj4uYLHK5sE60j1rSvJ5szcWMbNgJ2nY6taD3vY/RDBDFrgw==",
+      "version": "0.6.517",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli/-/moose-cli-0.6.517.tgz",
+      "integrity": "sha512-7XA9VckVMQJEKWihR26tvQnQ/eMDXrdKGgQwaLTY7pPUDvkQoEkoINJR4xJnxLGvwaXUH8q7PVFkZw2EtQVf/A==",
       "dev": true,
       "bin": {
         "moose": "dist/index.js",
         "moose-cli": "dist/index.js"
       },
       "optionalDependencies": {
-        "@514labs/moose-cli-darwin-arm64": "0.6.516",
-        "@514labs/moose-cli-darwin-x64": "0.6.516",
-        "@514labs/moose-cli-linux-arm64": "0.6.516",
-        "@514labs/moose-cli-linux-x64": "0.6.516"
+        "@514labs/moose-cli-darwin-arm64": "0.6.517",
+        "@514labs/moose-cli-darwin-x64": "0.6.517",
+        "@514labs/moose-cli-linux-arm64": "0.6.517",
+        "@514labs/moose-cli-linux-x64": "0.6.517"
       }
     },
     "node_modules/@514labs/moose-cli-darwin-arm64": {
-      "version": "0.6.516",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-darwin-arm64/-/moose-cli-darwin-arm64-0.6.516.tgz",
-      "integrity": "sha512-YIFSNFiThYucqk7McKJIZZSNZSgCvdoguB2SIAjcwAhgVnXJBYLUfCQx9PX+5ZoPbLTjOEoiq6JYZ1BqKpaCsg==",
+      "version": "0.6.517",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-darwin-arm64/-/moose-cli-darwin-arm64-0.6.517.tgz",
+      "integrity": "sha512-UIHna1K6D/t404e688OD624Hk6p0oJZ+wsZ5oyOf+p8YDAMBSYmpNA66sQaKxlLjyFAP1sqeQq2TArJi7hynNw==",
       "cpu": [
         "arm64"
       ],
@@ -62,9 +62,9 @@
       ]
     },
     "node_modules/@514labs/moose-cli-linux-arm64": {
-      "version": "0.6.516",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-arm64/-/moose-cli-linux-arm64-0.6.516.tgz",
-      "integrity": "sha512-+RcZC512mKeXQzw/lGKQKmUxnk3e66MbETlhxM3zfgLtM0KVRqOSuOhbPPOGNYtfHsLBklHtZA6nzqjPWq00CQ==",
+      "version": "0.6.517",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-arm64/-/moose-cli-linux-arm64-0.6.517.tgz",
+      "integrity": "sha512-O1flu4DS9DjD4E3YLqw6zEU5kyHTk5tvm6h1uQkZ7wn7UmCVQo1NKa4yDjz5pGdbKlhpzwRw10V6NGqn/7DU+g==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +75,9 @@
       ]
     },
     "node_modules/@514labs/moose-cli-linux-x64": {
-      "version": "0.6.516",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-x64/-/moose-cli-linux-x64-0.6.516.tgz",
-      "integrity": "sha512-yJaRk6EgCQqMgqU0/gTsM7loy9c5VD3MPjc63qvZHOlSbv2EUvvJQJkA8LcHveJSb97GMTP6wCSe4sRyzYL19A==",
+      "version": "0.6.517",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-cli-linux-x64/-/moose-cli-linux-x64-0.6.517.tgz",
+      "integrity": "sha512-tvDms4hKzCI7wULoZ/GvKqniSUrmNrrObzflonGR/z+6F/O7gNI+3ilXinMzhe/7GeWaBg17jiMQ9HyZbWk4Uw==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       "optional": true
     },
     "node_modules/@514labs/moose-lib": {
-      "version": "0.6.516",
-      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.516.tgz",
-      "integrity": "sha512-L+qshwSb1spJRW3ERVsDwZQqMcpw/uoSHI32BhFu/xjT8oZxp8QoVhS4gJSxIXRE2zs9B9QfDAT/0fqlorvjaA==",
+      "version": "0.6.517",
+      "resolved": "https://registry.npmjs.org/@514labs/moose-lib/-/moose-lib-0.6.517.tgz",
+      "integrity": "sha512-8hhuR1evLmRaiV8a6zfzuIAJ6VnX5CZK/JqGDhoWRx9PDXuk3Vy8dWa6j+pvv9/jVfWlba/CPSMereByS74GvA==",
       "dependencies": {
         "@514labs/kafka-javascript": "1.7.1-patch",
         "@clickhouse/client": "1.8.1",

--- a/templates/next-app-empty/moose/package.json
+++ b/templates/next-app-empty/moose/package.json
@@ -7,13 +7,13 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "@514labs/moose-cli": "0.6.505"
+    "@514labs/moose-cli": "0.6.516"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/next-app-empty/moose/package.json
+++ b/templates/next-app-empty/moose/package.json
@@ -7,13 +7,13 @@
     "build": "moose-cli build --docker"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "ts-patch": "^3.3.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "@514labs/moose-cli": "0.6.516"
+    "@514labs/moose-cli": "0.6.517"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/python-cluster/requirements.txt
+++ b/templates/python-cluster/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517
 faker
 sqlglot[c]>=29.0.1

--- a/templates/python-cluster/requirements.txt
+++ b/templates/python-cluster/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516
 faker
 sqlglot[c]>=29.0.1

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,5 +1,5 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,5 +1,5 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516

--- a/templates/python-fastapi-client-only/requirements.txt
+++ b/templates/python-fastapi-client-only/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517
 faker
 fastapi[standard]

--- a/templates/python-fastapi-client-only/requirements.txt
+++ b/templates/python-fastapi-client-only/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516
 faker
 fastapi[standard]

--- a/templates/python-fastapi/requirements.txt
+++ b/templates/python-fastapi/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517
 faker
 fastapi[standard]

--- a/templates/python-fastapi/requirements.txt
+++ b/templates/python-fastapi/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516
 faker
 fastapi[standard]

--- a/templates/python-tests/requirements.txt
+++ b/templates/python-tests/requirements.txt
@@ -1,8 +1,8 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516
 faker
 sqlglot[c]>=29.0.1
 fastapi[standard]

--- a/templates/python-tests/requirements.txt
+++ b/templates/python-tests/requirements.txt
@@ -1,8 +1,8 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517
 faker
 sqlglot[c]>=29.0.1
 fastapi[standard]

--- a/templates/python-webapp/requirements.txt
+++ b/templates/python-webapp/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516
 faker==40.8.0
 fastapi[standard]==0.135.1

--- a/templates/python-webapp/requirements.txt
+++ b/templates/python-webapp/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517
 faker==40.8.0
 fastapi[standard]==0.135.1

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.516
-moose-lib==0.6.516
+moose-cli==0.6.517
+moose-lib==0.6.517
 faker
 sqlglot[c]>=29.0.1

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,7 +1,7 @@
 kafka-python-ng==2.2.2
 clickhouse-connect==0.11.0
 requests==2.32.4
-moose-cli==0.6.505
-moose-lib==0.6.505
+moose-cli==0.6.516
+moose-lib==0.6.516
 faker
 sqlglot[c]>=29.0.1

--- a/templates/typescript-agent/pnpm-lock.yaml
+++ b/templates/typescript-agent/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@514labs/moose-cli':
-      specifier: 0.6.516
-      version: 0.6.516
+      specifier: 0.6.517
+      version: 0.6.517
     '@514labs/moose-lib':
-      specifier: 0.6.516
-      version: 0.6.516
+      specifier: 0.6.517
+      version: 0.6.517
     '@ai-sdk/amazon-bedrock':
       specifier: 4.0.83
       version: 4.0.83
@@ -370,7 +370,7 @@ importers:
     dependencies:
       '@514labs/moose-lib':
         specifier: 'catalog:'
-        version: 0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))
+        version: 0.6.517(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 'catalog:'
         version: 4.1.1
@@ -395,7 +395,7 @@ importers:
     devDependencies:
       '@514labs/moose-cli':
         specifier: 'catalog:'
-        version: 0.6.516
+        version: 0.6.517
       '@types/express':
         specifier: 'catalog:'
         version: 5.0.6
@@ -674,27 +674,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.516':
-    resolution: {integrity: sha512-YIFSNFiThYucqk7McKJIZZSNZSgCvdoguB2SIAjcwAhgVnXJBYLUfCQx9PX+5ZoPbLTjOEoiq6JYZ1BqKpaCsg==}
+  '@514labs/moose-cli-darwin-arm64@0.6.517':
+    resolution: {integrity: sha512-UIHna1K6D/t404e688OD624Hk6p0oJZ+wsZ5oyOf+p8YDAMBSYmpNA66sQaKxlLjyFAP1sqeQq2TArJi7hynNw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.516':
-    resolution: {integrity: sha512-+RcZC512mKeXQzw/lGKQKmUxnk3e66MbETlhxM3zfgLtM0KVRqOSuOhbPPOGNYtfHsLBklHtZA6nzqjPWq00CQ==}
+  '@514labs/moose-cli-linux-arm64@0.6.517':
+    resolution: {integrity: sha512-O1flu4DS9DjD4E3YLqw6zEU5kyHTk5tvm6h1uQkZ7wn7UmCVQo1NKa4yDjz5pGdbKlhpzwRw10V6NGqn/7DU+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.516':
-    resolution: {integrity: sha512-yJaRk6EgCQqMgqU0/gTsM7loy9c5VD3MPjc63qvZHOlSbv2EUvvJQJkA8LcHveJSb97GMTP6wCSe4sRyzYL19A==}
+  '@514labs/moose-cli-linux-x64@0.6.517':
+    resolution: {integrity: sha512-tvDms4hKzCI7wULoZ/GvKqniSUrmNrrObzflonGR/z+6F/O7gNI+3ilXinMzhe/7GeWaBg17jiMQ9HyZbWk4Uw==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.516':
-    resolution: {integrity: sha512-lymUQqmTVINZ2rQCsZwlox4IckQvGmcWS14BaBGj4uYLHK5sE60j1rSvJ5szcWMbNgJ2nY6taD3vY/RDBDFrgw==}
+  '@514labs/moose-cli@0.6.517':
+    resolution: {integrity: sha512-7XA9VckVMQJEKWihR26tvQnQ/eMDXrdKGgQwaLTY7pPUDvkQoEkoINJR4xJnxLGvwaXUH8q7PVFkZw2EtQVf/A==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.516':
-    resolution: {integrity: sha512-L+qshwSb1spJRW3ERVsDwZQqMcpw/uoSHI32BhFu/xjT8oZxp8QoVhS4gJSxIXRE2zs9B9QfDAT/0fqlorvjaA==}
+  '@514labs/moose-lib@0.6.517':
+    resolution: {integrity: sha512-8hhuR1evLmRaiV8a6zfzuIAJ6VnX5CZK/JqGDhoWRx9PDXuk3Vy8dWa6j+pvv9/jVfWlba/CPSMereByS74GvA==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -7112,22 +7112,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.516':
+  '@514labs/moose-cli-darwin-arm64@0.6.517':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.516':
+  '@514labs/moose-cli-linux-arm64@0.6.517':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.516':
+  '@514labs/moose-cli-linux-x64@0.6.517':
     optional: true
 
-  '@514labs/moose-cli@0.6.516':
+  '@514labs/moose-cli@0.6.517':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.516
-      '@514labs/moose-cli-linux-arm64': 0.6.516
-      '@514labs/moose-cli-linux-x64': 0.6.516
+      '@514labs/moose-cli-darwin-arm64': 0.6.517
+      '@514labs/moose-cli-linux-arm64': 0.6.517
+      '@514labs/moose-cli-linux-x64': 0.6.517
 
-  '@514labs/moose-lib@0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.517(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1

--- a/templates/typescript-agent/pnpm-lock.yaml
+++ b/templates/typescript-agent/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@514labs/moose-cli':
-      specifier: 0.6.505
-      version: 0.6.505
+      specifier: 0.6.516
+      version: 0.6.516
     '@514labs/moose-lib':
-      specifier: 0.6.505
-      version: 0.6.505
+      specifier: 0.6.516
+      version: 0.6.516
     '@ai-sdk/amazon-bedrock':
       specifier: 4.0.83
       version: 4.0.83
@@ -370,7 +370,7 @@ importers:
     dependencies:
       '@514labs/moose-lib':
         specifier: 'catalog:'
-        version: 0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))
+        version: 0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 'catalog:'
         version: 4.1.1
@@ -395,7 +395,7 @@ importers:
     devDependencies:
       '@514labs/moose-cli':
         specifier: 'catalog:'
-        version: 0.6.505
+        version: 0.6.516
       '@types/express':
         specifier: 'catalog:'
         version: 5.0.6
@@ -674,27 +674,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.505':
-    resolution: {integrity: sha512-CiHB2YwNFJhiR95A4E5REZETFGobtV4Fycxc3GJ1dwml8OUD0wVlIGlw1TG6rF3HGfoJRUBC7wkylfsW4g/4OQ==}
+  '@514labs/moose-cli-darwin-arm64@0.6.516':
+    resolution: {integrity: sha512-YIFSNFiThYucqk7McKJIZZSNZSgCvdoguB2SIAjcwAhgVnXJBYLUfCQx9PX+5ZoPbLTjOEoiq6JYZ1BqKpaCsg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.505':
-    resolution: {integrity: sha512-BTpJGSlHl8uTz+pTDDMyXcxsLhDXqA7oEOOZXfKSOTG3LbxOzQQREKRSmfqpKNBbxhjsW73oiN7owKSf/SZzeg==}
+  '@514labs/moose-cli-linux-arm64@0.6.516':
+    resolution: {integrity: sha512-+RcZC512mKeXQzw/lGKQKmUxnk3e66MbETlhxM3zfgLtM0KVRqOSuOhbPPOGNYtfHsLBklHtZA6nzqjPWq00CQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.505':
-    resolution: {integrity: sha512-Np0KokvmSHkbGJ7CWfVvBfSKIsxCPO2e1oV+9vrYHqmj1pVO+25zO01eeP4a3BZfP/1JRn+7scuOC0pZVYEnrQ==}
+  '@514labs/moose-cli-linux-x64@0.6.516':
+    resolution: {integrity: sha512-yJaRk6EgCQqMgqU0/gTsM7loy9c5VD3MPjc63qvZHOlSbv2EUvvJQJkA8LcHveJSb97GMTP6wCSe4sRyzYL19A==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.505':
-    resolution: {integrity: sha512-18g/7+g/fV7GQNiQ00mGxy+/++xsBMpD68cd4bU5IWoo+VxFF3u6AKwnNNWti3KTXDESKQDceMiBevagU1dLOg==}
+  '@514labs/moose-cli@0.6.516':
+    resolution: {integrity: sha512-lymUQqmTVINZ2rQCsZwlox4IckQvGmcWS14BaBGj4uYLHK5sE60j1rSvJ5szcWMbNgJ2nY6taD3vY/RDBDFrgw==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.505':
-    resolution: {integrity: sha512-dCO8daqsECgSxIG1GVHCISlvP41nbYvNKQ0fusZX0FzJppl6wNEe/ih7sKq3MpF7UvWuuRn71BmzS01MzDiJiA==}
+  '@514labs/moose-lib@0.6.516':
+    resolution: {integrity: sha512-L+qshwSb1spJRW3ERVsDwZQqMcpw/uoSHI32BhFu/xjT8oZxp8QoVhS4gJSxIXRE2zs9B9QfDAT/0fqlorvjaA==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -7112,22 +7112,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.505':
+  '@514labs/moose-cli-darwin-arm64@0.6.516':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.505':
+  '@514labs/moose-cli-linux-arm64@0.6.516':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.505':
+  '@514labs/moose-cli-linux-x64@0.6.516':
     optional: true
 
-  '@514labs/moose-cli@0.6.505':
+  '@514labs/moose-cli@0.6.516':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.505
-      '@514labs/moose-cli-linux-arm64': 0.6.505
-      '@514labs/moose-cli-linux-x64': 0.6.505
+      '@514labs/moose-cli-darwin-arm64': 0.6.516
+      '@514labs/moose-cli-linux-arm64': 0.6.516
+      '@514labs/moose-cli-linux-x64': 0.6.516
 
-  '@514labs/moose-lib@0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.37)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1

--- a/templates/typescript-agent/pnpm-workspace.yaml
+++ b/templates/typescript-agent/pnpm-workspace.yaml
@@ -2,8 +2,8 @@ packages:
   - "packages/*"
 
 catalog:
-  "@514labs/moose-cli": "0.6.505"
-  "@514labs/moose-lib": "0.6.505"
+  "@514labs/moose-cli": "0.6.516"
+  "@514labs/moose-lib": "0.6.516"
   "@ai-sdk/amazon-bedrock": "4.0.83"
   "@ai-sdk/anthropic": "3.0.64"
   "@ai-sdk/mcp": "1.0.30"

--- a/templates/typescript-agent/pnpm-workspace.yaml
+++ b/templates/typescript-agent/pnpm-workspace.yaml
@@ -2,8 +2,8 @@ packages:
   - "packages/*"
 
 catalog:
-  "@514labs/moose-cli": "0.6.516"
-  "@514labs/moose-lib": "0.6.516"
+  "@514labs/moose-cli": "0.6.517"
+  "@514labs/moose-lib": "0.6.517"
   "@ai-sdk/amazon-bedrock": "4.0.83"
   "@ai-sdk/anthropic": "3.0.64"
   "@ai-sdk/mcp": "1.0.30"

--- a/templates/typescript-cluster/package.json
+++ b/templates/typescript-cluster/package.json
@@ -11,7 +11,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"

--- a/templates/typescript-cluster/package.json
+++ b/templates/typescript-cluster/package.json
@@ -11,7 +11,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"

--- a/templates/typescript-empty/package.json
+++ b/templates/typescript-empty/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-empty/package.json
+++ b/templates/typescript-empty/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "axios": "^1.7.7",
     "express": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@types/express": "^5.0.3",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"

--- a/templates/typescript-express/package.json
+++ b/templates/typescript-express/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "axios": "^1.7.7",
     "express": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@types/express": "^5.0.3",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"

--- a/templates/typescript-fastify/package.json
+++ b/templates/typescript-fastify/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "axios": "^1.7.7",
     "fastify": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },

--- a/templates/typescript-fastify/package.json
+++ b/templates/typescript-fastify/package.json
@@ -10,7 +10,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "axios": "^1.7.7",
     "fastify": "^5.1.0",
     "ts-patch": "^3.3.0",
@@ -18,7 +18,7 @@
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },

--- a/templates/typescript-mcp/packages/moosestack-service/package.json
+++ b/templates/typescript-mcp/packages/moosestack-service/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "@514labs/express-pbkdf2-api-key-auth": "^1.0.4",
     "@cfworker/json-schema": "4.1.1",
     "@modelcontextprotocol/sdk": "1.26.0",
@@ -18,7 +18,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@types/express": "^5.0.3",
     "@types/node": "^20.12.12"
   }

--- a/templates/typescript-mcp/packages/moosestack-service/package.json
+++ b/templates/typescript-mcp/packages/moosestack-service/package.json
@@ -7,7 +7,7 @@
     "dev": "moose-cli dev"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "@514labs/express-pbkdf2-api-key-auth": "^1.0.4",
     "@cfworker/json-schema": "4.1.1",
     "@modelcontextprotocol/sdk": "1.26.0",
@@ -18,7 +18,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@types/express": "^5.0.3",
     "@types/node": "^20.12.12"
   }

--- a/templates/typescript-mcp/pnpm-lock.yaml
+++ b/templates/typescript-mcp/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4(express@5.2.1)
       '@514labs/moose-lib':
-        specifier: 0.6.505
-        version: 0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
+        specifier: 0.6.516
+        version: 0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 4.1.1
         version: 4.1.1
@@ -42,8 +42,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@514labs/moose-cli':
-        specifier: 0.6.505
-        version: 0.6.505
+        specifier: 0.6.516
+        version: 0.6.516
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
@@ -253,27 +253,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.505':
-    resolution: {integrity: sha512-CiHB2YwNFJhiR95A4E5REZETFGobtV4Fycxc3GJ1dwml8OUD0wVlIGlw1TG6rF3HGfoJRUBC7wkylfsW4g/4OQ==}
+  '@514labs/moose-cli-darwin-arm64@0.6.516':
+    resolution: {integrity: sha512-YIFSNFiThYucqk7McKJIZZSNZSgCvdoguB2SIAjcwAhgVnXJBYLUfCQx9PX+5ZoPbLTjOEoiq6JYZ1BqKpaCsg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.505':
-    resolution: {integrity: sha512-BTpJGSlHl8uTz+pTDDMyXcxsLhDXqA7oEOOZXfKSOTG3LbxOzQQREKRSmfqpKNBbxhjsW73oiN7owKSf/SZzeg==}
+  '@514labs/moose-cli-linux-arm64@0.6.516':
+    resolution: {integrity: sha512-+RcZC512mKeXQzw/lGKQKmUxnk3e66MbETlhxM3zfgLtM0KVRqOSuOhbPPOGNYtfHsLBklHtZA6nzqjPWq00CQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.505':
-    resolution: {integrity: sha512-Np0KokvmSHkbGJ7CWfVvBfSKIsxCPO2e1oV+9vrYHqmj1pVO+25zO01eeP4a3BZfP/1JRn+7scuOC0pZVYEnrQ==}
+  '@514labs/moose-cli-linux-x64@0.6.516':
+    resolution: {integrity: sha512-yJaRk6EgCQqMgqU0/gTsM7loy9c5VD3MPjc63qvZHOlSbv2EUvvJQJkA8LcHveJSb97GMTP6wCSe4sRyzYL19A==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.505':
-    resolution: {integrity: sha512-18g/7+g/fV7GQNiQ00mGxy+/++xsBMpD68cd4bU5IWoo+VxFF3u6AKwnNNWti3KTXDESKQDceMiBevagU1dLOg==}
+  '@514labs/moose-cli@0.6.516':
+    resolution: {integrity: sha512-lymUQqmTVINZ2rQCsZwlox4IckQvGmcWS14BaBGj4uYLHK5sE60j1rSvJ5szcWMbNgJ2nY6taD3vY/RDBDFrgw==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.505':
-    resolution: {integrity: sha512-dCO8daqsECgSxIG1GVHCISlvP41nbYvNKQ0fusZX0FzJppl6wNEe/ih7sKq3MpF7UvWuuRn71BmzS01MzDiJiA==}
+  '@514labs/moose-lib@0.6.516':
+    resolution: {integrity: sha512-L+qshwSb1spJRW3ERVsDwZQqMcpw/uoSHI32BhFu/xjT8oZxp8QoVhS4gJSxIXRE2zs9B9QfDAT/0fqlorvjaA==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -4841,22 +4841,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.505':
+  '@514labs/moose-cli-darwin-arm64@0.6.516':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.505':
+  '@514labs/moose-cli-linux-arm64@0.6.516':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.505':
+  '@514labs/moose-cli-linux-x64@0.6.516':
     optional: true
 
-  '@514labs/moose-cli@0.6.505':
+  '@514labs/moose-cli@0.6.516':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.505
-      '@514labs/moose-cli-linux-arm64': 0.6.505
-      '@514labs/moose-cli-linux-x64': 0.6.505
+      '@514labs/moose-cli-darwin-arm64': 0.6.516
+      '@514labs/moose-cli-linux-arm64': 0.6.516
+      '@514labs/moose-cli-linux-x64': 0.6.516
 
-  '@514labs/moose-lib@0.6.505(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1

--- a/templates/typescript-mcp/pnpm-lock.yaml
+++ b/templates/typescript-mcp/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4(express@5.2.1)
       '@514labs/moose-lib':
-        specifier: 0.6.516
-        version: 0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
+        specifier: 0.6.517
+        version: 0.6.517(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))
       '@cfworker/json-schema':
         specifier: 4.1.1
         version: 4.1.1
@@ -42,8 +42,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@514labs/moose-cli':
-        specifier: 0.6.516
-        version: 0.6.516
+        specifier: 0.6.517
+        version: 0.6.517
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
@@ -253,27 +253,27 @@ packages:
     resolution: {integrity: sha512-wE9zNdx39tcXOlMN4RGQEkuwGPUIJ+4xVQ4WRMFOjVN9Ixndat89jTUIBQSlCOc4B3RrRcn4VTz13pJo9tESMg==}
     engines: {node: '>=18.0.0'}
 
-  '@514labs/moose-cli-darwin-arm64@0.6.516':
-    resolution: {integrity: sha512-YIFSNFiThYucqk7McKJIZZSNZSgCvdoguB2SIAjcwAhgVnXJBYLUfCQx9PX+5ZoPbLTjOEoiq6JYZ1BqKpaCsg==}
+  '@514labs/moose-cli-darwin-arm64@0.6.517':
+    resolution: {integrity: sha512-UIHna1K6D/t404e688OD624Hk6p0oJZ+wsZ5oyOf+p8YDAMBSYmpNA66sQaKxlLjyFAP1sqeQq2TArJi7hynNw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.6.516':
-    resolution: {integrity: sha512-+RcZC512mKeXQzw/lGKQKmUxnk3e66MbETlhxM3zfgLtM0KVRqOSuOhbPPOGNYtfHsLBklHtZA6nzqjPWq00CQ==}
+  '@514labs/moose-cli-linux-arm64@0.6.517':
+    resolution: {integrity: sha512-O1flu4DS9DjD4E3YLqw6zEU5kyHTk5tvm6h1uQkZ7wn7UmCVQo1NKa4yDjz5pGdbKlhpzwRw10V6NGqn/7DU+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.6.516':
-    resolution: {integrity: sha512-yJaRk6EgCQqMgqU0/gTsM7loy9c5VD3MPjc63qvZHOlSbv2EUvvJQJkA8LcHveJSb97GMTP6wCSe4sRyzYL19A==}
+  '@514labs/moose-cli-linux-x64@0.6.517':
+    resolution: {integrity: sha512-tvDms4hKzCI7wULoZ/GvKqniSUrmNrrObzflonGR/z+6F/O7gNI+3ilXinMzhe/7GeWaBg17jiMQ9HyZbWk4Uw==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.6.516':
-    resolution: {integrity: sha512-lymUQqmTVINZ2rQCsZwlox4IckQvGmcWS14BaBGj4uYLHK5sE60j1rSvJ5szcWMbNgJ2nY6taD3vY/RDBDFrgw==}
+  '@514labs/moose-cli@0.6.517':
+    resolution: {integrity: sha512-7XA9VckVMQJEKWihR26tvQnQ/eMDXrdKGgQwaLTY7pPUDvkQoEkoINJR4xJnxLGvwaXUH8q7PVFkZw2EtQVf/A==}
     hasBin: true
 
-  '@514labs/moose-lib@0.6.516':
-    resolution: {integrity: sha512-L+qshwSb1spJRW3ERVsDwZQqMcpw/uoSHI32BhFu/xjT8oZxp8QoVhS4gJSxIXRE2zs9B9QfDAT/0fqlorvjaA==}
+  '@514labs/moose-lib@0.6.517':
+    resolution: {integrity: sha512-8hhuR1evLmRaiV8a6zfzuIAJ6VnX5CZK/JqGDhoWRx9PDXuk3Vy8dWa6j+pvv9/jVfWlba/CPSMereByS74GvA==}
     engines: {node: '>=20 <25'}
     hasBin: true
     peerDependencies:
@@ -4841,22 +4841,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@514labs/moose-cli-darwin-arm64@0.6.516':
+  '@514labs/moose-cli-darwin-arm64@0.6.517':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.6.516':
+  '@514labs/moose-cli-linux-arm64@0.6.517':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.6.516':
+  '@514labs/moose-cli-linux-x64@0.6.517':
     optional: true
 
-  '@514labs/moose-cli@0.6.516':
+  '@514labs/moose-cli@0.6.517':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.6.516
-      '@514labs/moose-cli-linux-arm64': 0.6.516
-      '@514labs/moose-cli-linux-x64': 0.6.516
+      '@514labs/moose-cli-darwin-arm64': 0.6.517
+      '@514labs/moose-cli-linux-arm64': 0.6.517
+      '@514labs/moose-cli-linux-x64': 0.6.517
 
-  '@514labs/moose-lib@0.6.516(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
+  '@514labs/moose-lib@0.6.517(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ts-patch@3.3.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typia@9.7.2(@types/node@20.19.30)(typescript@5.9.3))':
     dependencies:
       '@514labs/kafka-javascript': 1.7.1-patch
       '@clickhouse/client': 1.8.1

--- a/templates/typescript-migrate-test/migration/package.json
+++ b/templates/typescript-migrate-test/migration/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-migrate-test/migration/package.json
+++ b/templates/typescript-migrate-test/migration/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-migrate-test/package.json
+++ b/templates/typescript-migrate-test/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript-migrate-test/package.json
+++ b/templates/typescript-migrate-test/package.json
@@ -13,11 +13,11 @@
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@types/node": "^20.12.12"
   },
   "pnpm": {

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -13,14 +13,14 @@
     "generate-runtime": "tspc app/index.ts"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.505",
+    "@514labs/moose-lib": "0.6.516",
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.505",
+    "@514labs/moose-cli": "0.6.516",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -13,14 +13,14 @@
     "generate-runtime": "tspc app/index.ts"
   },
   "dependencies": {
-    "@514labs/moose-lib": "0.6.516",
+    "@514labs/moose-lib": "0.6.517",
     "axios": "^1.7.7",
     "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "typia": "^9.6.1"
   },
   "devDependencies": {
-    "@514labs/moose-cli": "0.6.516",
+    "@514labs/moose-cli": "0.6.517",
     "@faker-js/faker": "^9.7.0",
     "@types/node": "^20.12.12"
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Template-wide dependency bumps can change generated project behavior/builds without local code changes; risk is confined to new projects and template consumers rather than runtime production code.
> 
> **Overview**
> Updates all project templates to use `moose-lib` and `moose-cli` version `0.6.517` (from `0.6.505`), including Node/TypeScript `package.json` + lockfiles, Python `requirements.txt`, and the central `templates/_versions.toml`.
> 
> Lockfiles are refreshed to reflect the new npm package tarballs and platform-specific `@514labs/moose-cli-*` optional dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97e6c793a94670b9d0f0bbf35f577082923f1fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->