### PR TITLE
custom migration sql generation

### DIFF
--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -109,7 +109,8 @@ fn generate_raw_sql_migration(
     project: &crate::project::Project,
     description: Option<&str>,
     sql_arg: &str,
-) -> Result<crate::cli::routines::RoutineSuccess, crate::cli::routines::RoutineFailure> {
+) -> std::result::Result<crate::cli::routines::RoutineSuccess, crate::cli::routines::RoutineFailure>
+{
     use crate::cli::display::{Message, MessageType};
     use crate::cli::routines::{RoutineFailure, RoutineSuccess};
     use crate::framework::core::infra_delta::InfraDelta;
@@ -1024,8 +1025,14 @@ pub async fn top_command_handler(
                 // ./migrations/. `Some("")` means the flag was passed without
                 // a value → scaffold a stub with a TODO placeholder.
                 if let Some(sql_arg) = raw_sql {
-                    let outcome =
-                        generate_raw_sql_migration(&project, description.as_deref(), sql_arg);
+                    let outcome = if project.features.migrate_with_deltas {
+                        generate_raw_sql_migration(&project, description.as_deref(), sql_arg)
+                    } else {
+                        Err(RoutineFailure::error(Message::new(
+                            "Raw SQL".to_string(),
+                            "--raw-sql requires features.migrate_with_deltas = true in moose.config.toml".to_string(),
+                        )))
+                    };
                     wait_for_usage_capture(capture_handle).await;
                     return outcome;
                 }

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -95,6 +95,131 @@ fn env_bool(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Generate a migration file containing a single `RawSql` delta.
+///
+/// Computes `parent_state_hash` by folding every existing delta file in the
+/// project's `migrations/` directory — purely local, no Redis/ClickHouse
+/// connection required.
+///
+/// `sql_arg` comes from the `--raw-sql` flag: a non-empty string is taken
+/// verbatim; an empty string (flag passed without a value) produces a stub
+/// seeded with a `-- TODO` placeholder so the user can fill the SQL in
+/// their editor before deploying.
+fn generate_raw_sql_migration(
+    project: &crate::project::Project,
+    description: Option<&str>,
+    sql_arg: &str,
+) -> Result<crate::cli::routines::RoutineSuccess, crate::cli::routines::RoutineFailure> {
+    use crate::cli::display::{Message, MessageType};
+    use crate::cli::routines::{RoutineFailure, RoutineSuccess};
+    use crate::framework::core::infra_delta::InfraDelta;
+    use crate::framework::core::migration_file::{MigrationFile, MigrationHistory};
+
+    let trimmed_description = description.map(|s| s.trim()).unwrap_or("");
+    if trimmed_description.is_empty() {
+        return Err(RoutineFailure::error(Message::new(
+            "Raw SQL".to_string(),
+            "--description is required when using --raw-sql".to_string(),
+        )));
+    }
+
+    let sql = if sql_arg.is_empty() {
+        format!(
+            "-- TODO: {}\n-- Fill in your SQL here, then commit and deploy.\n",
+            trimmed_description
+        )
+    } else {
+        sql_arg.to_string()
+    };
+
+    let migrations_dir = project.project_location.join("migrations");
+    let default_database = &project.clickhouse_config.db_name;
+
+    // Fold existing delta files to compute the projected state the new file
+    // will be applied against. Empty dir / missing dir is fine — that just
+    // means parent_state_hash = empty-map hash for the very first migration.
+    let parent_state_hash = if migrations_dir.exists() {
+        let history = MigrationHistory::load_from_dir(&migrations_dir).map_err(|e| {
+            RoutineFailure::new(
+                Message::new(
+                    "Raw SQL".to_string(),
+                    format!(
+                        "Failed to load existing migration files from {}",
+                        migrations_dir.display()
+                    ),
+                ),
+                e,
+            )
+        })?;
+        history
+            .reconstruct_olap_map(default_database)
+            .map_err(|e| {
+                RoutineFailure::new(
+                    Message::new(
+                        "Raw SQL".to_string(),
+                        "Failed to fold existing migrations to compute parent_state_hash"
+                            .to_string(),
+                    ),
+                    e,
+                )
+            })?
+    } else {
+        std::fs::create_dir_all(&migrations_dir).map_err(|e| {
+            RoutineFailure::new(
+                Message::new(
+                    "Raw SQL".to_string(),
+                    format!("Failed to create {}", migrations_dir.display()),
+                ),
+                e,
+            )
+        })?;
+        crate::framework::core::infrastructure_map::InfrastructureMap::empty_from_project(project)
+    }
+    .olap_hash();
+
+    let delta = InfraDelta::RawSql {
+        description: trimmed_description.to_string(),
+        sql,
+    };
+    let file = MigrationFile::new(
+        trimmed_description.to_string(),
+        parent_state_hash,
+        vec![delta],
+    );
+    let yaml = file.to_yaml().map_err(|e| {
+        RoutineFailure::new(
+            Message::new(
+                "Raw SQL".to_string(),
+                "Failed to serialize migration yaml".to_string(),
+            ),
+            e,
+        )
+    })?;
+    let out_path = migrations_dir.join(format!("{}.yaml", file.id));
+    std::fs::write(&out_path, yaml).map_err(|e| {
+        RoutineFailure::new(
+            Message::new(
+                "Raw SQL".to_string(),
+                format!("Failed to write {}", out_path.display()),
+            ),
+            e,
+        )
+    })?;
+
+    crate::cli::display::show_message_wrapper(
+        MessageType::Success,
+        Message::new(
+            "Migration".to_string(),
+            format!("Written to {}", out_path.display()),
+        ),
+    );
+
+    Ok(RoutineSuccess::success(Message::new(
+        "Migration".to_string(),
+        "raw SQL migration generated".to_string(),
+    )))
+}
+
 /// Generic prompt function with hints, default values, and better formatting
 pub fn prompt_user(
     prompt_text: &str,
@@ -877,6 +1002,8 @@ pub async fn top_command_handler(
                 yes_destructive,
                 yes_rename,
                 no_auto_backfill_sql,
+                raw_sql,
+                description,
             }) => {
                 info!("Running generate migration command");
 
@@ -891,6 +1018,17 @@ pub async fn top_command_handler(
                 );
 
                 check_project_name(&project.name())?;
+
+                // Raw-SQL branch — activated by --raw-sql. Skips the remote
+                // diff entirely; parent_state_hash is computed locally from
+                // ./migrations/. `Some("")` means the flag was passed without
+                // a value → scaffold a stub with a TODO placeholder.
+                if let Some(sql_arg) = raw_sql {
+                    let outcome =
+                        generate_raw_sql_migration(&project, description.as_deref(), sql_arg);
+                    wait_for_usage_capture(capture_handle).await;
+                    return outcome;
+                }
 
                 // Determine which remote source to use and generate migration
                 let result = if let Some(ref moose_url) = url {

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -416,12 +416,17 @@ pub enum GenerateCommand {
         //   --raw-sql             → stub file with a TODO placeholder to edit
         /// Raw SQL escape hatch. Pass SQL inline, or use the flag alone to
         /// scaffold a stub file you can fill in later.
-        #[arg(long, num_args = 0..=1, default_missing_value = "")]
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_missing_value = "",
+            conflicts_with_all = ["url", "clickhouse_url", "redis_url"],
+        )]
         raw_sql: Option<String>,
 
         /// Human description. Required when --raw-sql is used; ignored
         /// otherwise (typed migrations use auto-generated descriptions).
-        #[arg(long, short = 'd')]
+        #[arg(long, short = 'd', requires = "raw_sql")]
         description: Option<String>,
     },
 }

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -404,6 +404,25 @@ pub enum GenerateCommand {
         /// Disable automatic backfill SQL generation
         #[arg(long)]
         no_auto_backfill_sql: bool,
+
+        // ── Raw SQL escape hatch ─────────────────────────────────────────
+        // Switches this command into raw-SQL mode: no remote connection is
+        // used, `parent_state_hash` is computed locally by folding existing
+        // delta files in `./migrations/`, and a single `RawSql` delta is
+        // written. Use for backfills, OPTIMIZE, ALTER SETTINGS, or anything
+        // the typed deltas can't express.
+        //
+        //   --raw-sql "SQL ..."   → inline SQL
+        //   --raw-sql             → stub file with a TODO placeholder to edit
+        /// Raw SQL escape hatch. Pass SQL inline, or use the flag alone to
+        /// scaffold a stub file you can fill in later.
+        #[arg(long, num_args = 0..=1, default_missing_value = "")]
+        raw_sql: Option<String>,
+
+        /// Human description. Required when --raw-sql is used; ignored
+        /// otherwise (typed migrations use auto-generated descriptions).
+        #[arg(long, short = 'd')]
+        description: Option<String>,
     },
 }
 

--- a/apps/framework-cli/src/framework/core/infra_delta.rs
+++ b/apps/framework-cli/src/framework/core/infra_delta.rs
@@ -217,6 +217,19 @@ pub enum InfraDelta {
         select_statement: String,
         should_truncate: bool,
     },
+
+    /// Arbitrary SQL escape hatch for things the typed deltas can't express
+    /// (data backfills via UPDATE/INSERT, OPTIMIZE, ALTER SETTINGS, cluster-
+    /// specific DDL, one-off cleanups). Fold-invisible — does not affect the
+    /// `parent_state_hash` of later migrations. Use typed deltas for any
+    /// schema change the system understands; reach for `RawSql` only when
+    /// none apply.
+    RawSql {
+        /// Short human label shown in apply logs and drift forensics.
+        description: String,
+        /// One or more SQL statements executed in order.
+        sql: String,
+    },
 }
 
 // ── Error types ─────────────────────────────────────────────────────
