### PR TITLE
fix: improve moose ls output for agent parsing

### DIFF
--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -196,7 +196,8 @@ pub enum Commands {
     Ls {
         /// Filter by infrastructure type
         /// (one of: tables, streams, ingestion, consumption, sql_resource,
-        /// workflows, web_apps, dictionaries). Omit to list every type.
+        /// stream_transformations, workflows, web_apps, dictionaries). Omit
+        /// to list every type.
         #[arg(long)]
         _type: Option<String>,
 

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -182,9 +182,21 @@ pub enum Commands {
     },
     /// View Moose processes
     Ps {},
-    /// View Moose primitives & infrastructure
+    /// List the project's Moose resources with queryable names and hittable URLs.
+    ///
+    /// Renders a table per resource type:
+    ///   - tables: database-qualified name + schema fields (pastable into `moose query`)
+    ///   - streams: topic id, schema fields, destination table
+    ///   - ingestion_apis: name, HTTP method, full URL, destination topic
+    ///   - consumption_apis: name, HTTP method, full URL, query params
+    ///   - sql_resources, dictionaries, workflows, stream_transformations, web_apps
+    ///
+    /// URLs are built from the dev server's host/port in `moose.config.toml`;
+    /// table names are the SQL-queryable form (database.name or bare name).
     Ls {
         /// Filter by infrastructure type
+        /// (one of: tables, streams, ingestion, consumption, sql_resource,
+        /// workflows, web_apps, dictionaries). Omit to list every type.
         #[arg(long)]
         _type: Option<String>,
 

--- a/apps/framework-cli/src/cli/routines/ls.rs
+++ b/apps/framework-cli/src/cli/routines/ls.rs
@@ -320,9 +320,12 @@ impl WebAppInfo {
         } else {
             format!("/{}", value.mount_path)
         };
+        // Trim any trailing slash from `base_url` so we never emit a
+        // doubled slash when `LocalWebserverConfig::url()` already includes
+        // a path prefix — same normalization as `endpoint_url` above.
         Self {
             name: value.name,
-            url: format!("{}{}", base_url, mount),
+            url: format!("{}{}", base_url.trim_end_matches('/'), mount),
             mount_path: value.mount_path,
         }
     }
@@ -435,7 +438,6 @@ pub async fn ls(
         tables: infra_map
             .tables
             .into_values()
-            .filter(|api| name.is_none_or(|name| api.name.contains(name)))
             .map(|t| TableInfo {
                 // Use the display name (bare `name` for the default database,
                 // `database.name` otherwise) so the output is directly
@@ -446,6 +448,9 @@ pub async fn ls(
                 name: t.display_name(),
                 schema_fields: t.columns.iter().map(|col| col.name.clone()).collect(),
             })
+            // Filter *after* mapping so `--name db.foo` matches the value we
+            // render (not the bare `foo` stored on the Table).
+            .filter(|t| name.is_none_or(|n| t.name.contains(n)))
             .collect(),
         streams: infra_map
             .topics
@@ -484,7 +489,6 @@ pub async fn ls(
         dictionaries: infra_map
             .olap_dictionaries
             .into_values()
-            .filter(|d| name.is_none_or(|n| d.name.contains(n)))
             .map(|d| DictionaryInfo {
                 // Same reasoning as for tables: render the query-pastable
                 // display name, not the infra-map `id()`.
@@ -492,6 +496,9 @@ pub async fn ls(
                 source_type: d.source.source_type_label().to_string(),
                 layout: d.layout.layout_type_label().to_string(),
             })
+            // Filter after mapping so `--name db.foo` matches the rendered
+            // display name rather than the bare stored `name`.
+            .filter(|d| name.is_none_or(|n| d.name.contains(n)))
             .collect(),
     };
     let listing: &dyn ResourceInfo = match _type {
@@ -501,13 +508,17 @@ pub async fn ls(
         Some("ingestion") => &resources.ingestion_apis,
         Some("sql_resource") => &resources.sql_resources,
         Some("consumption") => &resources.consumption_apis,
+        Some("stream_transformations") => &resources.stream_transformations,
         Some("workflows") => &resources.workflows,
         Some("web_apps") => &resources.web_apps,
         Some("dictionaries") => &resources.dictionaries,
-        _ => {
+        Some(other) => {
             return Err(RoutineFailure::error(Message::new(
                 "Unknown".to_string(),
-                "type".to_string(),
+                format!(
+                    "type '{other}'. Valid values: tables, streams, ingestion, consumption, \
+                     sql_resource, stream_transformations, workflows, web_apps, dictionaries."
+                ),
             )))
         }
     };
@@ -576,6 +587,17 @@ mod tests {
         assert_eq!(
             WebAppInfo::from_web_app(without_leading, base).url,
             "http://localhost:4000/admin"
+        );
+    }
+
+    #[test]
+    fn web_app_info_normalizes_trailing_slash_in_base_url() {
+        // `LocalWebserverConfig::url()` can emit a trailing slash when
+        // `path_prefix` is configured; ensure we don't double-slash.
+        let app = WebApp::new("docs".to_string(), "/docs".to_string());
+        assert_eq!(
+            WebAppInfo::from_web_app(app, "http://localhost:4000/").url,
+            "http://localhost:4000/docs"
         );
     }
 }

--- a/apps/framework-cli/src/cli/routines/ls.rs
+++ b/apps/framework-cli/src/cli/routines/ls.rs
@@ -41,9 +41,6 @@ impl ResourceInfo for Vec<TableInfo> {
     }
 }
 
-// Note: From trait removed because Table::id() now requires default_database parameter.
-// TableInfo is constructed directly where needed with the appropriate default_database.
-
 #[derive(Debug, Serialize)]
 pub struct StreamInfo {
     pub name: String,
@@ -96,10 +93,39 @@ impl ResourceInfo for Vec<StreamInfo> {
 #[derive(Debug, Serialize)]
 pub struct IngestionApiInfo {
     pub name: String,
+    pub method: String,
+    pub url: String,
     pub destination: String,
 }
 
-fn to_info(endpoint: &ApiEndpoint) -> Either<IngestionApiInfo, ConsumptionApiInfo> {
+fn endpoint_url(base_url: &str, endpoint: &ApiEndpoint) -> String {
+    // `endpoint.path` is the server-relative path Moose routes on (e.g.
+    // `"ingest/UserActivityEvent/1.0"`). Compose with the dev server's base
+    // URL so the rendered value is directly pastable into curl / HTTP
+    // clients without the user having to know the host/port.
+    let path = endpoint.path.to_string_lossy();
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+fn method_name(
+    method: &crate::framework::core::infrastructure::api_endpoint::Method,
+) -> &'static str {
+    use crate::framework::core::infrastructure::api_endpoint::Method;
+    match method {
+        Method::GET => "GET",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::DELETE => "DELETE",
+    }
+}
+
+fn to_info(endpoint: &ApiEndpoint, base_url: &str) -> Either<IngestionApiInfo, ConsumptionApiInfo> {
+    let url = endpoint_url(base_url, endpoint);
+    let method = method_name(&endpoint.method).to_string();
     match &endpoint.api_type {
         APIType::INGRESS {
             target_topic_id,
@@ -108,6 +134,8 @@ fn to_info(endpoint: &ApiEndpoint) -> Either<IngestionApiInfo, ConsumptionApiInf
             schema: _,
         } => Either::Left(IngestionApiInfo {
             name: endpoint.name.clone(),
+            method,
+            url,
             destination: target_topic_id.clone(),
         }),
         APIType::EGRESS {
@@ -115,14 +143,12 @@ fn to_info(endpoint: &ApiEndpoint) -> Either<IngestionApiInfo, ConsumptionApiInf
             output_schema: _,
         } => Either::Right(ConsumptionApiInfo {
             name: endpoint.name.clone(),
+            method,
+            url,
             params: query_params
                 .iter()
                 .map(|param| param.name.clone())
                 .collect(),
-            path: match &endpoint.version {
-                Some(version) => format!("api/{}/{}", endpoint.name, version),
-                None => format!("api/{}", endpoint.name),
-            },
         }),
     }
 }
@@ -131,9 +157,21 @@ impl ResourceInfo for Vec<IngestionApiInfo> {
     fn show(&self) {
         show_table(
             "Ingestion APIs".to_string(),
-            vec!["name".to_string(), "destination".to_string()],
+            vec![
+                "name".to_string(),
+                "method".to_string(),
+                "url".to_string(),
+                "destination".to_string(),
+            ],
             self.iter()
-                .map(|api| vec![api.name.clone(), api.destination.clone()])
+                .map(|api| {
+                    vec![
+                        api.name.clone(),
+                        api.method.clone(),
+                        api.url.clone(),
+                        api.destination.clone(),
+                    ]
+                })
                 .collect(),
         )
     }
@@ -165,21 +203,28 @@ impl ResourceInfo for Vec<SqlResourceInfo> {
 #[derive(Debug, Serialize)]
 pub struct ConsumptionApiInfo {
     pub name: String,
+    pub method: String,
+    pub url: String,
     pub params: Vec<String>,
-    pub path: String,
 }
 
 impl ResourceInfo for Vec<ConsumptionApiInfo> {
     fn show(&self) {
         show_table(
             "Analytics APIs".to_string(),
-            vec!["name".to_string(), "params".to_string(), "path".to_string()],
+            vec![
+                "name".to_string(),
+                "method".to_string(),
+                "url".to_string(),
+                "params".to_string(),
+            ],
             self.iter()
                 .map(|api| {
                     vec![
                         api.name.clone(),
+                        api.method.clone(),
+                        api.url.clone(),
                         api.params.iter().join(", "),
-                        api.path.clone(),
                     ]
                 })
                 .collect(),
@@ -265,12 +310,19 @@ impl From<Workflow> for WorkflowInfo {
 pub struct WebAppInfo {
     pub name: String,
     pub mount_path: String,
+    pub url: String,
 }
 
-impl From<WebApp> for WebAppInfo {
-    fn from(value: WebApp) -> Self {
+impl WebAppInfo {
+    fn from_web_app(value: WebApp, base_url: &str) -> Self {
+        let mount = if value.mount_path.starts_with('/') {
+            value.mount_path.clone()
+        } else {
+            format!("/{}", value.mount_path)
+        };
         Self {
             name: value.name,
+            url: format!("{}{}", base_url, mount),
             mount_path: value.mount_path,
         }
     }
@@ -280,9 +332,13 @@ impl ResourceInfo for Vec<WebAppInfo> {
     fn show(&self) {
         show_table(
             "Web Apps".to_string(),
-            vec!["name".to_string(), "mount_path".to_string()],
+            vec![
+                "name".to_string(),
+                "url".to_string(),
+                "mount_path".to_string(),
+            ],
             self.iter()
-                .map(|app| vec![app.name.clone(), app.mount_path.clone()])
+                .map(|app| vec![app.name.clone(), app.url.clone(), app.mount_path.clone()])
                 .collect(),
         )
     }
@@ -368,20 +424,26 @@ pub async fn ls(
             )
         })?;
 
-    let default_database = infra_map.default_database.clone();
+    let base_url = project.http_server_config.url();
 
     let (ingestion_apis, consumption_apis): (Vec<_>, Vec<_>) = infra_map
         .api_endpoints
         .values()
         .filter(|api| name.is_none_or(|name| api.name.contains(name)))
-        .partition_map(to_info);
+        .partition_map(|ep| to_info(ep, &base_url));
     let resources = ResourceListing {
         tables: infra_map
             .tables
             .into_values()
             .filter(|api| name.is_none_or(|name| api.name.contains(name)))
             .map(|t| TableInfo {
-                name: t.id(&default_database),
+                // Use the display name (bare `name` for the default database,
+                // `database.name` otherwise) so the output is directly
+                // pastable into `moose query` / ClickHouse SQL. The
+                // `{db}_{name}` form returned by `Table::id()` is the
+                // infra-map's internal uniqueness key, not a valid SQL
+                // identifier.
+                name: t.display_name(),
                 schema_fields: t.columns.iter().map(|col| col.name.clone()).collect(),
             })
             .collect(),
@@ -417,14 +479,16 @@ pub async fn ls(
             .web_apps
             .into_values()
             .filter(|app| name.is_none_or(|n| app.name.contains(n)))
-            .map(Into::into)
+            .map(|app| WebAppInfo::from_web_app(app, &base_url))
             .collect(),
         dictionaries: infra_map
             .olap_dictionaries
             .into_values()
             .filter(|d| name.is_none_or(|n| d.name.contains(n)))
             .map(|d| DictionaryInfo {
-                name: d.id(&default_database),
+                // Same reasoning as for tables: render the query-pastable
+                // display name, not the infra-map `id()`.
+                name: d.display_name(),
                 source_type: d.source.source_type_label().to_string(),
                 layout: d.layout.layout_type_label().to_string(),
             })
@@ -462,4 +526,56 @@ pub async fn ls(
 trait ResourceInfo {
     fn show(&self);
     fn to_json_string(&self) -> Result<String, serde_json::error::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn endpoint_url_joins_base_and_relative_path() {
+        let endpoint = ApiEndpoint {
+            name: "foo".to_string(),
+            api_type: APIType::EGRESS {
+                query_params: vec![],
+                output_schema: serde_json::Value::Null,
+            },
+            path: PathBuf::from("api/foo/1.0"),
+            method: crate::framework::core::infrastructure::api_endpoint::Method::GET,
+            version: None,
+            source_primitive: crate::framework::core::infrastructure_map::PrimitiveSignature {
+                name: "foo".to_string(),
+                primitive_type:
+                    crate::framework::core::infrastructure_map::PrimitiveTypes::ConsumptionAPI,
+            },
+            metadata: None,
+            pulls_data_from: vec![],
+            pushes_data_to: vec![],
+        };
+        assert_eq!(
+            endpoint_url("http://localhost:4000", &endpoint),
+            "http://localhost:4000/api/foo/1.0"
+        );
+        // Tolerates trailing/leading slashes — no doubled slash in output.
+        assert_eq!(
+            endpoint_url("http://localhost:4000/", &endpoint),
+            "http://localhost:4000/api/foo/1.0"
+        );
+    }
+
+    #[test]
+    fn web_app_info_builds_absolute_url_from_mount_path() {
+        let base = "http://localhost:4000";
+        let with_leading = WebApp::new("docs".to_string(), "/docs".to_string());
+        let without_leading = WebApp::new("admin".to_string(), "admin".to_string());
+        assert_eq!(
+            WebAppInfo::from_web_app(with_leading, base).url,
+            "http://localhost:4000/docs"
+        );
+        assert_eq!(
+            WebAppInfo::from_web_app(without_leading, base).url,
+            "http://localhost:4000/admin"
+        );
+    }
 }

--- a/apps/framework-cli/src/framework/core/infrastructure/dictionary.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/dictionary.rs
@@ -992,6 +992,18 @@ impl OlapDictionary {
         }
     }
 
+    /// Human-readable, query-pastable name for UX surfaces (`moose ls`,
+    /// logs, error messages). Mirrors `Table::display_name`: returns
+    /// `database.name` when the dictionary pins a specific database,
+    /// otherwise the bare `name` — which is directly pastable into
+    /// `moose query` against the default database.
+    pub fn display_name(&self) -> String {
+        match &self.database {
+            Some(db) => format!("{}.{}", db, self.name),
+            None => self.name.clone(),
+        }
+    }
+
     /// Optional ON CLUSTER clause
     fn cluster_clause(&self) -> String {
         match &self.cluster_name {
@@ -2770,5 +2782,31 @@ mod tests {
 
         let restored = OlapDictionary::from_proto(proto);
         assert_eq!(restored.version, None);
+    }
+
+    #[test]
+    fn display_name_bare_when_no_database() {
+        let dict = simple_dict("user_agents");
+        assert_eq!(dict.display_name(), "user_agents");
+    }
+
+    #[test]
+    fn display_name_qualified_when_database_set() {
+        let mut dict = simple_dict("user_agents");
+        dict.database = Some("analytics".to_string());
+        assert_eq!(dict.display_name(), "analytics.user_agents");
+    }
+
+    #[test]
+    fn display_name_is_queryable_unlike_id() {
+        // `id()` uses `_` as separator ("local_user_agents"), which is an
+        // infra-map key rather than a ClickHouse identifier. `display_name`
+        // uses `.` so the string is directly pastable into `moose query`.
+        let dict = simple_dict("user_agents");
+        let id = dict.id("local");
+        let display = dict.display_name();
+        assert_eq!(id, "local_user_agents");
+        assert_eq!(display, "user_agents");
+        assert_ne!(id, display);
     }
 }

--- a/apps/framework-cli/src/framework/core/infrastructure/table.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/table.rs
@@ -2154,6 +2154,54 @@ mod tests {
     }
 
     #[test]
+    fn test_display_name_is_queryable_unlike_id() {
+        // `display_name` is what `moose ls` renders: it must be a valid SQL
+        // identifier users/agents can paste straight into `moose query`.
+        // `id()` uses `_` as separator ("local_users") for infra-map
+        // uniqueness — not a valid ClickHouse identifier.
+        use crate::framework::core::infrastructure_map::PrimitiveTypes;
+
+        let base = Table {
+            name: "users".to_string(),
+            columns: vec![],
+            order_by: OrderBy::Fields(vec![]),
+            partition_by: None,
+            sample_by: None,
+            engine: ClickhouseEngine::MergeTree,
+            version: None,
+            source_primitive: PrimitiveSignature {
+                name: "Users".to_string(),
+                primitive_type: PrimitiveTypes::DataModel,
+            },
+            metadata: None,
+            life_cycle: LifeCycle::FullyManaged,
+            engine_params_hash: None,
+            table_settings_hash: None,
+            table_settings: None,
+            indexes: vec![],
+            projections: vec![],
+            constraints: vec![],
+            database: None,
+            table_ttl_setting: None,
+            cluster_name: None,
+            primary_key_expression: None,
+            seed_filter: Default::default(),
+        };
+
+        // database: None → bare name, pastable in default-db context.
+        assert_eq!(base.display_name(), "users");
+        assert_eq!(base.id(DEFAULT_DATABASE_NAME), "local_users");
+        assert_ne!(base.display_name(), base.id(DEFAULT_DATABASE_NAME));
+
+        // database: Some → `db.name`, pastable as a fully-qualified ident.
+        let qualified = Table {
+            database: Some("analytics".to_string()),
+            ..base.clone()
+        };
+        assert_eq!(qualified.display_name(), "analytics.users");
+    }
+
+    #[test]
     fn test_order_by_equals_with_implicit_primary_key() {
         use crate::framework::core::infrastructure_map::PrimitiveTypes;
 

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -379,12 +379,14 @@ olap = true
 ## Observe
 
 ### Ls
-View Moose primitives and infrastructure.
+List the project's Moose resources with queryable names and hittable URLs.
 ```bash
 moose ls [--type <type>] [--name <name>] [--json]
 ```
-- `--type`: Filter by infrastructure type
-- `--name`: Filter by name (supports partial matching)
+Renders a table per resource type: `tables` (database-qualified name + schema fields, pastable into `moose query`), `streams`, `ingestion_apis` (name, HTTP method, full URL, destination topic), `consumption_apis` (name, HTTP method, full URL, query params), `sql_resources`, `stream_transformations`, `workflows`, `web_apps` (name, full URL, mount path), and `dictionaries`. URLs are composed from the dev server's host/port in `moose.config.toml`.
+
+- `--type`: Filter by infrastructure type. One of: `tables`, `streams`, `ingestion`, `consumption`, `sql_resource`, `stream_transformations`, `workflows`, `web_apps`, `dictionaries`. Omit to list every type.
+- `--name`: Filter by name (supports partial matching; matches the rendered display name — e.g. `db.foo` for a table pinned to a non-default database)
 - `--json`: Output in JSON format
 
 ### Ps


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI output formatting/filtering and add small helpers/tests; no runtime infra behavior or data writes are modified.
> 
> **Overview**
> `moose ls` now renders **query-pastable names** for tables and dictionaries (using `display_name()` instead of infra-map `id()`), and updates `--name` filtering to match the rendered value.
> 
> It also enriches API and web app listings with **HTTP method + absolute URL** derived from the project dev server base URL, expands `--type` handling (including `stream_transformations` and a clearer error for unknown types), and updates CLI help text plus docs; unit tests cover URL joining/normalization and new display-name behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335e605463029026e31e86adf49f0304aa789798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->