### PR TITLE
Read new migration files 

### DIFF
--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -985,22 +985,33 @@ pub async fn start_production_mode(
     maybe_warmup_connections(&project, &redis_client).await;
 
     let use_deltas = project.features.migrate_with_deltas;
-    let has_delta_files = use_deltas && has_delta_migration_files()?;
-    let has_legacy_plan_yaml = !use_deltas && std::fs::exists(MIGRATION_FILE)?;
-    let execute_migration_yaml = has_delta_files || has_legacy_plan_yaml;
+    // "Pending" here means the delta file exists on disk but its id is not yet in
+    // `applied_migrations`. We deliberately do NOT key off "any delta file exists"
+    // because delta files are permanent in git — once a single one is committed,
+    // an any-file check would permanently short-circuit the block gate below and
+    // force skip_olap=true forever, silently hiding future un-migrated changes.
+    let has_unapplied_delta_files =
+        use_deltas && has_unapplied_delta_migrations(&project, &*state_storage).await?;
+    let has_legacy_plan_yaml =
+        !use_deltas && std::fs::exists(project.project_location.join(MIGRATION_FILE))?;
+    let execute_migration_yaml = has_unapplied_delta_files || has_legacy_plan_yaml;
 
     if !execute_migration_yaml {
-        info!("Migration file not found.")
+        if use_deltas {
+            info!("No pending delta migration files found under ./migrations/.");
+        } else {
+            info!("Legacy migration plan.yaml not found.");
+        }
     }
 
     // Delta mode: all OLAP changes must flow through a committed delta file.
-    // If changes are pending and no delta file exists, block startup — auto-applying
-    // via execute_initial_infra_change would mutate Redis's infrastructure map and
-    // invalidate the parent_state_hash of any later-generated delta.
-    if use_deltas && !has_delta_files && !plan.changes.olap_changes.is_empty() {
+    // If changes are pending and no unapplied delta covers them, block startup —
+    // auto-applying via execute_initial_infra_change would mutate Redis's infrastructure
+    // map and invalidate the parent_state_hash of any later-generated delta.
+    if use_deltas && !has_unapplied_delta_files && !plan.changes.olap_changes.is_empty() {
         return Err(anyhow::anyhow!(
             "Production startup blocked: {} pending OLAP change(s) detected but no \
-             delta migration files exist in ./migrations/.\n\n\
+             unapplied delta migration files exist in ./migrations/.\n\n\
              In delta mode, every infrastructure change must flow through a \
              committed migration file so prod can apply them with a validated \
              parent state hash.\n\n\
@@ -1041,7 +1052,7 @@ pub async fn start_production_mode(
         }
     }
 
-    if has_delta_files {
+    if has_unapplied_delta_files {
         migrate::execute_migration_deltas(
             &project,
             &project.clickhouse_config,
@@ -1109,19 +1120,34 @@ pub async fn start_production_mode(
     Ok(())
 }
 
-/// Returns true if `./migrations/` contains any delta migration YAML files.
+/// Returns true if `{project}/migrations/` contains delta migration files that
+/// have not yet been recorded in `applied_migrations`.
 ///
 /// Delta files are any `*.yaml` under the directory other than the legacy
 /// `plan.yaml` / `pending.yaml`. Parses them via `MigrationHistory::load_from_dir`
 /// so malformed files surface as errors rather than being silently skipped.
-fn has_delta_migration_files() -> anyhow::Result<bool> {
-    let dir = std::path::Path::new("./migrations");
+///
+/// Checking only for file presence would be incorrect: delta files are permanent
+/// in version control, so once any delta is committed the presence check would
+/// return true on every subsequent deploy and bypass the destructive gate even
+/// when the user added new un-migrated code changes. Filtering by
+/// `load_applied_migrations` means this returns true only when there is genuinely
+/// new migration work to run.
+async fn has_unapplied_delta_migrations(
+    project: &Project,
+    state_storage: &dyn crate::framework::core::state_storage::StateStorage,
+) -> anyhow::Result<bool> {
+    let dir = project.project_location.join("migrations");
     if !dir.exists() {
         return Ok(false);
     }
-    let history = MigrationHistory::load_from_dir(dir)
+    let history = MigrationHistory::load_from_dir(&dir)
         .map_err(|e| anyhow::anyhow!("Failed to load migration files: {}", e))?;
-    Ok(!history.is_empty())
+    if history.is_empty() {
+        return Ok(false);
+    }
+    let applied = state_storage.load_applied_migrations().await?;
+    Ok(history.files.iter().any(|f| !applied.contains(&f.id)))
 }
 
 fn prepend_base_url(base_url: Option<&str>, path: &str) -> String {

--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -985,17 +985,35 @@ pub async fn start_production_mode(
     maybe_warmup_connections(&project, &redis_client).await;
 
     let use_deltas = project.features.migrate_with_deltas;
-    let execute_migration_yaml = if use_deltas {
-        has_delta_migration_files()?
-    } else {
-        std::fs::exists(MIGRATION_FILE)?
-    };
+    let has_delta_files = use_deltas && has_delta_migration_files()?;
+    let has_legacy_plan_yaml = !use_deltas && std::fs::exists(MIGRATION_FILE)?;
+    let execute_migration_yaml = has_delta_files || has_legacy_plan_yaml;
 
     if !execute_migration_yaml {
         info!("Migration file not found.")
     }
 
-    if !project.migration_config.prod_auto_allow_destructive && !execute_migration_yaml {
+    // Delta mode: all OLAP changes must flow through a committed delta file.
+    // If changes are pending and no delta file exists, block startup — auto-applying
+    // via execute_initial_infra_change would mutate Redis's infrastructure map and
+    // invalidate the parent_state_hash of any later-generated delta.
+    if use_deltas && !has_delta_files && !plan.changes.olap_changes.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Production startup blocked: {} pending OLAP change(s) detected but no \
+             delta migration files exist in ./migrations/.\n\n\
+             In delta mode, every infrastructure change must flow through a \
+             committed migration file so prod can apply them with a validated \
+             parent state hash.\n\n\
+             To proceed, run `moose generate migration --save` locally, review the \
+             generated file, and commit it before deploying.",
+            plan.changes.olap_changes.len(),
+        ));
+    }
+
+    if !use_deltas
+        && !project.migration_config.prod_auto_allow_destructive
+        && !execute_migration_yaml
+    {
         info!("prod_auto_allow_destructive is false, analysing risk.");
         let risk = classify_plan_risk(&plan.changes);
         if risk.is_destructive() {
@@ -1005,56 +1023,41 @@ pub async fn start_production_mode(
                 .map(|c| format!("  - {c}"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            let missing_file_hint = if use_deltas {
-                "no migration files were found in ./migrations/"
-            } else {
-                "no plan.yaml was found"
-            };
-            let generate_hint = if use_deltas {
-                "1. Run `moose generate migration --save` to record the destructive \
-                 changes in a reviewed delta file under ./migrations/"
-            } else {
-                "1. Create a new version of the table by setting the `version` field in your \
-                 OlapTable config and updating the table name (e.g. my_table_v2) — the backfill \
-                 heuristic uses these to migrate data automatically"
-            };
             return Err(anyhow::anyhow!(
                 "Production startup blocked: the computed infrastructure diff contains {} \
-                 destructive operation(s) but {}.\n\
+                 destructive operation(s) but no plan.yaml was found.\n\
                  {}\n\n\
                  To proceed, either:\n  \
-                 {}\n  \
+                 1. Create a new version of the table by setting the `version` field in your \
+                 OlapTable config and updating the table name (e.g. my_table_v2) — the backfill \
+                 heuristic uses these to migrate data automatically\n  \
                  2. Set `prod_auto_allow_destructive = true` under [migration_config] \
                  in moose.config.toml to allow unplanned destructive changes.",
                 risk.destructive_changes.len(),
-                missing_file_hint,
                 summary,
-                generate_hint,
             ));
         } else {
             info!("PlanRisk: {:?}, proceeding.", risk)
         }
     }
 
-    if execute_migration_yaml {
-        if use_deltas {
-            migrate::execute_migration_deltas(
-                &project,
-                &project.clickhouse_config,
-                &current_state,
-                &*state_storage,
-            )
-            .await?;
-        } else {
-            migrate::execute_migration_plan(
-                &project,
-                &project.clickhouse_config,
-                &current_state,
-                &plan.target_infra_map,
-                &*state_storage,
-            )
-            .await?;
-        }
+    if has_delta_files {
+        migrate::execute_migration_deltas(
+            &project,
+            &project.clickhouse_config,
+            &current_state,
+            &*state_storage,
+        )
+        .await?;
+    } else if has_legacy_plan_yaml {
+        migrate::execute_migration_plan(
+            &project,
+            &project.clickhouse_config,
+            &current_state,
+            &plan.target_infra_map,
+            &*state_storage,
+        )
+        .await?;
     };
 
     plan_validator::validate(&project, &plan)?;
@@ -1069,7 +1072,7 @@ pub async fn start_production_mode(
         project: &project,
         settings,
         plan: &plan,
-        skip_olap: execute_migration_yaml,
+        skip_olap: execute_migration_yaml || use_deltas,
         api_changes_channel,
         webapp_changes_channel: webapp_update_channel,
         metrics: metrics.clone(),

--- a/apps/framework-cli/src/cli/routines/mod.rs
+++ b/apps/framework-cli/src/cli/routines/mod.rs
@@ -95,6 +95,7 @@ use crate::framework::core::infra_reality_checker::InfraDiscrepancies;
 use crate::framework::core::infrastructure_map::{
     compute_table_columns_diff, InfrastructureMap, OlapChange, TableChange,
 };
+use crate::framework::core::migration_file::MigrationHistory;
 use crate::framework::core::migration_plan::MigrationPlanWithBeforeAfter;
 use crate::framework::core::plan_validator;
 use crate::framework::typescript::parser::get_compiled_index_path;
@@ -983,7 +984,12 @@ pub async fn start_production_mode(
     let (current_state, plan) = plan_changes(&*state_storage, &project).await?;
     maybe_warmup_connections(&project, &redis_client).await;
 
-    let execute_migration_yaml = std::fs::exists(MIGRATION_FILE)?;
+    let use_deltas = project.features.migrate_with_deltas;
+    let execute_migration_yaml = if use_deltas {
+        has_delta_migration_files()?
+    } else {
+        std::fs::exists(MIGRATION_FILE)?
+    };
 
     if !execute_migration_yaml {
         info!("Migration file not found.")
@@ -999,18 +1005,31 @@ pub async fn start_production_mode(
                 .map(|c| format!("  - {c}"))
                 .collect::<Vec<_>>()
                 .join("\n");
+            let missing_file_hint = if use_deltas {
+                "no migration files were found in ./migrations/"
+            } else {
+                "no plan.yaml was found"
+            };
+            let generate_hint = if use_deltas {
+                "1. Run `moose generate migration --save` to record the destructive \
+                 changes in a reviewed delta file under ./migrations/"
+            } else {
+                "1. Create a new version of the table by setting the `version` field in your \
+                 OlapTable config and updating the table name (e.g. my_table_v2) — the backfill \
+                 heuristic uses these to migrate data automatically"
+            };
             return Err(anyhow::anyhow!(
                 "Production startup blocked: the computed infrastructure diff contains {} \
-                 destructive operation(s) but no plan.yaml was found.\n\
+                 destructive operation(s) but {}.\n\
                  {}\n\n\
                  To proceed, either:\n  \
-                 1. Create a new version of the table by setting the `version` field in your \
-                 OlapTable config and updating the table name (e.g. my_table_v2) — the backfill \
-                 heuristic uses these to migrate data automatically\n  \
+                 {}\n  \
                  2. Set `prod_auto_allow_destructive = true` under [migration_config] \
                  in moose.config.toml to allow unplanned destructive changes.",
                 risk.destructive_changes.len(),
+                missing_file_hint,
                 summary,
+                generate_hint,
             ));
         } else {
             info!("PlanRisk: {:?}, proceeding.", risk)
@@ -1018,14 +1037,24 @@ pub async fn start_production_mode(
     }
 
     if execute_migration_yaml {
-        migrate::execute_migration_plan(
-            &project,
-            &project.clickhouse_config,
-            &current_state,
-            &plan.target_infra_map,
-            &*state_storage,
-        )
-        .await?;
+        if use_deltas {
+            migrate::execute_migration_deltas(
+                &project,
+                &project.clickhouse_config,
+                &current_state,
+                &*state_storage,
+            )
+            .await?;
+        } else {
+            migrate::execute_migration_plan(
+                &project,
+                &project.clickhouse_config,
+                &current_state,
+                &plan.target_infra_map,
+                &*state_storage,
+            )
+            .await?;
+        }
     };
 
     plan_validator::validate(&project, &plan)?;
@@ -1075,6 +1104,21 @@ pub async fn start_production_mode(
         .await;
 
     Ok(())
+}
+
+/// Returns true if `./migrations/` contains any delta migration YAML files.
+///
+/// Delta files are any `*.yaml` under the directory other than the legacy
+/// `plan.yaml` / `pending.yaml`. Parses them via `MigrationHistory::load_from_dir`
+/// so malformed files surface as errors rather than being silently skipped.
+fn has_delta_migration_files() -> anyhow::Result<bool> {
+    let dir = std::path::Path::new("./migrations");
+    if !dir.exists() {
+        return Ok(false);
+    }
+    let history = MigrationHistory::load_from_dir(dir)
+        .map_err(|e| anyhow::anyhow!("Failed to load migration files: {}", e))?;
+    Ok(!history.is_empty())
 }
 
 fn prepend_base_url(base_url: Option<&str>, path: &str) -> String {

--- a/apps/framework-cli/src/framework/core/state_storage.rs
+++ b/apps/framework-cli/src/framework/core/state_storage.rs
@@ -151,11 +151,31 @@ impl StateStorage for RedisStateStorage {
     }
 
     async fn load_applied_migrations(&self) -> Result<Vec<String>> {
+        // Try current prefix first (same-deployment restarts); fall back to the
+        // previous deploy's prefix so applied-migration state survives a new
+        // deploy_id. Without this fallback, every deployment would replay all
+        // delta files and fail on parent_state_hash validation because the
+        // infra map (which does carry over via load_from_last_redis_prefix) is
+        // already past the first migration's parent hash.
         let value: Option<String> = self
             .client
             .get_with_service_prefix(Self::APPLIED_MIGRATIONS_KEY)
             .await?;
-        match value {
+        if let Some(json) = value {
+            return Ok(serde_json::from_str(&json)?);
+        }
+
+        let last_prefix = &self.client.config.last_key_prefix;
+        let default_prefix = crate::infrastructure::redis::RedisConfig::default_key_prefix();
+        if *last_prefix == default_prefix {
+            return Ok(vec![]);
+        }
+
+        let fallback: Option<String> = self
+            .client
+            .get_with_explicit_prefix(last_prefix, Self::APPLIED_MIGRATIONS_KEY)
+            .await?;
+        match fallback {
             Some(json) => Ok(serde_json::from_str(&json)?),
             None => Ok(vec![]),
         }

--- a/apps/framework-cli/src/framework/core/state_storage.rs
+++ b/apps/framework-cli/src/framework/core/state_storage.rs
@@ -157,6 +157,12 @@ impl StateStorage for RedisStateStorage {
         // delta files and fail on parent_state_hash validation because the
         // infra map (which does carry over via load_from_last_redis_prefix) is
         // already past the first migration's parent hash.
+        //
+        // The fallback guard matches `load_from_last_redis_prefix` semantics:
+        // skip only when `last_key_prefix` would re-read the current prefix
+        // (i.e. they're identical). A previous deploy that legitimately ran
+        // with the default prefix still gets its applied list carried forward,
+        // consistent with how the infra map itself is loaded.
         let value: Option<String> = self
             .client
             .get_with_service_prefix(Self::APPLIED_MIGRATIONS_KEY)
@@ -166,8 +172,8 @@ impl StateStorage for RedisStateStorage {
         }
 
         let last_prefix = &self.client.config.last_key_prefix;
-        let default_prefix = crate::infrastructure::redis::RedisConfig::default_key_prefix();
-        if *last_prefix == default_prefix {
+        let current_prefix = &self.client.config.key_prefix;
+        if last_prefix == current_prefix {
             return Ok(vec![]);
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes production migration gating and state lookup, which can block startup or alter when migrations run if misconfigured. Behavior depends on correct delta file IDs and Redis prefix settings across deployments.
> 
> **Overview**
> Updates production startup to support *delta-based migrations* by detecting **unapplied** `./migrations/*.yaml` deltas (via `MigrationHistory` + `load_applied_migrations`) and running `execute_migration_deltas` when present, while keeping legacy `plan.yaml` behavior for non-delta mode.
> 
> In delta mode, production now **blocks startup** if there are pending OLAP changes but no unapplied delta files, and it forces `execute_initial_infra_change` to `skip_olap` to prevent auto-applying schema changes outside of committed migrations.
> 
> Improves Redis state handling for deltas by making `RedisStateStorage::load_applied_migrations` fall back to the previous Redis key prefix so applied-migration tracking survives `deploy_id`/prefix changes and avoids reapplying old delta files on new deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b00d0111e69c9e39204ab761c7935ea72946d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->