@@ -664,7 +677,9 @@ impl InfraDelta {
             }
 
             // ── Execution-only (no-op) ──────────────────────────
-            InfraDelta::BackfillTable { .. } | InfraDelta::PopulateMaterializedView { .. } => {
+            InfraDelta::BackfillTable { .. }
+            | InfraDelta::PopulateMaterializedView { .. }
+            | InfraDelta::RawSql { .. } => {
                 // These only matter at DDL execution time, not during map reconstruction.
             }
         }
@@ -772,6 +787,13 @@ impl InfraDelta {
             } => format!("Backfill '{}' from '{}'", target_table, source_table),
             InfraDelta::PopulateMaterializedView { view_name, .. } => {
                 format!("Populate materialized view '{}'", view_name)
+            }
+            InfraDelta::RawSql { description, .. } => {
+                if description.is_empty() {
+                    "Raw SQL".to_string()
+                } else {
+                    format!("Raw SQL: {}", description)
+                }
             }
         }
     }
@@ -1228,6 +1250,31 @@ impl InfraDelta {
                     target_database: target_database.clone(),
                     select_statement: select_statement.clone(),
                     should_truncate: *should_truncate,
+                    dependency_info: empty_deps,
+                }]
+            }
+            InfraDelta::RawSql { description, sql } => {
+                // Lower via the SqlResource/RunSetupSql machinery so RawSql
+                // reuses the existing atomic executor; the description is
+                // surfaced through `SqlResource::name` which is what the
+                // executor logs.
+                let name = if description.is_empty() {
+                    "raw_sql".to_string()
+                } else {
+                    format!("raw_sql: {}", description)
+                };
+                vec![AtomicOlapOperation::RunSetupSql {
+                    resource: SqlResource {
+                        name,
+                        database: None,
+                        source_file: None,
+                        source_line: None,
+                        source_column: None,
+                        setup: vec![sql.clone()],
+                        teardown: vec![],
+                        pulls_data_from: vec![],
+                        pushes_data_to: vec![],
+                    },
                     dependency_info: empty_deps,
                 }]
             }
