### PR TITLE
docs(migrate): consolidate migration docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,7 @@ content-generation.mdc
 
 # Claude local marketing context
 .claude/marketing-context/
+
+# Claude Code ephemeral agent worktrees
+.claude/worktrees/
 .pnpm-store

--- a/apps/framework-docs-v2/content/moosestack/apis/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/index.mdx
@@ -14,9 +14,9 @@ MooseStack lets you expose HTTP endpoints for **ingestion**, **analytics**, and 
 You can do this in two distinct ways:
 
 - **Native Moose APIs**: define endpoints with Moose primitives (type-safe, OpenAPI-friendly).
-- **Web apps inside the Moose Runtime**: run Express/Fastify/Koa/FastAPI (or raw Node) inside MooseStack via `WebApp`.
+- **Web apps inside the Moose Server**: run Express/Fastify/Koa/FastAPI (or raw Node) inside MooseStack via `WebApp`.
 
-If you want to **embed Moose as a library inside an existing web app** (no separate Moose Runtime service), follow the “Add to Existing App” guides like [Next.js](/moosestack/getting-started/existing-app/next-js) or [Fastify](/moosestack/getting-started/existing-app/fastify).
+If you want to **embed Moose as a library inside an existing web app** (no separate Moose Server service), follow the “Add to Existing App” guides like [Next.js](/moosestack/getting-started/existing-app/next-js) or [Fastify](/moosestack/getting-started/existing-app/fastify).
 
 ## What this is
 
@@ -35,7 +35,7 @@ APIs are where external systems interface with your OLAP database. MooseStack gi
 | You want… | Use… |
 | --- | --- |
 | Fastest path to ingestion/analytics endpoints | **Native Moose APIs** |
-| Custom middleware/routing, but still want Moose to run your web server | **WebApp (inside Moose Runtime)** |
+| Custom middleware/routing, but still want Moose to run your web server | **WebApp (inside Moose Server)** |
 | Typed ClickHouse models + queries in your existing backend runtime | **Embed MooseStack in an existing app** (e.g. [Fastify](/moosestack/getting-started/existing-app/fastify)) |
 
 ### 1) Native Moose APIs
@@ -46,9 +46,9 @@ Native APIs are best for straightforward endpoints with minimal routing/middlewa
 - **[Analytics API](/moosestack/apis/analytics-api)**: create GET endpoints that run queries (OLAP or custom logic).
 - **[Query Layer](/moosestack/reference/query-layer)**: define metrics, dimensions, and filters once — expose them as REST APIs, AI SDK tool calls, and MCP tools.
 
-### 2) Web apps inside the Moose Runtime (WebApp)
+### 2) Web apps inside the Moose Server (WebApp)
 
-If you want a full-featured web framework, MooseStack can host it via `WebApp` as part of the Moose Runtime.
+If you want a full-featured web framework, MooseStack can host it via `WebApp` as part of the Moose Server.
 
 **Why embed your framework:**
 
