### PR TITLE
fix(migrate): clean up hash-mismatch error output

### DIFF
--- a/apps/framework-cli/src/cli/routines/migrate.rs
+++ b/apps/framework-cli/src/cli/routines/migrate.rs
@@ -4,7 +4,7 @@ use crate::cli::display::Message;
 use crate::cli::routines::RoutineFailure;
 use crate::framework::core::infrastructure::table::Table;
 use crate::framework::core::infrastructure_map::InfrastructureMap;
-use crate::framework::core::migration_file::MigrationFile;
+use crate::framework::core::migration_file::{MigrationFile, MigrationHistoryError};
 use crate::framework::core::migration_plan::MigrationPlan;
 use crate::framework::core::plan::{reconcile_with_reality, ReconciliationFilter};
 use crate::framework::core::state_storage::{StateStorage, StateStorageBuilder};
@@ -1062,6 +1062,10 @@ pub async fn execute_migration_deltas(
             println!("  • This migration is stale\n");
             println!("To resolve, regenerate the migration against the current database state:");
             println!("  moose generate migration --clickhouse-url <url>\n");
+            // Preserve the raw error in the log file; the user-facing output is
+            // already above, and the outer `execute_migration` suppresses the
+            // duplicate anyhow chain so the terminal stays clean.
+            tracing::error!("Migration hash mismatch: {}", e);
             return Err(e.into());
         }
 
@@ -1208,13 +1212,23 @@ pub async fn execute_migration(
             )
             .await
             .map_err(|e| {
-                RoutineFailure::new(
-                    Message::new(
-                        "\nMigration".to_string(),
-                        "Failed to execute migration deltas".to_string(),
-                    ),
-                    e,
-                )
+                // `HashMismatch` already emitted a detailed, user-friendly explanation
+                // (including drift forensics and recovery steps) to stdout before
+                // bubbling up. Return a silent failure so we don't tack a redundant
+                // "Migration: Failed to execute migration deltas …" tail onto it.
+                if e.downcast_ref::<MigrationHistoryError>()
+                    .is_some_and(|err| matches!(err, MigrationHistoryError::HashMismatch { .. }))
+                {
+                    RoutineFailure::error(Message::new(String::new(), String::new()))
+                } else {
+                    RoutineFailure::new(
+                        Message::new(
+                            "\nMigration".to_string(),
+                            "Failed to execute migration deltas".to_string(),
+                        ),
+                        e,
+                    )
+                }
             })?;
         } else {
             // Legacy plan.yaml migration path

--- a/apps/framework-cli/src/main.rs
+++ b/apps/framework-cli/src/main.rs
@@ -137,7 +137,11 @@ fn main() -> ExitCode {
             ExitCode::from(0)
         }
         Err(e) => {
-            show_message!(e.message_type, e.message);
+            // Skip displaying empty messages (used when the routine has already
+            // printed its own user-facing failure output).
+            if !e.message.action.is_empty() || !e.message.details.is_empty() {
+                show_message!(e.message_type, e.message);
+            }
             if let Some(err) = e.error {
                 eprintln!("{err:?}");
             }


### PR DESCRIPTION
# Human

all this does is remove some scary looking unhelpful text from an existing error message when migrations fail to apply.

## Summary

Fixes [ENG-2777](https://linear.app/fiveonefour/issue/ENG-2777) — when `moose migrate` aborts because a delta migration's `parent_state_hash` doesn't match the live database state, the technical tail undercut the polished message the user had just read.

**Before**
```
❌ Migration '20260421_100000_first_migration' cannot be applied: database state has diverged from
what this migration was generated against.

This could happen if:
  • Another developer applied migrations to this database
  • Manual DDL was run against the database
  • This migration is stale

To resolve, regenerate the migration against the current database state:
  moose generate migration --clickhouse-url <url>

     Migration  Failed to execute migration deltas
parent state hash mismatch in migration '20260421_100000_first_migration': expected '0000000000000000000000000000000000000000000000000000000000000000', got '2cef55d3abf87fd8ab3e438898a908d7af537773c06e46ee692b6bd622e44901'
```

**After**
```
❌ Migration '20260421_100000_first_migration' cannot be applied: database state has diverged from
what this migration was generated against.

This could happen if:
  • Another developer applied migrations to this database
  • Manual DDL was run against the database
  • This migration is stale

To resolve, regenerate the migration against the current database state:
  moose generate migration --clickhouse-url <url>
```

Both exit with code `1`. The raw error is still captured via `tracing::error!` so it lands in `~/.moose/*-cli.log` for debugging.

## Changes

- `apps/framework-cli/src/cli/routines/migrate.rs`: In `execute_migration`, downcast the delta-path error and return a silent `RoutineFailure` specifically for `HashMismatch` (other errors keep the default `"Failed to execute migration deltas"` wrap). Log the raw error to tracing before bubbling up from `execute_migration_deltas`.
- `apps/framework-cli/src/main.rs`: Mirror the Ok-branch's empty-message guard on the Err branch so silent failures don't render a blank header.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` passes (15 `migration_file` tests, 40 `migrate` bin tests)
- [x] Manually verified before/after UX by running `moose-cli migrate` against a mismatching `parent_state_hash` with a real ClickHouse + Redis (see screenshots/outputs above)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only change to CLI error presentation; migration execution/validation behavior is unchanged, but error-wrapping tweaks could accidentally hide non-hash-mismatch failures if misclassified.
> 
> **Overview**
> Improves `moose migrate` output when a delta migration fails due to `MigrationHistoryError::HashMismatch` by **avoiding the redundant wrapped “Failed to execute migration deltas” footer**.
> 
> The hash-mismatch path now logs the raw error via `tracing::error!` (for CLI logs) while returning a *silent* `RoutineFailure`, and `main.rs` skips rendering empty error messages so the terminal stays clean while still exiting with code `1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4cb4c84824d683ef43b71fe3212f89fe607d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->