@@ -2244,6 +2291,64 @@ mod tests {
         };
         delta.apply(&mut map, TEST_DB).unwrap();
         assert!(map.materialized_views.is_empty());
+    }
+
+    #[test]
+    fn test_apply_raw_sql_is_noop() {
+        let mut map = empty_map();
+        let pre_hash = map.olap_hash();
+        let delta = InfraDelta::RawSql {
+            description: "cleanup legacy rows".to_string(),
+            sql: "ALTER TABLE foo DELETE WHERE legacy = 1".to_string(),
+        };
+        delta.apply(&mut map, TEST_DB).unwrap();
+        assert!(map.tables.is_empty());
+        // Fold invariance: RawSql must not shift the parent_state_hash chain.
+        assert_eq!(pre_hash, map.olap_hash());
+    }
+
+    #[test]
+    fn test_raw_sql_lowers_to_run_setup_sql() {
+        let map = empty_map();
+        let delta = InfraDelta::RawSql {
+            description: "backfill created_at".to_string(),
+            sql: "ALTER TABLE foo UPDATE created_at = now() WHERE created_at IS NULL".to_string(),
+        };
+        let ops = delta.to_atomic_operations(&map, TEST_DB);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            AtomicOlapOperation::RunSetupSql { resource, .. } => {
+                assert!(
+                    resource.name.contains("backfill created_at"),
+                    "description should be surfaced via resource.name, got {:?}",
+                    resource.name
+                );
+                assert_eq!(resource.setup.len(), 1);
+                assert!(resource.setup[0].contains("ALTER TABLE foo UPDATE"));
+                assert!(resource.teardown.is_empty());
+            }
+            other => panic!("expected RunSetupSql, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_raw_sql_round_trips_through_yaml() {
+        let delta = InfraDelta::RawSql {
+            description: "one-off optimize".to_string(),
+            sql: "OPTIMIZE TABLE events FINAL".to_string(),
+        };
+        let yaml = serde_yaml::to_string(&delta).unwrap();
+        // Tagged enum serialization should emit `type: RawSql` so hand-written
+        // yaml matches what serde writes.
+        assert!(yaml.contains("type: RawSql"), "yaml missing tag: {}", yaml);
+        let parsed: InfraDelta = serde_yaml::from_str(&yaml).unwrap();
+        match parsed {
+            InfraDelta::RawSql { description, sql } => {
+                assert_eq!(description, "one-off optimize");
+                assert_eq!(sql, "OPTIMIZE TABLE events FINAL");
+            }
+            other => panic!("expected RawSql, got {:?}", other),
+        }
     }
 
     // ── Fold: full sequence from empty map ──────────────────────

--- a/apps/framework-cli/src/framework/core/infra_delta.rs
+++ b/apps/framework-cli/src/framework/core/infra_delta.rs
@@ -1263,6 +1263,23 @@ impl InfraDelta {
                 } else {
                     format!("raw_sql: {}", description)
                 };
+                // ClickHouse's HTTP query API accepts a single statement per
+                // request, but the `setup` Vec is iterated and each entry is
+                // passed to `run_query` separately. Split on `;` so users can
+                // bundle multiple statements in one RawSql delta. Naive split
+                // — a `;` inside a string literal would split incorrectly,
+                // which is acceptable for an escape hatch.
+                let statements: Vec<String> = sql
+                    .split(';')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .collect();
+                let setup = if statements.is_empty() {
+                    vec![sql.clone()]
+                } else {
+                    statements
+                };
                 vec![AtomicOlapOperation::RunSetupSql {
                     resource: SqlResource {
                         name,
@@ -1270,7 +1287,7 @@ impl InfraDelta {
                         source_file: None,
                         source_line: None,
                         source_column: None,
-                        setup: vec![sql.clone()],
+                        setup,
                         teardown: vec![],
                         pulls_data_from: vec![],
                         pushes_data_to: vec![],
@@ -2326,6 +2343,28 @@ mod tests {
                 assert_eq!(resource.setup.len(), 1);
                 assert!(resource.setup[0].contains("ALTER TABLE foo UPDATE"));
                 assert!(resource.teardown.is_empty());
+            }
+            other => panic!("expected RunSetupSql, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_raw_sql_lowering_splits_multiple_statements() {
+        let map = empty_map();
+        let delta = InfraDelta::RawSql {
+            description: "two-step backfill".to_string(),
+            sql: "ALTER TABLE foo UPDATE x = 1 WHERE x IS NULL;\nOPTIMIZE TABLE foo FINAL;"
+                .to_string(),
+        };
+        let ops = delta.to_atomic_operations(&map, TEST_DB);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            AtomicOlapOperation::RunSetupSql { resource, .. } => {
+                assert_eq!(resource.setup.len(), 2);
+                assert!(resource.setup[0].contains("ALTER TABLE foo UPDATE"));
+                assert!(resource.setup[1].contains("OPTIMIZE TABLE foo FINAL"));
+                // Trailing/empty segments must be filtered out.
+                assert!(resource.setup.iter().all(|s| !s.trim().is_empty()));
             }
             other => panic!("expected RunSetupSql, got {:?}", other),
         }

--- a/apps/framework-cli/src/framework/core/migration_file.rs
+++ b/apps/framework-cli/src/framework/core/migration_file.rs
@@ -237,9 +237,18 @@ impl MigrationFile {
     pub fn new(description: String, parent_state_hash: String, deltas: Vec<InfraDelta>) -> Self {
         let now = Utc::now();
         let timestamp = now.format("%Y%m%d_%H%M%S_%3f");
-        let slug = description
+        // Sanitize description into a filesystem-safe slug: lowercase ASCII
+        // alphanumerics survive verbatim; everything else (whitespace, path
+        // separators, punctuation, non-ASCII) collapses to a single `_`. This
+        // prevents user-provided descriptions like `backfill users/orders`
+        // from producing nested `id` paths that fail on file write.
+        let slug: String = description
             .to_lowercase()
-            .split_whitespace()
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect::<String>()
+            .split('_')
+            .filter(|s| !s.is_empty())
             .collect::<Vec<_>>()
             .join("_");
         let id = format!("{}_{}", timestamp, slug);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `--raw-sql` path that writes and later executes arbitrary ClickHouse SQL as part of migrations; mistakes in user-provided SQL or statement splitting could cause production-impacting data/DDL changes. Other changes are localized (migration filename sanitization) and low risk.
> 
> **Overview**
> Adds a **raw SQL escape hatch** to `moose generate migration` via `--raw-sql` (with required `--description`), generating a local delta migration YAML without contacting Moose/ClickHouse/Redis and computing `parent_state_hash` by folding existing `./migrations`.
> 
> Introduces a new execution-only `InfraDelta::RawSql` that is *fold-invisible* (does not affect `parent_state_hash`), includes display summaries, and lowers to `AtomicOlapOperation::RunSetupSql` (splitting multiple statements on `;`); includes new unit tests for no-op folding, lowering behavior, and YAML round-tripping.
> 
> Hardens migration file IDs by sanitizing the description into a filesystem-safe slug to prevent invalid/nested paths when writing migration YAML files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626e4348f222f7a59583b512cdc49f16f137c843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->