@@ -60,7 +60,7 @@ Supported adapters include: [Express](/moosestack/app-api-frameworks/express), [
 
 ### 3) Use Moose CLI + library in your existing backend
 
-If you already have an app server (like Next.js or Fastify), you can keep it where it is and use Moose as a **CLI tool** (for schema migrations) and **library** (for type-safe ClickHouse queries) **without deploying a separate Moose Runtime web service**.
+If you already have an app server (like Next.js or Fastify), you can keep it where it is and use Moose as a **CLI tool** (for schema migrations) and **library** (for type-safe ClickHouse queries) **without deploying a separate Moose Server web service**.
 
 See: [Next.js](/moosestack/getting-started/existing-app/next-js) or [Fastify](/moosestack/getting-started/existing-app/fastify).
 
@@ -105,7 +105,7 @@ See: [Next.js](/moosestack/getting-started/existing-app/next-js) or [Fastify](/m
 </CTACards>
 
 <Callout type="info" title="Don’t conflate WebApp with client-only embedding">
-  **WebApp** runs your API framework inside the Moose Runtime. **Client-only embedding** keeps your existing app server
+  **WebApp** runs your API framework inside the Moose Server. **Client-only embedding** keeps your existing app server
   and uses Moose as a library (see [Next.js](/moosestack/getting-started/existing-app/next-js)).
 </Callout>
 

--- a/apps/framework-docs-v2/content/moosestack/apis/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/apis/index.mdx
@@ -16,7 +16,7 @@ You can do this in two distinct ways:
 - **Native Moose APIs**: define endpoints with Moose primitives (type-safe, OpenAPI-friendly).
 - **Web apps inside the Moose Server**: run Express/Fastify/Koa/FastAPI (or raw Node) inside MooseStack via `WebApp`.
 
-If you want to **embed Moose as a library inside an existing web app** (no separate Moose Server service), follow the “Add to Existing App” guides like [Next.js](/moosestack/getting-started/existing-app/next-js) or [Fastify](/moosestack/getting-started/existing-app/fastify).
+If you want to **embed Moose as a library inside an existing web app** (no separate Moose Server), follow the “Add to Existing App” guides like [Next.js](/moosestack/getting-started/existing-app/next-js) or [Fastify](/moosestack/getting-started/existing-app/fastify).
 
 ## What this is
 

--- a/apps/framework-docs-v2/content/moosestack/app-api-frameworks/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/app-api-frameworks/index.mdx
@@ -47,7 +47,7 @@ Join our Slack community to chat about other framework integrations you'd like t
 
 ## Client-only embedding (existing apps)
 
-Optionally, if you already have a running app server, you can keep it where it is and use MooseStack as a library for ClickHouse modeling + type-safe queries (no separate Moose Runtime web service).
+Optionally, if you already have a running app server, you can keep it where it is and use MooseStack as a library for ClickHouse modeling + type-safe queries (no separate Moose Server web service).
 
 - [Embed ClickHouse analytics in Next.js](/moosestack/getting-started/existing-app/next-js)
 - [Embed ClickHouse analytics in Fastify](/moosestack/getting-started/existing-app/fastify)

--- a/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/dev-environment.mdx
@@ -260,7 +260,7 @@ Credentials (username/password) are **not** stored in `moose.config.toml`. On fi
 
 ## Networking Reference
 
-Reference for default ports and URLs used by the Moose Runtime in development mode.
+Reference for default ports and URLs used by the Moose Server in development mode.
 
 ### Default Ports
 

--- a/apps/framework-docs-v2/content/moosestack/configuration/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/index.mdx
@@ -6,7 +6,7 @@ order: 10
 
 # Configuration
 
-MooseStack settings live in two places: a project config file and runtime environment variables. The config file is tracked in git and defines the shape of your app; env vars are per-environment values (often secrets) that override the file at runtime. Moose Runtime loads both at startup, with env vars winning when they overlap.
+MooseStack settings live in two places: a project config file and runtime environment variables. The config file is tracked in git and defines the shape of your app; env vars are per-environment values (often secrets) that override the file at runtime. Moose Server loads both at startup, with env vars winning when they overlap.
 
 ## Concept
 
@@ -41,7 +41,7 @@ Environment variables are the primary mechanism for managing secrets and differe
 
 ### `.env` Files
 
-Moose Runtime automatically loads `.env` files in order of precedence. Files loaded later override values from earlier files.
+Moose Server automatically loads `.env` files in order of precedence. Files loaded later override values from earlier files.
 
 | File | Purpose | Committed? | When Loaded |
 |:-----|:--------|:-----------|:------------|

--- a/apps/framework-docs-v2/content/moosestack/deploying/preparing-clickhouse-redpanda.mdx
+++ b/apps/framework-docs-v2/content/moosestack/deploying/preparing-clickhouse-redpanda.mdx
@@ -20,7 +20,7 @@ You can stand up open source versions of these applications within your environm
 ## ClickHouse Configuration
 
 <Callout type="info" title="KeeperMap Engine Required for ClickHouse State Storage">
-If you're using `state_config.storage = "clickhouse"` in your config (serverless mode without Redis), your ClickHouse instance must support the **KeeperMap** table engine. This is used for migration state storage and distributed locking.
+If you're using `state_config.storage = "clickhouse"` in your config (Standalone CLI mode without Redis), your ClickHouse instance must support the **KeeperMap** table engine. This is used for migration state storage and distributed locking.
 
 ✅ **ClickHouse Cloud**: Supported by default
 ✅ **`moose dev` / `moose prod`**: Already configured in our Docker setup

--- a/apps/framework-docs-v2/content/moosestack/getting-started/existing-app/fastify.mdx
+++ b/apps/framework-docs-v2/content/moosestack/getting-started/existing-app/fastify.mdx
@@ -162,7 +162,7 @@ Add more tables by exporting additional `OlapTable` objects from `moose/app/inde
 
 ## Start local ClickHouse
 
-Start the Moose Runtime in `dev` mode. This brings up a local ClickHouse instance (via Docker) and hot-reloads schema changes to it whenever you edit your models.
+Start the Moose Server in `dev` mode. This brings up a local ClickHouse instance (via Docker) and hot-reloads schema changes to it whenever you edit your models.
 
 Navigate to your `moose` directory and run:
 
@@ -265,7 +265,7 @@ export default async function clickhouseController(fastify: FastifyInstance) {
 
 ## Deploy to production
 
-There's no separate production Moose Runtime to deploy. You just need to:
+There's no separate production Moose Server to deploy. You just need to:
 
 1. Apply your schema to production ClickHouse
 2. Configure your production environment with production credentials

--- a/apps/framework-docs-v2/content/moosestack/getting-started/existing-app/next-js.mdx
+++ b/apps/framework-docs-v2/content/moosestack/getting-started/existing-app/next-js.mdx
@@ -187,7 +187,7 @@ Add more tables by exporting additional `OlapTable` objects from `moose/app/mode
 
 ## Start local ClickHouse
 
-Start the Moose Runtime in `dev` mode. This brings up a local ClickHouse instance (via Docker) and hot-reloads schema changes to it whenever you edit your models.
+Start the Moose Server in `dev` mode. This brings up a local ClickHouse instance (via Docker) and hot-reloads schema changes to it whenever you edit your models.
 
 Navigate to your `moose` directory and run:
 
@@ -298,7 +298,7 @@ Do not call ClickHouse from the browser. Use Server Components, Route Handlers, 
 
 ## Deploy to production
 
-There's no separate production Moose Runtime to deploy. You just need to:
+There's no separate production Moose Server to deploy. You just need to:
 
 1. Apply your schema to production ClickHouse
 2. Configure your production environment with production credentials

--- a/apps/framework-docs-v2/content/moosestack/getting-started/from-clickhouse.mdx
+++ b/apps/framework-docs-v2/content/moosestack/getting-started/from-clickhouse.mdx
@@ -247,7 +247,7 @@ Check what Moose created from your tables in the `app/main.py` file:
 
 <Callout type="info" title="Import Pattern">
 <div>Your generated table models are imported here so Moose can detect them.</div>
-<div className="text-sm mt-2">Learn more about export pattern: <a href="/moosestack/runtime?lang=python#finding-dependencies" className="text-blue-500 hover:underline">local development</a> / <a href="/moosestack/migrate?lang=python" className="text-blue-500 hover:underline">hosted</a></div>
+<div className="text-sm mt-2">Learn more about export pattern: <a href="/moosestack/server?lang=python#finding-dependencies" className="text-blue-500 hover:underline">local development</a> / <a href="/moosestack/migrate?lang=python" className="text-blue-500 hover:underline">hosted</a></div>
 </Callout>
   </LanguageTabContent>
   <LanguageTabContent value="typescript">
@@ -260,7 +260,7 @@ Check what Moose created from your tables in the `app/index.ts` file:
 
 <Callout type="info" title="Export Pattern">
 <div>Your generated table models are exported here so Moose can detect them.</div>
-<div className="text-sm mt-2">Learn more about export pattern: <a href="/moosestack/runtime?lang=typescript#finding-dependencies" className="text-blue-500 hover:underline">local development</a> / <a href="/moosestack/migrate?lang=typescript" className="text-blue-500 hover:underline">hosted</a></div>
+<div className="text-sm mt-2">Learn more about export pattern: <a href="/moosestack/server?lang=typescript#finding-dependencies" className="text-blue-500 hover:underline">local development</a> / <a href="/moosestack/migrate?lang=typescript" className="text-blue-500 hover:underline">hosted</a></div>
 </Callout>
   </LanguageTabContent>
 </LanguageTabs>

--- a/apps/framework-docs-v2/content/moosestack/migrate/apply-planned-migrations-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/apply-planned-migrations-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: moose migrate
-description: Reference documentation for the manual migration CLI command used in serverless deployments.
+description: Reference documentation for the manual migration CLI command used in Standalone CLI deployments.
 order: 7
 category: olap
 ---
@@ -9,11 +9,11 @@ import { Callout } from "@/components/mdx";
 
 # moose migrate
 
-The **CLI** deployment model relies on the `moose migrate` CLI command to execute planned schema changes. This gives you explicit control over when migrations run, which is essential for architectures where Moose OLAP is integrated as a library rather than a standalone server (e.g. as a library in a Python or TypeScript application).
+The **Standalone CLI** deployment model relies on the `moose migrate` CLI command to execute planned schema changes. This gives you explicit control over when migrations run, which is essential for architectures where Moose OLAP is integrated as a library rather than a long-lived server (e.g. as a library in a Python or TypeScript application).
 
 ## Overview
 
-In serverless or library-based deployments, MooseStack does not control the application runtime. Therefore, migrations must be triggered externally, typically as a step in a CI/CD pipeline or a manual administrative action.
+In Standalone CLI deployments (Moose used as a library, with no long-lived server), MooseStack does not control the application runtime. Therefore, migrations must be triggered externally, typically as a step in a CI/CD pipeline or a manual administrative action.
 
 | Feature | Description |
 | :--- | :--- |
@@ -69,5 +69,5 @@ This command is typically used in a deployment pipeline before updating the appl
 ## See Also
 
 - [Planned Migrations](/moosestack/migrate/planned-migrations) — Generating the plan files
-- [moose prod (Moose Runtime Migrations)](/moosestack/migrate/apply-planned-migrations-service) — Automatic migrations for Moose Runtime deployments
+- [moose prod (Moose Server)](/moosestack/migrate/apply-planned-migrations-service) — Automatic migrations for Moose Server deployments
 - [Migration Modes](/moosestack/migrate/modes) — Overview of schema evolution modes

--- a/apps/framework-docs-v2/content/moosestack/migrate/apply-planned-migrations-service.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/apply-planned-migrations-service.mdx
@@ -1,6 +1,6 @@
 ---
 title: moose prod
-description: Reference documentation for automatic migration execution in the Moose server runtime.
+description: Reference documentation for automatic migration execution on the Moose Server.
 order: 8
 category: olap
 ---
@@ -9,7 +9,7 @@ import { Callout } from "@/components/mdx";
 
 # moose prod
 
-The **Moose Runtime** deployment model (invoked via `moose prod`) includes an automatic migration runner that executes planned changes during the application boot sequence.
+The **Moose Server** deployment model (invoked via `moose prod`) includes an automatic migration runner that executes planned changes during the application boot sequence.
 
 ## Overview
 
@@ -58,4 +58,4 @@ If you are using Fiveonefour hosting, this process is handled automatically. The
 ## See Also
 
 - [Planned Migrations](/moosestack/migrate/planned-migrations) — Generate the migration plan files
-- [moose migrate](/moosestack/migrate/apply-planned-migrations-cli) — Manual CLI migrations for serverless deployments
+- [moose migrate](/moosestack/migrate/apply-planned-migrations-cli) — Manual CLI migrations for Standalone CLI deployments

--- a/apps/framework-docs-v2/content/moosestack/migrate/apply.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/apply.mdx
@@ -15,26 +15,26 @@ This overview describes the delta-based migration workflow, enabled with `featur
 
 Once a migration plan has been generated, Moose provides two execution paths. Choose the one that matches your deployment model.
 
-## moose migrate (CLI)
+## moose migrate (Standalone CLI)
 
-Apply migrations manually or from a CI/CD step as a one-shot command. Use this for serverless deployments or pipelines that don't run a long-lived Moose server.
+Apply migrations manually or from a CI/CD step as a one-shot command. Use this for Standalone CLI deployments or pipelines that don't run a long-lived Moose Server.
 
-See [moose migrate (CLI)](/moosestack/migrate/apply-planned-migrations-cli) for details.
+See [moose migrate (Standalone CLI)](/moosestack/migrate/apply-planned-migrations-cli) for details.
 
-## moose prod (Runtime)
+## moose prod (Moose Server)
 
-Apply migrations automatically when the Moose server starts. Use this for long-lived server deployments where migrations run as part of the application lifecycle.
+Apply migrations automatically when the Moose Server starts. Use this for long-lived server deployments where migrations run as part of the application lifecycle.
 
-See [moose prod (Runtime)](/moosestack/migrate/apply-planned-migrations-service) for details.
+See [moose prod (Moose Server)](/moosestack/migrate/apply-planned-migrations-service) for details.
 
 ## When to use each
 
 | Scenario | Recommended path |
 | :--- | :--- |
-| Serverless deployment | `moose migrate` (CLI) |
-| CI/CD-driven database changes | `moose migrate` (CLI) |
-| Long-lived Moose server | `moose prod` (Runtime) |
-| Manual execution for a one-off rollout | `moose migrate` (CLI) |
+| Standalone CLI deployment | `moose migrate` |
+| CI/CD-driven database changes | `moose migrate` |
+| Long-lived Moose Server | `moose prod` |
+| Manual execution for a one-off rollout | `moose migrate` |
 
 ## Recovering from failed migrations
 

--- a/apps/framework-docs-v2/content/moosestack/migrate/apply.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/apply.mdx
@@ -44,4 +44,4 @@ If a migration fails partway through, see [Failed Migrations](/moosestack/migrat
 
 - [Generate migrations](/moosestack/migrate/generate) — how migration plans are produced
 - [Migration Plan](/moosestack/migrate/plan-format) — the plan-file format and editable operations
-- [Lifecycle management](/moosestack/migrate/lifecycle) — controlling which changes Moose is allowed to make
+- [Lifecycle management](/moosestack/migrate/lifecycle-fully-managed) — controlling which changes Moose is allowed to make

--- a/apps/framework-docs-v2/content/moosestack/migrate/apply.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/apply.mdx
@@ -1,0 +1,47 @@
+---
+title: Apply migrations
+description: Execute generated migrations against your database
+order: 2
+category: migrate
+---
+
+import { Callout } from "@/components/mdx";
+
+# Apply migrations
+
+<Callout type="info" title="Delta-based workflow — opt-in during beta">
+This overview describes the delta-based migration workflow, enabled with `features.migrate_with_deltas = true` in `moose.config.toml`. The current default is `false`; once beta testing ends, delta migrations will become the default. Until then, `moose migrate` and `moose prod` run the legacy `plan.yaml` workflow — see the reference pages linked below for current behavior.
+</Callout>
+
+Once a migration plan has been generated, Moose provides two execution paths. Choose the one that matches your deployment model.
+
+## moose migrate (CLI)
+
+Apply migrations manually or from a CI/CD step as a one-shot command. Use this for serverless deployments or pipelines that don't run a long-lived Moose server.
+
+See [moose migrate (CLI)](/moosestack/migrate/apply-planned-migrations-cli) for details.
+
+## moose prod (Runtime)
+
+Apply migrations automatically when the Moose server starts. Use this for long-lived server deployments where migrations run as part of the application lifecycle.
+
+See [moose prod (Runtime)](/moosestack/migrate/apply-planned-migrations-service) for details.
+
+## When to use each
+
+| Scenario | Recommended path |
+| :--- | :--- |
+| Serverless deployment | `moose migrate` (CLI) |
+| CI/CD-driven database changes | `moose migrate` (CLI) |
+| Long-lived Moose server | `moose prod` (Runtime) |
+| Manual execution for a one-off rollout | `moose migrate` (CLI) |
+
+## Recovering from failed migrations
+
+If a migration fails partway through, see [Failed Migrations](/moosestack/migrate/failed-migrations) for recovery guidance.
+
+## Related
+
+- [Generate migrations](/moosestack/migrate/generate) — how migration plans are produced
+- [Migration Plan](/moosestack/migrate/plan-format) — the plan-file format and editable operations
+- [Lifecycle management](/moosestack/migrate/lifecycle) — controlling which changes Moose is allowed to make

--- a/apps/framework-docs-v2/content/moosestack/migrate/automatic.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/automatic.mdx
@@ -135,4 +135,4 @@ The CLI communicates migration actions via standard output prefixes in the termi
 
 - [Planned Migrations](/moosestack/migrate/planned-migrations) - The reference for production-grade migration workflows.
 - [Schema Change Reference](/moosestack/migrate/plan-format) - Detailed breakdown of migration plan objects.
-- [Serverless (moose migrate)](/moosestack/migrate/apply-planned-migrations-cli) - Commands for managing migrations manually.
+- [Standalone CLI (moose migrate)](/moosestack/migrate/apply-planned-migrations-cli) - Commands for managing migrations manually.

--- a/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
@@ -1,0 +1,46 @@
+---
+title: Generate migrations
+description: How Moose generates schema migrations from code changes
+order: 1
+category: migrate
+---
+
+import { Callout } from "@/components/mdx";
+
+# Generate migrations
+
+<Callout type="info" title="Delta-based workflow — opt-in during beta">
+This page describes the delta-based migration workflow, enabled with `features.migrate_with_deltas = true` in `moose.config.toml`. The current default is `false`; once beta testing ends, delta migrations will become the default. For the current default workflow, see [Planned Migrations](/moosestack/migrate/planned-migrations) and [Automatic Migrations](/moosestack/migrate/automatic).
+</Callout>
+
+Moose represents schema changes as a series of **migration files** under `./migrations/`. Each committed migration file records an incremental diff from the previous migrated state. Once applied, a migration is tracked in state and is never re-run.
+
+## During development
+
+`moose dev` watches your code for schema changes and appends operations to `./migrations/pending.yaml` in realtime as you save. The pending file reflects the uncommitted changes in your working directory, so you can review it as you work to see exactly what will be included in the next migration.
+
+## Finalizing a migration
+
+When you're ready to commit a migration for deployment, run:
+
+```bash
+moose generate migration --save
+```
+
+This takes the current pending migration, computes the final diff against the previous migrated state, and writes a new committed migration file under `./migrations/`. Review the file, commit it to version control, then deploy.
+
+## How migrations are tracked in production
+
+In production, Moose reads every migration file in `./migrations/`, compares against the applied-migrations list stored in state, and runs only the unapplied ones. Applied migrations are never re-run.
+
+<Callout type="warning" title="Production blocks unmigrated changes">
+If your code has pending OLAP changes but no committed migration file covers them, production startup is blocked. Every infrastructure change must flow through a committed migration file so production can apply them with a validated parent state hash.
+
+Run `moose generate migration --save` locally, review the generated file, and commit it before deploying.
+</Callout>
+
+## Related
+
+- [Migration Plan](/moosestack/migrate/plan-format) — the operation reference and migration-file format
+- [Apply migrations](/moosestack/migrate/apply) — how committed migrations are executed against your database
+- [Lifecycle management](/moosestack/migrate/lifecycle) — controlling which changes Moose is allowed to make

--- a/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
@@ -21,13 +21,65 @@ Moose represents schema changes as a series of **migration files** under `./migr
 
 ## Finalizing a migration
 
-When you're ready to commit a migration for deployment, run:
+When you're ready to commit a migration for deployment, run `moose generate migration --save`. This takes the current pending migration, computes the final diff against the previous migrated state, and writes a new committed migration file under `./migrations/`. Review the file, commit it to version control, then deploy.
+
+## Command
+
+Generate a migration by comparing your local code against a remote environment:
 
 ```bash
-moose generate migration --save
+# For Server Runtime (connect to Moose Admin API)
+moose generate migration --url <ADMIN_API_URL> --token <ADMIN_TOKEN> --save
+
+# For Serverless (connect to ClickHouse directly)
+moose generate migration --clickhouse-url <CLICKHOUSE_CONNECTION_STRING> --save
 ```
 
-This takes the current pending migration, computes the final diff against the previous migrated state, and writes a new committed migration file under `./migrations/`. Review the file, commit it to version control, then deploy.
+## Command Options
+
+The `moose generate migration` command accepts different arguments depending on your [deployment model for applying changes](/moosestack/migrate#applying-changes).
+
+### via Moose Runtime (`moose prod`)
+
+Connect to the **Admin API** of the running service.
+
+```bash
+moose generate migration --url <ADMIN_API_URL> --token <ADMIN_TOKEN> --save
+```
+
+| Option | Description |
+| :--- | :--- |
+| `--url` | The endpoint of your production Moose Admin API. |
+| `--token` | The authentication token for the Admin API. |
+| `--save` | Writes the generated migration file to the `migrations/` directory. Without this, it performs a dry run. |
+
+### via Serverless (`moose migrate`)
+
+Connect directly to the **ClickHouse database**.
+
+```bash
+moose generate migration --clickhouse-url <CLICKHOUSE_CONNECTION_STRING> --save
+```
+
+| Option | Description |
+| :--- | :--- |
+| `--clickhouse-url` | Direct connection string (e.g., `clickhouse://user:pass@host:9440/db`). |
+| `--save` | Writes the generated migration file to the `migrations/` directory. Without this, it performs a dry run. |
+
+### Confirmation flags
+
+These flags control the interactive confirmation prompts during migration generation:
+
+| Option | Environment Variable | Description |
+| :--- | :--- | :--- |
+| `--yes-all` | `MOOSE_ACCEPT_ALL=1` | Skip all confirmation prompts (renames and destructive operations). |
+| `--yes-destructive` | `MOOSE_ACCEPT_DESTRUCTIVE=1` | Skip the confirmation prompt for destructive operations. |
+| `--yes-rename` | `MOOSE_ACCEPT_RENAME=1` | Auto-accept detected column renames as genuine renames. |
+| `--no-auto-backfill-sql` | — | Disable automatic backfill SQL generation for versioned tables. |
+
+<Callout type="info" title="Versioned table backfills" compact>
+If you are using migrations for a breaking OLAP table change, see [Schema Versioning](/moosestack/olap/schema-versioning) for the end-to-end version bump and generated backfill workflow.
+</Callout>
 
 ## How migrations are tracked in production
 

--- a/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
@@ -10,7 +10,9 @@ import { Callout } from "@/components/mdx";
 # Generate migrations
 
 <Callout type="info" title="Delta-based workflow — opt-in during beta">
-This page describes the delta-based migration workflow, enabled with `features.migrate_with_deltas = true` in `moose.config.toml`. The current default is `false`; once beta testing ends, delta migrations will become the default. For the current default workflow, see [Planned Migrations](/moosestack/migrate/planned-migrations) and [Automatic Migrations](/moosestack/migrate/automatic).
+This page describes the delta-based migration workflow, available since the [April 9, 2026 release](/moosestack/release-notes/2026-04-09) and enabled by setting `features.migrate_with_deltas = true` in `moose.config.toml`. The current default is `false`; once beta testing ends, delta migrations will become the default.
+
+**On earlier Moose versions, or running with the default config?** See [Planned Migrations](/moosestack/migrate/planned-migrations) and [Automatic Migrations](/moosestack/migrate/automatic) for the current-default workflow.
 </Callout>
 
 Moose represents schema changes as a series of **migration files** under `./migrations/`. Each committed migration file records an incremental diff from the previous migrated state. Once applied, a migration is tracked in state and is never re-run.
@@ -21,7 +23,7 @@ Moose represents schema changes as a series of **migration files** under `./migr
 
 ## Finalizing a migration
 
-When you're ready to commit a migration for deployment, run `moose generate migration --save`. This takes the current pending migration, computes the final diff against the previous migrated state, and writes a new committed migration file under `./migrations/`. Review the file, commit it to version control, then deploy.
+When you're ready to commit a migration for deployment, run `moose generate migration --save`. This takes the current pending migration, computes the final diff against the previous migrated state, and writes a new committed migration file under `./migrations/` with a timestamp-prefixed ID (e.g., `20260415_add_user_prefs.yaml`). Review the file, commit it to version control, then deploy.
 
 ## Command
 

--- a/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
@@ -30,18 +30,21 @@ When you're ready to commit a migration for deployment, run `moose generate migr
 Generate a migration by comparing your local code against a remote environment:
 
 ```bash
-# For Server Runtime (connect to Moose Admin API)
+# Moose Server (connect to the Admin API)
 moose generate migration --url <ADMIN_API_URL> --token <ADMIN_TOKEN> --save
 
-# For Serverless (connect to ClickHouse directly)
+# Standalone CLI (connect to ClickHouse directly)
 moose generate migration --clickhouse-url <CLICKHOUSE_CONNECTION_STRING> --save
 ```
 
 ## Command Options
 
-The `moose generate migration` command accepts different arguments depending on your [deployment model for applying changes](/moosestack/migrate#applying-changes).
+The `moose generate migration` command accepts different arguments depending on how you run Moose:
 
-### via Moose Runtime (`moose prod`)
+- **Running the Moose Server in production** — use the first command below to connect to the Admin API with `--url` and `--token`.
+- **No Moose Server, using Moose only for remote schema management (Standalone CLI)** — use the second command below to connect directly to ClickHouse with `--clickhouse-url`.
+
+### via Moose Server (`moose prod`)
 
 Connect to the **Admin API** of the running service.
 
@@ -55,7 +58,7 @@ moose generate migration --url <ADMIN_API_URL> --token <ADMIN_TOKEN> --save
 | `--token` | The authentication token for the Admin API. |
 | `--save` | Writes the generated migration file to the `migrations/` directory. Without this, it performs a dry run. |
 
-### via Serverless (`moose migrate`)
+### via Standalone CLI (`moose migrate`)
 
 Connect directly to the **ClickHouse database**.
 

--- a/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/generate.mdx
@@ -95,4 +95,4 @@ Run `moose generate migration --save` locally, review the generated file, and co
 
 - [Migration Plan](/moosestack/migrate/plan-format) — the operation reference and migration-file format
 - [Apply migrations](/moosestack/migrate/apply) — how committed migrations are executed against your database
-- [Lifecycle management](/moosestack/migrate/lifecycle) — controlling which changes Moose is allowed to make
+- [Lifecycle management](/moosestack/migrate/lifecycle-fully-managed) — controlling which changes Moose is allowed to make

--- a/apps/framework-docs-v2/content/moosestack/migrate/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/index.mdx
@@ -20,7 +20,7 @@ This documentation describes the delta-based migration workflow, enabled with `f
 | Phase | What it does | Page |
 | :--- | :--- | :--- |
 | **Generate** | Run `moose generate migration --save` to produce a committed migration file from your code changes. | [Generate migrations](/moosestack/migrate/generate) |
-| **Apply** | On deploy, `moose migrate` (CLI) or `moose prod` (Runtime) executes the committed migration against your database. | [Apply migrations](/moosestack/migrate/apply) |
+| **Apply** | On deploy, `moose migrate` (Standalone CLI) or `moose prod` (Moose Server) executes the committed migration against your database. | [Apply migrations](/moosestack/migrate/apply) |
 
 ## How it works
 

--- a/apps/framework-docs-v2/content/moosestack/migrate/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/index.mdx
@@ -1,117 +1,47 @@
 ---
-title: Migrations
-description: Understanding how Moose manages database schema changes through code
+title: Moose Migrate
+description: Manage schema changes across your MooseStack infrastructure with reviewable migration files
 order: 0
 category: migrate
 ---
 
 import { Callout } from "@/components/mdx";
 
-# Migrations
+# Moose Migrate
 
-Migrations synchronize your code-defined database schema with your production infrastructure. As your application evolves, you'll add/remove fields, change data types, and restructure tables. Moose Migrate handles these schema changes safely and reliably.
+Moose Migrate synchronizes your code-defined schema with your production infrastructure. Add a field, change a type, drop a table — Moose generates reviewable migration files that apply the change safely on deploy.
 
-## How Migrations Work
+<Callout type="info" title="Delta-based workflow — opt-in during beta">
+This documentation describes the delta-based migration workflow, enabled with `features.migrate_with_deltas = true` in `moose.config.toml`. The current default is `false`; once beta testing ends, delta migrations will become the default.
+</Callout>
+
+## Two phases
+
+| Phase | What it does | Page |
+| :--- | :--- | :--- |
+| **Generate** | Run `moose generate migration --save` to produce a committed migration file from your code changes. | [Generate migrations](/moosestack/migrate/generate) |
+| **Apply** | On deploy, `moose migrate` (CLI) or `moose prod` (Runtime) executes the committed migration against your database. | [Apply migrations](/moosestack/migrate/apply) |
+
+## How it works
 
 Moose Migrate operates by comparing two states:
 
-1. **Your code** - Tables and streams defined in your application
-2. **Your database** - The actual schema in ClickHouse, Kafka, or Redpanda
+1. **Your code** — tables and streams defined in your application
+2. **Your database** — the live schema in ClickHouse, Kafka, or Redpanda
 
-When these states differ, Moose Migrate generates operations to bring them into alignment. These operations might include:
+When they differ, Moose generates operations (add/drop table, add/rename/retype column, create topic, etc.) and writes them as incremental migration files under `./migrations/`. Each committed file records a diff from the previous migrated state and is applied exactly once in production.
 
-- Adding or dropping tables
-- Adding, removing, or renaming columns
-- Changing data types
-- Creating or modifying streaming topics
+## Lifecycle control
 
-The full list of operations is available in the [Migration Plan Format](/moosestack/migrate/plan-format) documentation.
+For each table and stream, the `LifeCycle` configuration property controls what changes Moose is allowed to make:
 
-## Core Concepts
+| Option | Behavior |
+| :--- | :--- |
+| [`FULLY_MANAGED`](/moosestack/migrate/lifecycle-fully-managed) (default) | Moose modifies resources to match your code, including destructive operations. |
+| [`DELETION_PROTECTED`](/moosestack/migrate/lifecycle-deletion-protected) | Moose modifies resources to match your code but blocks destructive operations. |
+| [`EXTERNALLY_MANAGED`](/moosestack/migrate/lifecycle-externally-managed) | Moose does not modify resources; you manage the schema manually. |
 
-Migrations in Moose revolve around three key decisions:
+## See also
 
-| Concept | What it is | Where to go |
-| :--- | :--- | :--- |
-| [Lifecycle Management](#lifecycle-management) | Controlling *what* changes are allowed (e.g., preventing data deletion). | [Overview](/moosestack/migrate/lifecycle) • [Fully Managed](/moosestack/migrate/lifecycle-fully-managed) • [Deletion Protected](/moosestack/migrate/lifecycle-deletion-protected) • [Externally Managed](/moosestack/migrate/lifecycle-externally-managed) |
-| [Generating Migrations](#generating-migrations) | Deciding *how* changes are generated. | [Overview](/moosestack/migrate/modes) • [Automatic](/moosestack/migrate/automatic) • [Planned](/moosestack/migrate/planned-migrations) |
-| [Applying Changes](#applying-changes-to-production) | The workflow for executing migrations: serverless (`moose migrate`) vs server runtime (`moose prod`). | [Serverless](/moosestack/migrate/apply-planned-migrations-cli) • [Server Runtime](/moosestack/migrate/apply-planned-migrations-service) |
-
-
-### Lifecycle Management
-
-For each table and stream resource defined in your code, you can control *what* changes are allowed (e.g., preventing data deletion, ignoring schema changes, etc.) with the `LifeCycle` configuration property:
-
-<LanguageTabs>
-  <LanguageTabContent value="typescript" label="TypeScript">
-```ts
-import { OlapTable, LifeCycle } from "@514labs/moose-lib";
-
-interface Schema {
-  id: string;
-  name: string;
-  age: number;
-}
-
-const table = new OlapTable<Schema>("table_name", {
-  lifeCycle: LifeCycle.FULLY_MANAGED
-  orderByFields: ["id"]
-});
-```
-
-  </LanguageTabContent>
-  <LanguageTabContent value="python" label="Python">
-```py
-from moose_lib import OlapTable, LifeCycle, OlapConfig
-from pydantic import BaseModel
-
-class Schema(BaseModel):
-  id: str
-  name: str
-  age: int
-
-table = OlapTable[Schema]("table_name", OlapConfig(
-  life_cycle=LifeCycle.FULLY_MANAGED
-  order_by_fields=["id"]
-))
-```
-  </LanguageTabContent>
-</LanguageTabs>
-
-| Option | Behavior | Use When |
-| :--- | :--- | :--- |
-| [`FULLY_MANAGED`](/moosestack/migrate/lifecycle-fully-managed) (default) | Automatically modifies resources to match your code, including destructive operations. | When you're developing new tables that you want your application to manage and evolve over time. |
-| [`DELETION_PROTECTED`](/moosestack/migrate/lifecycle-deletion-protected) | Automatically modifies resources to match your code, but blocks destructive operations (drops, deletions). | When you want to protect critical production tables from accidental data loss. |
-| [`EXTERNALLY_MANAGED`](/moosestack/migrate/lifecycle-externally-managed) | Does not modify resources. You manage the schema manually directly in your database. | When you have existing tables that you want to manage outside of your application, or if you're using a Managed CDC service like [ClickPipes](https://clickhouse.com/cloud/clickpipes) or [PeerDB](https://peerdb.io) to manage your schema. |
-
-<Callout type="info" title="Per-resource configuration">
-You configure lifecycle modes individually on each `OlapTable` and `Stream` object. This allows you to mix fully managed development tables with deletion-protected production tables and externally managed legacy resources in the same application.
-</Callout>
-
-[Compare Lifecycle Management Modes →](/moosestack/migrate/lifecycle)
-
-### Generating Migrations
-
-Moose Migrate provides two complementary ways to generate migrations. Each is designed for use in different stages of the application lifecycle, and it's best practice to use both in your workflow:
-
-| Option | Behavior | Use Case |
-| :--- | :--- | :--- |
-| [Automatic](/moosestack/migrate/automatic) | Updates database instantly on file save. Fast iteration, but can be destructive. | Local development, fast prototyping |
-| [Planned](/moosestack/migrate/planned-migrations) | Generates reviewable plan files. Safe, deterministic, with drift detection. | Production deployment, CI/CD |
-
-
-[Compare Migration Modes →](/moosestack/migrate/modes)
-
-### Applying Changes
-
-You have two options for executing planned migrations against your production database:
-
-| Mode | Behavior | Use Case |
-| :--- | :--- | :--- |
-| [Serverless (`moose migrate`)](/moosestack/migrate/apply-planned-migrations-cli) | You run migrations manually or via CI/CD. | Integrating Moose OLAP into an existing application as a library. |
-| [Server Runtime (`moose prod`)](/moosestack/migrate/apply-planned-migrations-service) | Migrations are automatically run within the Moose Runtime on server startup. | Building a dedicated analytics service with the full Moose Runtime. |
-
-
-## Advanced Topics
-
-- [Failed Migrations](/moosestack/migrate/failed-migrations) - Recover from migration errors
+- [Plan Reference](/moosestack/migrate/plan-format) — operation reference and file-format details
+- [Failed migrations](/moosestack/migrate/failed-migrations) — recovery guidance

--- a/apps/framework-docs-v2/content/moosestack/migrate/planned-migrations.mdx
+++ b/apps/framework-docs-v2/content/moosestack/migrate/planned-migrations.mdx
@@ -16,10 +16,10 @@ import { Callout } from "@/components/mdx";
 Generate a migration plan by comparing your local code against a production environment:
 
 ```bash
-# For Server Runtime (connect to Moose Admin API)
+# Moose Server (connect to the Admin API)
 moose generate migration --url <ADMIN_API_URL> --token <ADMIN_TOKEN> --save
 
-# For Serverless (connect to ClickHouse directly)
+# Standalone CLI (connect to ClickHouse directly)
 moose generate migration --clickhouse-url <CLICKHOUSE_CONNECTION_STRING> --save
 ```
 
@@ -39,11 +39,11 @@ The lifecycle consists of four distinct stages:
     moose generate migration --save ...
     ```
 3.  **Review** — Inspect the generated `migrations/plan.yaml` file and commit it to Git.
-4.  **Application** — Execute the plan during deployment (if using Moose Runtime), manually via the CLI or your own CI/CD pipeline (if using Serverless).
+4.  **Application** — Execute the plan during deployment (if using Moose Server), manually via the CLI or your own CI/CD pipeline (if using the Standalone CLI).
     ```bash
     moose migrate ...
     
-    ## or if using the Moose Runtime
+    ## or if using the Moose Server
     moose prod
     ```
 
@@ -95,7 +95,7 @@ When startup is blocked, the error message lists every destructive operation and
 
 The `moose generate migration` command accepts different arguments depending on your [deployment model for applying changes](/moosestack/migrate#applying-changes).
 
-### via Moose Runtime (`moose prod`)
+### via Moose Server (`moose prod`)
 
 Connect to the **Admin API** of the running service.
 
@@ -109,7 +109,7 @@ moose generate migration --url <ADMIN_API_URL> --token <ADMIN_TOKEN> --save
 | `--token` | The authentication token for the Admin API. |
 | `--save` | Writes the generated plan to the `migrations/` directory. Without this, it performs a dry run. |
 
-### via Serverless (`moose migrate`)
+### via Standalone CLI (`moose migrate`)
 
 Connect directly to the **ClickHouse database**.
 
@@ -150,7 +150,7 @@ Drift occurs when the target database's schema changes between the time you gene
 
 **How it works:**
 1. `moose generate migration` writes the current DB state to `remote_state.json`.
-2. `moose migrate` (serverless) or `moose prod` (server runtime) compares `remote_state.json` with the *current* DB state.
+2. `moose migrate` (Standalone CLI) or `moose prod` (Moose Server) compares `remote_state.json` with the *current* DB state.
 3. If they differ (hash mismatch), the migration **aborts**.
 
 **Resolution:**

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -325,7 +325,7 @@ moose plan [--url <url>] [--token <token>] [--json]
 - `--token`: API token for the remote Moose instance
 - `--json`: Output plan as JSON
 
-**For serverless deployments:**
+**For Standalone CLI deployments:**
 ```bash
 moose plan --clickhouse-url <url>
 ```
@@ -360,8 +360,8 @@ moose generate migration [--url <url> --token <token> | --clickhouse-url <url>] 
 ```
 
 **Connection options** (one required):
-- `--url` + `--token`: Connect to a running Moose server
-- `--clickhouse-url`: Connect directly to ClickHouse (for serverless). Also requires `--redis-url` when `state_config.storage = "redis"`.
+- `--url` + `--token`: Connect to a running Moose Server
+- `--clickhouse-url`: Connect directly to ClickHouse (for Standalone CLI). Also requires `--redis-url` when `state_config.storage = "redis"`.
 
 All connection flags accept env var fallbacks: `MOOSE_CLICKHOUSE_CONFIG__URL` for `--clickhouse-url` and `MOOSE_REDIS_CONFIG__URL` for `--redis-url`.
 

--- a/apps/framework-docs-v2/content/moosestack/olap/planned-migrations.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/planned-migrations.mdx
@@ -57,12 +57,12 @@ olap = true
 
 Once done editing your code in your feature branch, you can generate a plan that diffs your local code against your live remote database:
 
-**For Moose server deployments:**
+**For Moose Server deployments:**
 ```bash filename="Terminal" copy
 moose generate migration --url https://<remote-env> --token <api-token> --save
 ```
 
-**For serverless deployments:**
+**For Standalone CLI deployments:**
 ```bash filename="Terminal" copy
 moose generate migration --clickhouse-url clickhouse://user:pass@host:port/db --save
 ```
@@ -293,7 +293,7 @@ You can also override the the default behavior by using the `RawSql` operation t
 
 ### Moose Server Deployments
 
-For Moose server deployments (with `moose prod` running), migrations are applied automatically on startup. Generate plans using:
+For Moose Server deployments (with `moose prod` running), migrations are applied automatically on startup. Generate plans using:
 
 ```bash filename="Terminal" copy
 moose generate migration --url https://<remote-env> --token <api-token> --save
@@ -301,9 +301,9 @@ moose generate migration --url https://<remote-env> --token <api-token> --save
 
 When you deploy, Moose validates the plan and executes it automatically.
 
-### Serverless Deployments
+### Standalone CLI Deployments
 
-For serverless deployments (no Moose server), you manage migrations manually using the ClickHouse connection directly:
+For Standalone CLI deployments (no Moose Server), you manage migrations manually using the ClickHouse connection directly:
 
 ```toml filename="moose.config.toml" copy
 [state_config]

--- a/apps/framework-docs-v2/content/moosestack/server/index.mdx
+++ b/apps/framework-docs-v2/content/moosestack/server/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: The Moose Runtime
+title: The Moose Server
 description: Understanding how MooseStack runs locally and in production
 languages: ["typescript", "python"]
 order: 3
@@ -7,9 +7,9 @@ order: 3
 
 import { LanguageTabs, LanguageTabContent, Callout, FileTree, CompareBulletPointsCard } from "@/components/mdx";
 
-# The Moose Runtime
+# The Moose Server
 
-The Moose Runtime is the execution engine for your MooseStack application. It connects your code to your infrastructure by:
+The Moose Server is the long-lived process that runs your MooseStack application. It connects your code to your infrastructure by:
 *   **Managing Data Schemas**: It automatically applies changes to ClickHouse and Redpanda based on your code.
 *   **Running Your Application**: It provides the server that runs your APIs, streaming consumers, data synchronization (e.g. Kafka to ClickHouse) workflows, and other server-side processes defined in your code.
 
@@ -43,7 +43,7 @@ Moose runs in two ways: `moose dev` and `moose prod`.
     bullets: [
       {
         title: "Bring Your Own Infrastructure",
-        description: "You bring your own infrastructure. Moose Runtime won't start databases for you in production. It expects services to be running and connects via environment variables."
+        description: "You bring your own infrastructure. Moose Server won't start databases for you in production. It expects services to be running and connects via environment variables."
       },
       {
         title: "Single Migration",
@@ -58,16 +58,16 @@ Moose runs in two ways: `moose dev` and `moose prod`.
 />
 
 <Callout type="info" title="Local Prototyping" compact>
-Even if you are not using the Moose Runtime in production, it is a useful tool for quickly prototyping OLAP models locally. You do not need to have a production environment set up to use the local development server.
+Even if you are not using the Moose Server in production, it is a useful tool for quickly prototyping OLAP models locally. You do not need to have a production environment set up to use the local development server.
 </Callout>
 
 ## The Infrastructure Map
 
-The core of the Moose Runtime is the infrastructure map. This is a representation of your infrastructure as it exists in your code. The runtime uses this map to determine exactly what needs to be provisioned, migrated, or destroyed to make your live infrastructure match your code.
+The core of the Moose Server is the infrastructure map. This is a representation of your infrastructure as it exists in your code. The server uses this map to determine exactly what needs to be provisioned, migrated, or destroyed to make your live infrastructure match your code.
 
 ### Finding Dependencies
 
-Moose Runtime looks at your **Root Entrypoint** (`index.ts` for TypeScript or `main.py` for Python) to figure out what resources to include in the infrastructure map. For MooseStack to manage a resource (like a Table, Stream, or API), **it must be declared in or reachable from your root file**.
+Moose Server looks at your **Root Entrypoint** (`index.ts` for TypeScript or `main.py` for Python) to figure out what resources to include in the infrastructure map. For MooseStack to manage a resource (like a Table, Stream, or API), **it must be declared in or reachable from your root file**.
 
 This "strict declaration" rule ensures that your running infrastructure always matches the active code path of your application, preventing "zombie" tables or endpoints from lingering in your environment.
 

--- a/apps/framework-docs-v2/next.config.js
+++ b/apps/framework-docs-v2/next.config.js
@@ -38,6 +38,11 @@ const nextConfig = {
         destination: "/moosestack/workflows/trigger-workflow",
         permanent: true,
       },
+      {
+        source: "/moosestack/runtime",
+        destination: "/moosestack/server",
+        permanent: true,
+      },
     ];
   },
   async rewrites() {

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -561,6 +561,20 @@ const moosestackNavigationConfig: NavigationConfig = [
         languages: ["typescript", "python"],
       },
       { type: "separator" },
+      { type: "label", title: "Delta migrations (beta)" },
+      {
+        type: "page",
+        slug: "moosestack/migrate/generate",
+        title: "Generate migrations",
+        languages: ["typescript", "python"],
+      },
+      {
+        type: "page",
+        slug: "moosestack/migrate/apply",
+        title: "Apply migrations",
+        languages: ["typescript", "python"],
+      },
+      { type: "separator" },
       { type: "label", title: "Lifecycle Management" },
       {
         type: "page",

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -521,46 +521,10 @@ const moosestackNavigationConfig: NavigationConfig = [
     ],
   },
   {
-    type: "page",
-    slug: "moosestack/migrate",
+    type: "section",
     title: "Moose Migrate",
     icon: IconGitMerge,
-    languages: ["typescript", "python"],
-    children: [
-      { type: "label", title: "Migration Modes" },
-      {
-        type: "page",
-        slug: "moosestack/migrate/automatic",
-        title: "Automatic Migrations",
-        languages: ["typescript", "python"],
-      },
-      {
-        type: "page",
-        slug: "moosestack/migrate/planned-migrations",
-        title: "Planned Migrations",
-        languages: ["typescript", "python"],
-      },
-      {
-        type: "page",
-        slug: "moosestack/migrate/plan-format",
-        title: "Plan Reference",
-        languages: ["typescript", "python"],
-      },
-      { type: "separator" },
-      { type: "label", title: "Executing Migrations" },
-      {
-        type: "page",
-        slug: "moosestack/migrate/apply-planned-migrations-cli",
-        title: "moose migrate (CLI)",
-        languages: ["typescript", "python"],
-      },
-      {
-        type: "page",
-        slug: "moosestack/migrate/apply-planned-migrations-service",
-        title: "moose prod (Runtime)",
-        languages: ["typescript", "python"],
-      },
-      { type: "separator" },
+    items: [
       { type: "label", title: "Delta migrations (beta)" },
       {
         type: "page",
@@ -572,6 +536,14 @@ const moosestackNavigationConfig: NavigationConfig = [
         type: "page",
         slug: "moosestack/migrate/apply",
         title: "Apply migrations",
+        languages: ["typescript", "python"],
+      },
+      { type: "separator" },
+      { type: "label", title: "Reference" },
+      {
+        type: "page",
+        slug: "moosestack/migrate/plan-format",
+        title: "Plan Reference",
         languages: ["typescript", "python"],
       },
       { type: "separator" },

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -521,10 +521,12 @@ const moosestackNavigationConfig: NavigationConfig = [
     ],
   },
   {
-    type: "section",
+    type: "page",
+    slug: "moosestack/migrate",
     title: "Moose Migrate",
     icon: IconGitMerge,
-    items: [
+    languages: ["typescript", "python"],
+    children: [
       { type: "label", title: "Delta migrations (beta)" },
       {
         type: "page",

--- a/apps/framework-docs-v2/src/config/navigation.ts
+++ b/apps/framework-docs-v2/src/config/navigation.ts
@@ -191,8 +191,8 @@ const moosestackNavigationConfig: NavigationConfig = [
   { type: "label", title: "Fundamentals" },
   {
     type: "page",
-    slug: "moosestack/runtime",
-    title: "Moose Runtime",
+    slug: "moosestack/server",
+    title: "Moose Server",
     icon: IconRoute,
     languages: ["typescript", "python"],
   },


### PR DESCRIPTION
## Summary

Part 2 of 4 splitting #4030. Stacked on top of \`split-1-trigger-api\`.

Collapse the sprawling migrate/* + olap/{apply,planned}-migrations surface into two focused pages (\`migrate/apply\`, \`migrate/generate\`) and promote schema-versioning to a top-level page.

- **Deleted**: \`migrate/{automatic,migration-types,modes,planned-migrations}.mdx\`, \`olap/{apply-migrations,planned-migrations}.mdx\`
- **Moved**: \`olap/schema-versioning.mdx\` → \`schema-versioning.mdx\` (top-level)
- **New**: \`migrate/apply.mdx\`, \`migrate/generate.mdx\`
- **Updated**: \`migrate/{index,apply-planned-migrations-cli,apply-planned-migrations-service,failed-migrations,plan-format}.mdx\`, OLAP cross-refs (\`olap/{index,external-tables,model-materialized-view,schema-change,ttl}.mdx\`), two data-management guides, release notes
- **Nav**: schema-versioning pulled to top-level; new generate/apply entries; removed deprecated migrate entries
- **Redirects**: 7 entries for deleted / moved pages

## Stack

- PR 1/4: \`split-1-trigger-api\`
- **PR 2/4 (this)**
- PR 3/4: \`split-3-model-table\`
- PR 4/4: \`split-4-read-insert\`

## Test plan

- [ ] Vercel preview loads; all 7 redirects land on their new targets
- [ ] \`/moosestack/schema-versioning\` renders at its new location
- [ ] No broken internal links from migrated pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes plus a redirect and nav updates; primary risk is broken internal links/redirect coverage if any referenced slugs were missed.
> 
> **Overview**
> **Docs restructure for migrations:** adds new overview pages `moosestack/migrate/generate` and `moosestack/migrate/apply`, and rewrites `moosestack/migrate/index` to a simpler “generate → apply” flow with delta-migrations beta callouts.
> 
> **Terminology + cross-link updates:** replaces “Moose Runtime/serverless” wording with **“Moose Server/Standalone CLI”** across multiple docs and updates related links.
> 
> **Site plumbing:** updates docs navigation to feature the new migrate pages and removes older entries, adds a permanent redirect from `/moosestack/runtime` → `/moosestack/server`, and extends `.gitignore` to exclude `.claude/worktrees/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3ed88a9d7f85a2b3614e652d5a8429fb26bb9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->