### PR TITLE
feat(dictionaries): add structural mismatch detection to check_reality()

### DIFF
--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -1181,9 +1181,15 @@ impl<T: OlapOperations + Sync> InfraRealityChecker<T> {
 
         // Structural comparison: for each dict present in both the infra map and CH,
         // compare the DDL body from SHOW CREATE DICTIONARY against the infra map
-        // definition.  Credentials are compared as-is (runtime env vars are resolved
-        // before calling to_create_if_not_exists_sql, so a credential rotation is
-        // correctly detected as a mismatch).
+        // definition.
+        //
+        // Credential visibility depends on the ClickHouse setting
+        // `display_secrets_in_show_and_select`:
+        //   - When ON (self-hosted default): credentials appear in SHOW CREATE output,
+        //     so a credential rotation IS detected as a mismatch.
+        //   - When OFF (ClickHouse Cloud default): credentials are replaced with
+        //     [HIDDEN]; dicts_ddl_equivalent() substitutes them from desired so the
+        //     comparison succeeds, but credential rotation cannot be detected.
         //
         // Limitation: SHOW CREATE DICTIONARY may order clauses differently from our
         // generated DDL (e.g. LIFETIME before LAYOUT).  dicts_ddl_equivalent() sorts

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -1100,169 +1100,18 @@ impl<T: OlapOperations + Sync> InfraRealityChecker<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::local_webserver::LocalWebserverConfig;
     use crate::framework::core::infrastructure::consumption_webserver::ConsumptionApiWebServer;
-    use crate::framework::core::infrastructure::table::{
-        Column, ColumnType, IntType, OrderBy, Table,
-    };
-    use crate::framework::core::infrastructure_map::{
-        PrimitiveSignature, PrimitiveTypes, TableChange,
-    };
-    use crate::framework::core::partial_infrastructure_map::LifeCycle;
+    use crate::framework::core::infrastructure::table::{Column, ColumnType, OrderBy, Table};
+    use crate::framework::core::infrastructure_map::TableChange;
+    use crate::framework::core::test_helpers::*;
     use crate::framework::versions::Version;
     use crate::infrastructure::olap::clickhouse::config::DEFAULT_DATABASE_NAME;
     use crate::infrastructure::olap::clickhouse::queries::ClickhouseEngine;
-    use crate::infrastructure::olap::clickhouse::TableWithUnsupportedType;
-    use async_trait::async_trait;
-
-    // Mock OLAP client for testing
-    struct MockOlapClient {
-        tables: Vec<Table>,
-        sql_resources: Vec<SqlResource>,
-        row_policies: Vec<SelectRowPolicy>,
-        dictionaries: Vec<String>,
-        /// DDL returned by show_create_dictionary, keyed by "db\x00name"
-        dictionary_ddls: std::collections::HashMap<String, String>,
-    }
-
-    impl MockOlapClient {
-        fn ddl_key(db: &str, name: &str) -> String {
-            format!("{}\x00{}", db, name)
-        }
-    }
-
-    #[async_trait]
-    impl OlapOperations for MockOlapClient {
-        async fn list_tables(
-            &self,
-            _db_name: &str,
-            _project: &Project,
-        ) -> Result<(Vec<Table>, Vec<TableWithUnsupportedType>), OlapChangesError> {
-            Ok((self.tables.clone(), vec![]))
-        }
-
-        async fn list_sql_resources(
-            &self,
-            _db_name: &str,
-            _default_database: &str,
-        ) -> Result<
-            Vec<crate::framework::core::infrastructure::sql_resource::SqlResource>,
-            OlapChangesError,
-        > {
-            Ok(self.sql_resources.clone())
-        }
-
-        async fn list_row_policies(
-            &self,
-            _db_name: &str,
-        ) -> Result<Vec<SelectRowPolicy>, OlapChangesError> {
-            Ok(self.row_policies.clone())
-        }
-
-        async fn list_dictionaries(&self, _db_name: &str) -> Result<Vec<String>, OlapChangesError> {
-            Ok(self.dictionaries.clone())
-        }
-
-        async fn show_create_dictionary(
-            &self,
-            db_name: &str,
-            dict_name: &str,
-        ) -> Result<String, OlapChangesError> {
-            let key = MockOlapClient::ddl_key(db_name, dict_name);
-            Ok(self.dictionary_ddls.get(&key).cloned().unwrap_or_default())
-        }
-    }
-
-    // Helper function to create a test project
-    fn create_test_project() -> Project {
-        Project {
-            language: crate::framework::languages::SupportedLanguages::Typescript,
-            redpanda_config: crate::infrastructure::stream::kafka::models::KafkaConfig::default(),
-            clickhouse_config: crate::infrastructure::olap::clickhouse::ClickHouseConfig {
-                db_name: "test".to_string(),
-                user: "test".to_string(),
-                password: "test".to_string(),
-                use_ssl: false,
-                host: "localhost".to_string(),
-                host_port: 18123,
-                native_port: 9000,
-                ..Default::default()
-            },
-            http_server_config: LocalWebserverConfig {
-                proxy_port: crate::cli::local_webserver::default_proxy_port(),
-                ..LocalWebserverConfig::default()
-            },
-            redis_config: crate::infrastructure::redis::redis_client::RedisConfig::default(),
-            git_config: crate::utilities::git::GitConfig::default(),
-            temporal_config:
-                crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
-            state_config: crate::project::StateConfig::default(),
-            migration_config: crate::project::MigrationConfig::default(),
-            language_project_config: crate::project::LanguageProjectConfig::default(),
-            project_location: std::path::PathBuf::new(),
-            is_production: false,
-            log_payloads: false,
-            supported_old_versions: std::collections::HashMap::new(),
-            jwt: None,
-            authentication: crate::project::AuthenticationConfig::default(),
-
-            features: crate::project::ProjectFeatures::default(),
-            load_infra: None,
-
-            typescript_config: crate::project::TypescriptConfig::default(),
-            source_dir: crate::project::default_source_dir(),
-            docker_config: crate::project::DockerConfig::default(),
-            watcher_config: crate::cli::watcher::WatcherConfig::default(),
-            dev: crate::project::DevConfig::default(),
-        }
-    }
-
-    fn create_base_table(name: &str) -> Table {
-        Table {
-            name: name.to_string(),
-            columns: vec![Column {
-                name: "id".to_string(),
-                data_type: ColumnType::Int(IntType::Int64),
-                required: true,
-                unique: true,
-                primary_key: true,
-                default: None,
-                annotations: vec![],
-                comment: None,
-                ttl: None,
-                codec: None,
-                materialized: None,
-                alias: None,
-            }],
-            order_by: OrderBy::Fields(vec!["id".to_string()]),
-            partition_by: None,
-            sample_by: None,
-            engine: ClickhouseEngine::MergeTree,
-            version: Some(Version::from_string("1.0.0".to_string())),
-            source_primitive: PrimitiveSignature {
-                name: "test".to_string(),
-                primitive_type: PrimitiveTypes::DataModel,
-            },
-            metadata: None,
-            life_cycle: LifeCycle::FullyManaged,
-            engine_params_hash: None,
-            table_settings_hash: None,
-            table_settings: None,
-            indexes: vec![],
-            projections: vec![],
-            constraints: vec![],
-            database: None,
-            table_ttl_setting: None,
-            cluster_name: None,
-            primary_key_expression: None,
-            seed_filter: Default::default(),
-        }
-    }
 
     #[tokio::test]
     async fn test_reality_checker_basic() {
         // Create a mock table
-        let table = create_base_table("test_table");
+        let table = create_test_table("test_table");
 
         // Create mock OLAP client with one table
         let mock_client = MockOlapClient {
@@ -1270,33 +1119,11 @@ mod tests {
                 database: Some(DEFAULT_DATABASE_NAME.to_string()),
                 ..table.clone()
             }],
-            sql_resources: vec![],
-            row_policies: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create empty infrastructure map
-        let mut infra_map = InfrastructureMap {
-            default_database: DEFAULT_DATABASE_NAME.to_string(),
-            topics: HashMap::new(),
-            api_endpoints: HashMap::new(),
-            tables: HashMap::new(),
-            dmv1_views: HashMap::new(),
-            topic_to_table_sync_processes: HashMap::new(),
-            topic_to_topic_sync_processes: HashMap::new(),
-            function_processes: HashMap::new(),
-            consumption_api_web_server: ConsumptionApiWebServer {},
-            orchestration_workers: HashMap::new(),
-            sql_resources: HashMap::new(),
-            workflows: HashMap::new(),
-            web_apps: HashMap::new(),
-            materialized_views: HashMap::new(),
-            views: HashMap::new(),
-            select_row_policies: HashMap::new(),
-            moose_version: None,
-            olap_dictionaries: Default::default(),
-        };
+        let mut infra_map = make_empty_infra_map();
 
         // Create reality checker
         let checker = InfraRealityChecker::new(mock_client);
@@ -1326,8 +1153,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reality_checker_structural_mismatch() {
-        let mut actual_table = create_base_table("test_table");
-        let infra_table = create_base_table("test_table");
+        let mut actual_table = create_test_table("test_table");
+        let infra_table = create_test_table("test_table");
 
         // Add an extra column to the actual table that's not in infra map
         actual_table.columns.push(Column {
@@ -1405,8 +1232,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reality_checker_order_by_mismatch() {
-        let mut actual_table = create_base_table("test_table");
-        let mut infra_table = create_base_table("test_table");
+        let mut actual_table = create_test_table("test_table");
+        let mut infra_table = create_test_table("test_table");
 
         // Add timestamp column to both tables
         let timestamp_col = Column {
@@ -1495,8 +1322,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reality_checker_engine_mismatch() {
-        let mut actual_table = create_base_table("test_table");
-        let mut infra_table = create_base_table("test_table");
+        let mut actual_table = create_test_table("test_table");
+        let mut infra_table = create_test_table("test_table");
 
         // Set different engine values
         actual_table.engine = ClickhouseEngine::ReplacingMergeTree {
@@ -1569,8 +1396,8 @@ mod tests {
         // - ClickHouse actually has ReplicatedReplacingMergeTree
         // - Stored infra map has MergeTree
         // - We should detect a mismatch
-        let mut actual_table = create_base_table("test_table");
-        let mut infra_table = create_base_table("test_table");
+        let mut actual_table = create_test_table("test_table");
+        let mut infra_table = create_test_table("test_table");
 
         // ClickHouse has ReplicatedReplacingMergeTree (with empty params - cloud mode)
         actual_table.engine = ClickhouseEngine::ReplicatedReplacingMergeTree {
@@ -1738,13 +1565,13 @@ mod tests {
     fn test_find_table_exact_id_match() {
         let table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
 
         let mut infra_map_tables = HashMap::new();
         let infra_table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
         let table_id = infra_table.id(DEFAULT_DATABASE_NAME);
         infra_map_tables.insert(table_id.clone(), infra_table);
@@ -1758,13 +1585,13 @@ mod tests {
         // When infra_map entry has no database, it should match any table
         let table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
 
         let mut infra_map_tables = HashMap::new();
         let infra_table = Table {
             database: None, // No database in infra_map
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
         let infra_table_id = infra_table.id(DEFAULT_DATABASE_NAME);
         infra_map_tables.insert(infra_table_id.clone(), infra_table);
@@ -1778,14 +1605,14 @@ mod tests {
         // FIX for ENG-1689: When both have matching databases, should match
         let table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
 
         let mut infra_map_tables = HashMap::new();
         // Use a different key to force fallback path
         let infra_table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
         let wrong_key = "wrong_key_custom_db_test_table_1_0_0".to_string();
         infra_map_tables.insert(wrong_key.clone(), infra_table);
@@ -1803,13 +1630,13 @@ mod tests {
         // Tables in different databases should NOT match
         let table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
 
         let mut infra_map_tables = HashMap::new();
         let infra_table = Table {
             database: Some("other_db".to_string()), // Different database
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
         let wrong_key = "wrong_key_other_db_test_table_1_0_0".to_string();
         infra_map_tables.insert(wrong_key, infra_table);
@@ -1826,13 +1653,13 @@ mod tests {
         // When infra_map has database but table doesn't, should NOT match
         let table = Table {
             database: None,
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
 
         let mut infra_map_tables = HashMap::new();
         let infra_table = Table {
             database: Some("custom_db".to_string()),
-            ..create_base_table("test_table")
+            ..create_test_table("test_table")
         };
         let wrong_key = "wrong_key_custom_db_test_table_1_0_0".to_string();
         infra_map_tables.insert(wrong_key, infra_table);
@@ -1847,12 +1674,12 @@ mod tests {
     #[test]
     fn test_find_table_version_mismatch_no_match() {
         // Different versions should NOT match
-        let mut table = create_base_table("test_table");
+        let mut table = create_test_table("test_table");
         table.database = Some("custom_db".to_string());
         table.version = Some(Version::from_string("2.0.0".to_string()));
 
         let mut infra_map_tables = HashMap::new();
-        let mut infra_table = create_base_table("test_table");
+        let mut infra_table = create_test_table("test_table");
         infra_table.database = Some("custom_db".to_string());
         infra_table.version = Some(Version::from_string("1.0.0".to_string()));
         let wrong_key = "wrong_key_custom_db_test_table_1_0_0".to_string();
@@ -1866,8 +1693,8 @@ mod tests {
     async fn test_reality_checker_custom_database_engine_mismatch() {
         // This test verifies the ENG-1689 fix:
         // Tables in custom databases should properly match and detect engine mismatches
-        let mut actual_table = create_base_table("test_table");
-        let mut infra_table = create_base_table("test_table");
+        let mut actual_table = create_test_table("test_table");
+        let mut infra_table = create_test_table("test_table");
 
         // Both tables are in a custom database
         actual_table.database = Some("custom_db".to_string());
@@ -1943,8 +1770,8 @@ mod tests {
     async fn test_reality_checker_custom_database_detects_engine_difference() {
         // This test verifies that after the ENG-1689 fix, we properly detect
         // engine differences in custom database tables
-        let mut actual_table = create_base_table("test_table");
-        let mut infra_table = create_base_table("test_table");
+        let mut actual_table = create_test_table("test_table");
+        let mut infra_table = create_test_table("test_table");
 
         // Both tables are in a custom database
         actual_table.database = Some("custom_db".to_string());
@@ -2231,94 +2058,6 @@ mod tests {
 
     // ─── Dictionary discrepancy tests ───────────────────────────────────────
 
-    fn make_empty_infra_map() -> InfrastructureMap {
-        InfrastructureMap {
-            default_database: DEFAULT_DATABASE_NAME.to_string(),
-            topics: HashMap::new(),
-            api_endpoints: HashMap::new(),
-            tables: HashMap::new(),
-            dmv1_views: HashMap::new(),
-            topic_to_table_sync_processes: HashMap::new(),
-            topic_to_topic_sync_processes: HashMap::new(),
-            function_processes: HashMap::new(),
-            consumption_api_web_server: ConsumptionApiWebServer {},
-            orchestration_workers: HashMap::new(),
-            sql_resources: HashMap::new(),
-            workflows: HashMap::new(),
-            web_apps: HashMap::new(),
-            materialized_views: HashMap::new(),
-            views: HashMap::new(),
-            select_row_policies: HashMap::new(),
-            moose_version: None,
-            olap_dictionaries: Default::default(),
-        }
-    }
-
-    fn make_simple_mock(dictionaries: Vec<String>) -> MockOlapClient {
-        MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
-            row_policies: vec![],
-            dictionaries,
-            dictionary_ddls: std::collections::HashMap::new(),
-        }
-    }
-
-    fn make_mock_with_ddls(
-        dictionaries: Vec<String>,
-        dictionary_ddls: std::collections::HashMap<String, String>,
-    ) -> MockOlapClient {
-        MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
-            row_policies: vec![],
-            dictionaries,
-            dictionary_ddls,
-        }
-    }
-
-    fn make_simple_dict(
-        name: &str,
-    ) -> crate::infrastructure::olap::clickhouse::dictionary::OlapDictionary {
-        use crate::infrastructure::olap::clickhouse::dictionary::{
-            DictionaryColumn, DictionaryLayout, DictionaryLifetime, DictionarySource,
-            DictionaryTableSource, OlapDictionary,
-        };
-        OlapDictionary {
-            name: name.to_string(),
-            database: None,
-            cluster_name: None,
-            source: DictionarySource::Table(DictionaryTableSource {
-                table: "src".to_string(),
-                database: None,
-                where_clause: None,
-                invalidate_query: None,
-            }),
-            primary_key: vec!["id".to_string()],
-            columns: vec![DictionaryColumn {
-                name: "id".to_string(),
-                type_string: "UInt64".to_string(),
-                default_value: None,
-                expression: None,
-                is_injective: None,
-                is_hierarchical: None,
-                is_object_id: None,
-                comment: None,
-            }],
-            layout: DictionaryLayout::Hashed {
-                initial_array_size: None,
-                max_load_factor: None,
-            },
-            lifetime: DictionaryLifetime::Single { seconds: 300 },
-            invalidate_query: None,
-            settings: HashMap::new(),
-            comment: None,
-            life_cycle: LifeCycle::FullyManaged,
-            version: None,
-            metadata: None,
-        }
-    }
-
     #[tokio::test]
     async fn test_dictionary_unmapped_detected() {
         // dict exists in reality but NOT in the infra map → unmapped
@@ -2341,7 +2080,7 @@ mod tests {
         // dict is in the infra map but NOT in reality → missing
         let mock_client = make_simple_mock(vec![]);
         let mut infra_map = make_empty_infra_map();
-        let dict = make_simple_dict("dict_products");
+        let dict = make_test_dict("dict_products");
         let map_key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict.name);
         infra_map.olap_dictionaries.insert(map_key.clone(), dict);
 
@@ -2423,7 +2162,7 @@ mod tests {
         // → the map key is "local_dict_foo", not "test_dict_foo"
         let mock_client = make_simple_mock(vec![]); // nothing in reality
         let mut infra_map = make_empty_infra_map();
-        let dict = make_simple_dict("dict_foo");
+        let dict = make_test_dict("dict_foo");
         let map_key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict.name); // "local_dict_foo"
         infra_map.olap_dictionaries.insert(map_key.clone(), dict);
 
@@ -2483,7 +2222,7 @@ mod tests {
         // check_reality() uses project.clickhouse_config.db_name as the default_db when
         // resolving a dict's database, so show_create_dictionary is called with "test".
         // The map key uses DEFAULT_DATABASE_NAME so reconcile_with_reality can remove it.
-        let dict = make_simple_dict("dict_products");
+        let dict = make_test_dict("dict_products");
         let project_db = "test"; // matches create_test_project().clickhouse_config.db_name
         let map_key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict.name);
 
@@ -2520,7 +2259,7 @@ mod tests {
         // dict is in both map and reality with the same structural DDL.
         // LAYOUT/LIFETIME order difference (SHOW CREATE vs our generator) should not
         // be flagged as a mismatch.
-        let dict = make_simple_dict("dict_products");
+        let dict = make_test_dict("dict_products");
         let project_db = "test"; // matches create_test_project().clickhouse_config.db_name
         let map_key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict.name);
 
@@ -2554,7 +2293,7 @@ mod tests {
     #[test]
     fn test_is_empty_false_with_mismatched_dictionary() {
         use crate::framework::core::infrastructure_map::{Change, OlapChange};
-        let dict = make_simple_dict("dict_x");
+        let dict = make_test_dict("dict_x");
         let discrepancies = InfraDiscrepancies {
             unmapped_tables: vec![],
             missing_tables: vec![],

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -2370,8 +2370,8 @@ mod tests {
         let actual_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
             .replace(
-                "LAYOUT(HASHED())\nLIFETIME(300)",
-                "LIFETIME(300)\nLAYOUT(HASHED())",
+                "LAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)",
+                "LIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())",
             );
 
         let mut ddls = std::collections::HashMap::new();

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -152,10 +152,28 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
 
         // Walk the DDL from the opening `(` tracking depth to find the
         // matching `)` that closes the column list.
+        // Quote-aware: a `)` inside a DEFAULT value like `DEFAULT ')'` must not
+        // prematurely end the column block.
         let mut depth = 0usize;
+        let mut in_single = false;
+        let mut in_double = false;
         let mut end = start;
         for (off, ch) in ddl[start..].char_indices() {
+            if in_single {
+                if ch == '\'' {
+                    in_single = false;
+                }
+                continue;
+            }
+            if in_double {
+                if ch == '"' {
+                    in_double = false;
+                }
+                continue;
+            }
             match ch {
+                '\'' => in_single = true,
+                '"' => in_double = true,
                 '(' => depth += 1,
                 ')' => {
                     depth -= 1;
@@ -215,8 +233,10 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
                 match c {
                     '(' => depth += 1,
                     ')' => depth = depth.saturating_sub(1),
-                    '\'' if depth == 0 => in_single_quote = true,
-                    '"' if depth == 0 => in_double_quote = true,
+                    // Track quotes at any depth so a ')' inside SOURCE(MYSQL(PASSWORD 'p@ss)word'))
+                    // does not corrupt the depth counter.
+                    '\'' => in_single_quote = true,
+                    '"' => in_double_quote = true,
                     _ if depth == 0 => {
                         for &kw in keywords {
                             if text[abs_pos..].starts_with(kw) {
@@ -2318,6 +2338,20 @@ mod tests {
         let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'old_src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'new_src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         assert!(!dicts_ddl_equivalent(actual, desired));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_column_default_with_paren() {
+        // A column DEFAULT containing ')' must not prematurely close the column block.
+        let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64,\n    `status` String DEFAULT ')'\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_source_password_with_paren() {
+        // A SOURCE credential containing ')' must not corrupt clause boundary detection.
+        let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'p@ss)word' DB 'mydb' TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(ddl, ddl));
     }
 
     // ─── Structural mismatch detection tests ───────────────────────────────

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -127,6 +127,22 @@ fn normalize_database(db: &Option<String>, default_database: &str) -> String {
 
 /// Returns true if two dictionary DDL strings are structurally equivalent.
 ///
+/// Returns the byte offset of the closing single quote in `s`, skipping
+/// backslash-escaped characters (`\'` is an embedded quote, not a closer).
+fn find_closing_quote(s: &str) -> Option<usize> {
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '\\' {
+            chars.next(); // skip escaped character
+            continue;
+        }
+        if c == '\'' {
+            return Some(i);
+        }
+    }
+    None
+}
+
 /// Substitutes `'[HIDDEN]'` credential placeholders in `actual` with the
 /// corresponding values from `desired`, matched by the keyword immediately
 /// preceding each placeholder.
@@ -152,7 +168,7 @@ fn fill_hidden_credentials(actual: &str, desired: &str) -> String {
             let search = format!("{} '", kw);
             if let Some(kw_pos) = desired.find(&search) {
                 let val_start = kw_pos + search.len();
-                if let Some(val_end) = desired[val_start..].find('\'') {
+                if let Some(val_end) = find_closing_quote(&desired[val_start..]) {
                     let replacement = format!("'{}'", &desired[val_start..val_start + val_end]);
                     result.replace_range(abs..abs + placeholder.len(), &replacement);
                     offset = abs + replacement.len();
@@ -2446,6 +2462,15 @@ mod tests {
         let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD '[HIDDEN]' TABLE 'old_src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'real_pass' TABLE 'new_src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         assert!(!dicts_ddl_equivalent(actual, desired));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_hidden_credentials_escaped_quote_in_password() {
+        // A password containing a single quote is backslash-escaped in the desired DDL
+        // (`pass\'word`). fill_hidden_credentials must not stop at the escaped quote.
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD '[HIDDEN]' TABLE 'src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'pass\\'word' TABLE 'src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(actual, desired));
     }
 
     #[test]

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -2530,8 +2530,8 @@ mod tests {
         let actual_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
             .replace(
-                "LAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)",
-                "LIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())",
+                "LAYOUT(HASHED())\nLIFETIME(300)",
+                "LIFETIME(300)\nLAYOUT(HASHED())",
             );
 
         let mut ddls = std::collections::HashMap::new();

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -273,7 +273,17 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
     }
 
     fn norm(s: &str) -> String {
-        s.split_whitespace().collect::<Vec<_>>().join(" ")
+        let s = s.split_whitespace().collect::<Vec<_>>().join(" ");
+        // Normalize LIFETIME(N) → LIFETIME(MIN 0 MAX N) to match ClickHouse SHOW CREATE output.
+        // Both forms are valid ClickHouse DDL; SHOW CREATE always returns the long form.
+        if let Some(rest) = s.strip_prefix("LIFETIME(") {
+            if let Some(inner) = rest.strip_suffix(')') {
+                if inner.bytes().all(|b| b.is_ascii_digit()) {
+                    return format!("LIFETIME(MIN 0 MAX {})", inner);
+                }
+            }
+        }
+        s
     }
 
     let (actual_cols, mut actual_clauses) = extract_body(actual_ddl);
@@ -2367,10 +2377,12 @@ mod tests {
         let desired_ddl = dict.to_create_if_not_exists_sql();
         // Simulate SHOW CREATE DICTIONARY: same structure, LAYOUT/LIFETIME swapped,
         // no IF NOT EXISTS prefix.
+        // Simulate SHOW CREATE DICTIONARY: strip IF NOT EXISTS, swap LAYOUT/LIFETIME order,
+        // and normalize LIFETIME(N) → LIFETIME(MIN 0 MAX N) as ClickHouse does.
         let actual_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
             .replace(
-                "LAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)",
+                "LAYOUT(HASHED())\nLIFETIME(300)",
                 "LIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())",
             );
 

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -127,23 +127,73 @@ fn normalize_database(db: &Option<String>, default_database: &str) -> String {
 
 /// Returns true if two dictionary DDL strings are structurally equivalent.
 ///
+/// Substitutes `'[HIDDEN]'` credential placeholders in `actual` with the
+/// corresponding values from `desired`, matched by the keyword immediately
+/// preceding each placeholder.
+///
+/// ClickHouse replaces credential field values with `[HIDDEN]` in `SHOW CREATE`
+/// output when `display_secrets_in_show_and_select = 0` (the ClickHouse Cloud
+/// default). Without this substitution, every dictionary with SOURCE credentials
+/// would be flagged as structurally mismatched on every reconcile cycle.
+fn fill_hidden_credentials(actual: &str, desired: &str) -> String {
+    if !actual.contains("[HIDDEN]") {
+        return actual.to_string();
+    }
+    let placeholder = "'[HIDDEN]'";
+    let mut result = actual.to_string();
+    let mut offset = 0;
+    while let Some(pos) = result[offset..].find(placeholder) {
+        let abs = offset + pos;
+        // Find the keyword immediately before '[HIDDEN]' (last whitespace-delimited
+        // token before the opening quote).
+        let kw = result[..abs]
+            .trim_end()
+            .split_whitespace()
+            .next_back()
+            .unwrap_or("");
+        if !kw.is_empty() {
+            // Find `KEYWORD 'value'` in desired and extract the value.
+            let search = format!("{} '", kw);
+            if let Some(kw_pos) = desired.find(&search) {
+                let val_start = kw_pos + search.len();
+                if let Some(val_end) = desired[val_start..].find('\'') {
+                    let replacement = format!("'{}'", &desired[val_start..val_start + val_end]);
+                    result.replace_range(abs..abs + placeholder.len(), &replacement);
+                    offset = abs + replacement.len();
+                    continue;
+                }
+            }
+        }
+        offset = abs + placeholder.len();
+    }
+    result
+}
+
 /// Strips the `CREATE DICTIONARY …` header from each (everything before the
 /// first `(`), then for the column block and each subsequent clause:
 ///   - normalises whitespace (collapses runs of whitespace to a single space)
 ///   - sorts the post-column clauses to tolerate ordering differences between
 ///     our generated DDL (LAYOUT before LIFETIME) and ClickHouse's SHOW CREATE
 ///     output (LIFETIME before LAYOUT)
+///   - fills `'[HIDDEN]'` credential placeholders in actual with the
+///     corresponding values from desired (ClickHouse Cloud hides credentials)
 ///
 /// Recognised top-level clauses: `PRIMARY KEY`, `SOURCE`, `LAYOUT`, `LIFETIME`,
 /// `INVALIDATE_QUERY`, `SETTINGS`, `COMMENT`. Clause boundaries are detected with
-/// a depth/quote-aware scanner so keywords inside parentheses or quoted strings
-/// (e.g. an `INVALIDATE_QUERY` body containing the word `SETTINGS`) are not
-/// mistaken for clause starts.
+/// a depth/quote/backtick-aware scanner so keywords inside parentheses or quoted
+/// strings are not mistaken for clause starts.
 ///
 /// **Limitation**: identifier quoting and type-alias differences (e.g.
 /// `Int64` vs `Int64`) are preserved as-is; ClickHouse and our generator both
 /// use backtick-quoted identifiers so these should agree in practice.
 fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
+    let filled;
+    let actual_ddl = if actual_ddl.contains("[HIDDEN]") {
+        filled = fill_hidden_credentials(actual_ddl, desired_ddl);
+        filled.as_str()
+    } else {
+        actual_ddl
+    };
     fn extract_body(ddl: &str) -> (String, Vec<String>) {
         let start = match ddl.find('(') {
             Some(i) => i,
@@ -2377,6 +2427,23 @@ mod tests {
         // close the column block (e.g. `col)name` is unusual but valid ClickHouse DDL).
         let ddl = "CREATE DICTIONARY `db`.`d` (\n    `col)name` UInt64\n)\nPRIMARY KEY `col)name`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_hidden_credentials_no_false_mismatch() {
+        // ClickHouse Cloud hides credentials in SHOW CREATE output. A '[HIDDEN]'
+        // password must not cause a false structural mismatch.
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD '[HIDDEN]' TABLE 'src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'real_pass' TABLE 'src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(actual, desired));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_hidden_credentials_source_change_detected() {
+        // Even with a hidden password, a changed TABLE value must still be detected.
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD '[HIDDEN]' TABLE 'old_src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'real_pass' TABLE 'new_src' DB 'mydb'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(!dicts_ddl_equivalent(actual, desired));
     }
 
     #[test]

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -125,6 +125,71 @@ fn normalize_database(db: &Option<String>, default_database: &str) -> String {
     db.as_deref().unwrap_or(default_database).to_string()
 }
 
+/// Returns true if two dictionary DDL strings are structurally equivalent.
+///
+/// Strips the `CREATE DICTIONARY …` header from each (everything before the
+/// first `(`), then for the column block and each subsequent clause:
+///   - normalises whitespace (collapses runs of whitespace to a single space)
+///   - sorts the post-column clauses to tolerate ordering differences between
+///     our generated DDL (LAYOUT before LIFETIME) and ClickHouse's SHOW CREATE
+///     output (LIFETIME before LAYOUT)
+///
+/// **Limitation**: identifier quoting and type-alias differences (e.g.
+/// `Int64` vs `Int64`) are preserved as-is; ClickHouse and our generator both
+/// use backtick-quoted identifiers so these should agree in practice.
+fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
+    fn extract_body(ddl: &str) -> (String, Vec<String>) {
+        let start = match ddl.find('(') {
+            Some(i) => i,
+            None => return (ddl.trim().to_string(), vec![]),
+        };
+
+        // Walk the DDL from the opening `(` tracking depth to find the
+        // matching `)` that closes the column list.
+        let mut depth = 0usize;
+        let mut end = start;
+        for (off, ch) in ddl[start..].char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = start + off + ')'.len_utf8();
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let col_block = ddl[start..end].to_string();
+        let clauses: Vec<String> = ddl[end..]
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        (col_block, clauses)
+    }
+
+    fn norm(s: &str) -> String {
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    let (actual_cols, mut actual_clauses) = extract_body(actual_ddl);
+    let (desired_cols, mut desired_clauses) = extract_body(desired_ddl);
+
+    if norm(&actual_cols) != norm(&desired_cols) {
+        return false;
+    }
+
+    actual_clauses.sort();
+    desired_clauses.sort();
+
+    actual_clauses.iter().map(|c| norm(c)).collect::<Vec<_>>()
+        == desired_clauses.iter().map(|c| norm(c)).collect::<Vec<_>>()
+}
+
 /// Normalizes a table reference for comparison.
 /// Now that source_tables come pre-formatted from TypeScript/Python libraries as:
 /// - `database_name`.`table_name` (with backticks) when database is specified
@@ -918,13 +983,62 @@ impl<T: OlapOperations + Sync> InfraRealityChecker<T> {
             .map(|(key, _)| key.clone())
             .collect();
 
-        // Structural comparison (mismatched) is deferred — list_dictionaries returns names only.
-        let mismatched_dictionaries: Vec<OlapChange> = Vec::new();
+        // Structural comparison: for each dict present in both the infra map and CH,
+        // compare the DDL body from SHOW CREATE DICTIONARY against the infra map
+        // definition.  Credentials are compared as-is (runtime env vars are resolved
+        // before calling to_create_if_not_exists_sql, so a credential rotation is
+        // correctly detected as a mismatch).
+        //
+        // Limitation: SHOW CREATE DICTIONARY may order clauses differently from our
+        // generated DDL (e.g. LIFETIME before LAYOUT).  dicts_ddl_equivalent() sorts
+        // post-column clauses before comparing to avoid false positives.
+        let mut mismatched_dictionaries: Vec<OlapChange> = Vec::new();
+        for desired in infra_map.olap_dictionaries.values() {
+            let db = desired.database.as_deref().unwrap_or(default_db);
+            if !actual_dictionaries.contains(&(db.to_string(), desired.name.clone())) {
+                // Already counted as missing — skip.
+                continue;
+            }
+            let actual_ddl = match self
+                .olap_client
+                .show_create_dictionary(db, &desired.name)
+                .await
+            {
+                Ok(ddl) => ddl,
+                Err(e) => {
+                    debug!(
+                        "Could not get DDL for dictionary '{}.{}': {:?}",
+                        db, desired.name, e
+                    );
+                    continue;
+                }
+            };
+            if actual_ddl.is_empty() {
+                continue;
+            }
+            let desired_ddl = desired.to_create_if_not_exists_sql();
+            if !dicts_ddl_equivalent(&actual_ddl, &desired_ddl) {
+                debug!(
+                    "Structural mismatch in dictionary '{}.{}'",
+                    db, desired.name
+                );
+                // Store the infra-map dict as both before and after.  The actual CH
+                // definition is not reconstructed here — reconcile_with_reality()
+                // removes the dict from the reconciled map so the diff generates an
+                // Added change, which execute_create_dictionary resolves via
+                // CREATE OR REPLACE DICTIONARY.
+                mismatched_dictionaries.push(OlapChange::OlapDictionary(Change::Updated {
+                    before: Box::new(desired.clone()),
+                    after: Box::new(desired.clone()),
+                }));
+            }
+        }
 
         debug!(
-            "Found {} unmapped, {} missing dictionaries",
+            "Found {} unmapped, {} missing, {} mismatched dictionaries",
             unmapped_dictionaries.len(),
-            missing_dictionaries.len()
+            missing_dictionaries.len(),
+            mismatched_dictionaries.len()
         );
 
         let discrepancies = InfraDiscrepancies {
@@ -954,7 +1068,7 @@ impl<T: OlapOperations + Sync> InfraRealityChecker<T> {
             {} unmapped MVs, {} missing MVs, {} mismatched MVs, \
             {} unmapped views, {} missing views, {} mismatched views, \
             {} unmapped row policies, {} missing row policies, {} mismatched row policies, \
-            {} unmapped dictionaries, {} missing dictionaries",
+            {} unmapped dictionaries, {} missing dictionaries, {} mismatched dictionaries",
             discrepancies.unmapped_tables.len(),
             discrepancies.missing_tables.len(),
             discrepancies.mismatched_tables.len(),
@@ -971,7 +1085,8 @@ impl<T: OlapOperations + Sync> InfraRealityChecker<T> {
             discrepancies.missing_row_policies.len(),
             discrepancies.mismatched_row_policies.len(),
             discrepancies.unmapped_dictionaries.len(),
-            discrepancies.missing_dictionaries.len()
+            discrepancies.missing_dictionaries.len(),
+            discrepancies.mismatched_dictionaries.len()
         );
 
         if discrepancies.is_empty() {
@@ -1006,6 +1121,14 @@ mod tests {
         sql_resources: Vec<SqlResource>,
         row_policies: Vec<SelectRowPolicy>,
         dictionaries: Vec<String>,
+        /// DDL returned by show_create_dictionary, keyed by "db\x00name"
+        dictionary_ddls: std::collections::HashMap<String, String>,
+    }
+
+    impl MockOlapClient {
+        fn ddl_key(db: &str, name: &str) -> String {
+            format!("{}\x00{}", db, name)
+        }
     }
 
     #[async_trait]
@@ -1038,6 +1161,15 @@ mod tests {
 
         async fn list_dictionaries(&self, _db_name: &str) -> Result<Vec<String>, OlapChangesError> {
             Ok(self.dictionaries.clone())
+        }
+
+        async fn show_create_dictionary(
+            &self,
+            db_name: &str,
+            dict_name: &str,
+        ) -> Result<String, OlapChangesError> {
+            let key = MockOlapClient::ddl_key(db_name, dict_name);
+            Ok(self.dictionary_ddls.get(&key).cloned().unwrap_or_default())
         }
     }
 
@@ -1141,6 +1273,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create empty infrastructure map
@@ -1220,6 +1353,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -1304,6 +1438,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -1378,6 +1513,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -1454,6 +1590,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -1546,6 +1683,7 @@ mod tests {
             sql_resources: vec![actual_resource.clone()],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -1755,6 +1893,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -1826,6 +1965,7 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let mut infra_map = InfrastructureMap {
@@ -2120,6 +2260,20 @@ mod tests {
             sql_resources: vec![],
             row_policies: vec![],
             dictionaries,
+            dictionary_ddls: std::collections::HashMap::new(),
+        }
+    }
+
+    fn make_mock_with_ddls(
+        dictionaries: Vec<String>,
+        dictionary_ddls: std::collections::HashMap<String, String>,
+    ) -> MockOlapClient {
+        MockOlapClient {
+            tables: vec![],
+            sql_resources: vec![],
+            row_policies: vec![],
+            dictionaries,
+            dictionary_ddls,
         }
     }
 
@@ -2286,5 +2440,144 @@ mod tests {
              reconcile_with_reality can remove it; got '{}', want '{}'",
             discrepancies.missing_dictionaries[0], map_key
         );
+    }
+
+    // ─── dicts_ddl_equivalent helper tests ─────────────────────────────────
+
+    #[test]
+    fn test_dicts_ddl_equivalent_identical() {
+        let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_clause_reordering() {
+        // LAYOUT/LIFETIME order swapped — should still be equivalent
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(actual, desired));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_column_mismatch() {
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64,\n    `value` String\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(!dicts_ddl_equivalent(actual, desired));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_source_mismatch() {
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'old_src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'new_src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(!dicts_ddl_equivalent(actual, desired));
+    }
+
+    // ─── Structural mismatch detection tests ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_dictionary_mismatched_detected() {
+        // dict is in both the infra map AND in reality, but with a different DDL.
+        //
+        // Note: create_test_project() uses clickhouse_config.db_name = "test", while
+        // make_empty_infra_map() uses default_database = DEFAULT_DATABASE_NAME = "local".
+        // check_reality() uses project.clickhouse_config.db_name as the default_db when
+        // resolving a dict's database, so show_create_dictionary is called with "test".
+        // The map key uses DEFAULT_DATABASE_NAME so reconcile_with_reality can remove it.
+        let dict = make_simple_dict("dict_products");
+        let project_db = "test"; // matches create_test_project().clickhouse_config.db_name
+        let map_key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict.name);
+
+        // Desired DDL generated from the infra map dict
+        let desired_ddl = dict.to_create_if_not_exists_sql();
+        // Simulate a drifted CH definition (extra column added manually)
+        let drifted_ddl =
+            desired_ddl.replace("PRIMARY KEY", "    `extra_col` String,\nPRIMARY KEY");
+        // Simulate SHOW CREATE DICTIONARY output (no IF NOT EXISTS)
+        let actual_ddl =
+            drifted_ddl.replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY");
+
+        let mut ddls = std::collections::HashMap::new();
+        ddls.insert(MockOlapClient::ddl_key(project_db, &dict.name), actual_ddl);
+        let mock_client = make_mock_with_ddls(vec![dict.name.clone()], ddls);
+
+        let mut infra_map = make_empty_infra_map();
+        infra_map.olap_dictionaries.insert(map_key, dict);
+
+        let checker = InfraRealityChecker::new(mock_client);
+        let discrepancies = checker
+            .check_reality(&create_test_project(), &infra_map)
+            .await
+            .unwrap();
+
+        assert!(discrepancies.unmapped_dictionaries.is_empty());
+        assert!(discrepancies.missing_dictionaries.is_empty());
+        assert_eq!(discrepancies.mismatched_dictionaries.len(), 1);
+        assert!(!discrepancies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_dictionary_no_false_mismatch_when_ddl_matches() {
+        // dict is in both map and reality with the same structural DDL.
+        // LAYOUT/LIFETIME order difference (SHOW CREATE vs our generator) should not
+        // be flagged as a mismatch.
+        let dict = make_simple_dict("dict_products");
+        let project_db = "test"; // matches create_test_project().clickhouse_config.db_name
+        let map_key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict.name);
+
+        let desired_ddl = dict.to_create_if_not_exists_sql();
+        // Simulate SHOW CREATE DICTIONARY: same structure, LAYOUT/LIFETIME swapped,
+        // no IF NOT EXISTS prefix.
+        let actual_ddl = desired_ddl
+            .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
+            .replace(
+                "LAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)",
+                "LIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())",
+            );
+
+        let mut ddls = std::collections::HashMap::new();
+        ddls.insert(MockOlapClient::ddl_key(project_db, &dict.name), actual_ddl);
+        let mock_client = make_mock_with_ddls(vec![dict.name.clone()], ddls);
+
+        let mut infra_map = make_empty_infra_map();
+        infra_map.olap_dictionaries.insert(map_key, dict);
+
+        let checker = InfraRealityChecker::new(mock_client);
+        let discrepancies = checker
+            .check_reality(&create_test_project(), &infra_map)
+            .await
+            .unwrap();
+
+        assert!(discrepancies.mismatched_dictionaries.is_empty());
+        assert!(discrepancies.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_false_with_mismatched_dictionary() {
+        use crate::framework::core::infrastructure_map::{Change, OlapChange};
+        let dict = make_simple_dict("dict_x");
+        let discrepancies = InfraDiscrepancies {
+            unmapped_tables: vec![],
+            missing_tables: vec![],
+            mismatched_tables: vec![],
+            unmapped_sql_resources: vec![],
+            missing_sql_resources: vec![],
+            mismatched_sql_resources: vec![],
+            unmapped_materialized_views: vec![],
+            missing_materialized_views: vec![],
+            mismatched_materialized_views: vec![],
+            unmapped_views: vec![],
+            missing_views: vec![],
+            mismatched_views: vec![],
+            unmapped_row_policies: vec![],
+            missing_row_policies: vec![],
+            mismatched_row_policies: vec![],
+            unmapped_dictionaries: vec![],
+            missing_dictionaries: vec![],
+            mismatched_dictionaries: vec![OlapChange::OlapDictionary(Change::Updated {
+                before: Box::new(dict.clone()),
+                after: Box::new(dict),
+            })],
+        };
+        assert!(!discrepancies.is_empty());
     }
 }

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -146,11 +146,7 @@ fn fill_hidden_credentials(actual: &str, desired: &str) -> String {
         let abs = offset + pos;
         // Find the keyword immediately before '[HIDDEN]' (last whitespace-delimited
         // token before the opening quote).
-        let kw = result[..abs]
-            .trim_end()
-            .split_whitespace()
-            .next_back()
-            .unwrap_or("");
+        let kw = result[..abs].split_whitespace().next_back().unwrap_or("");
         if !kw.is_empty() {
             // Find `KEYWORD 'value'` in desired and extract the value.
             let search = format!("{} '", kw);
@@ -234,7 +230,7 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
                 '`' => in_backtick = true,
                 '(' => depth += 1,
                 ')' => {
-                    depth -= 1;
+                    depth = depth.saturating_sub(1);
                     if depth == 0 {
                         end = start + off + ')'.len_utf8();
                         break;

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -220,13 +220,12 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
                     _ if depth == 0 => {
                         for &kw in keywords {
                             if text[abs_pos..].starts_with(kw) {
-                                // Require a word boundary before (start or non-alnum/underscore)
-                                let prev_ok = abs_pos == from
-                                    || text[..abs_pos]
-                                        .chars()
-                                        .next_back()
-                                        .map(|p| !p.is_alphanumeric() && p != '_')
-                                        .unwrap_or(true);
+                                // Require a word boundary before (start of text or non-alnum/underscore)
+                                let prev_ok = text[..abs_pos]
+                                    .chars()
+                                    .next_back()
+                                    .map(|p| !p.is_alphanumeric() && p != '_')
+                                    .unwrap_or(true);
                                 // Require a word boundary after (end or non-alnum/underscore)
                                 let after = abs_pos + kw.len();
                                 let next_ok = text[after..]

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -181,6 +181,62 @@ fn fill_hidden_credentials(actual: &str, desired: &str) -> String {
     result
 }
 
+/// Stateful depth-and-quote tracker for walking ClickHouse DDL text character
+/// by character.
+///
+/// Call [`advance`] once per character. When it returns `true` the character
+/// is "active" (not inside a quoted string) and `self.depth` reflects the paren
+/// depth *after* processing it. When it returns `false` the character was
+/// consumed as part of a quoted literal and the caller should skip it.
+#[derive(Default)]
+struct QuoteDepthState {
+    pub depth: usize,
+    in_single: bool,
+    in_double: bool,
+    in_backtick: bool,
+    skip_next_single: bool,
+}
+
+impl QuoteDepthState {
+    fn advance(&mut self, ch: char) -> bool {
+        if self.in_single {
+            if self.skip_next_single {
+                self.skip_next_single = false;
+                return false;
+            }
+            if ch == '\\' {
+                self.skip_next_single = true;
+                return false;
+            }
+            if ch == '\'' {
+                self.in_single = false;
+            }
+            return false;
+        }
+        if self.in_double {
+            if ch == '"' {
+                self.in_double = false;
+            }
+            return false;
+        }
+        if self.in_backtick {
+            if ch == '`' {
+                self.in_backtick = false;
+            }
+            return false;
+        }
+        match ch {
+            '\'' => self.in_single = true,
+            '"' => self.in_double = true,
+            '`' => self.in_backtick = true,
+            '(' => self.depth += 1,
+            ')' => self.depth = self.depth.saturating_sub(1),
+            _ => {}
+        }
+        true
+    }
+}
+
 /// Strips the `CREATE DICTIONARY …` header from each (everything before the
 /// first `(`), then for the column block and each subsequent clause:
 ///   - normalises whitespace (collapses runs of whitespace to a single space)
@@ -216,52 +272,15 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
         // matching `)` that closes the column list.
         // Quote-aware: a `)` inside a quoted value (single, double, or backtick)
         // must not prematurely end the column block.
-        let mut depth = 0usize;
-        let mut in_single = false;
-        let mut in_double = false;
-        let mut in_backtick = false;
-        let mut skip_next_single = false;
+        let mut qs = QuoteDepthState::default();
         let mut end = start;
         for (off, ch) in ddl[start..].char_indices() {
-            if in_single {
-                if skip_next_single {
-                    skip_next_single = false;
-                    continue;
-                }
-                if ch == '\\' {
-                    skip_next_single = true;
-                    continue;
-                }
-                if ch == '\'' {
-                    in_single = false;
-                }
+            if !qs.advance(ch) {
                 continue;
             }
-            if in_double {
-                if ch == '"' {
-                    in_double = false;
-                }
-                continue;
-            }
-            if in_backtick {
-                if ch == '`' {
-                    in_backtick = false;
-                }
-                continue;
-            }
-            match ch {
-                '\'' => in_single = true,
-                '"' => in_double = true,
-                '`' => in_backtick = true,
-                '(' => depth += 1,
-                ')' => {
-                    depth = depth.saturating_sub(1);
-                    if depth == 0 {
-                        end = start + off + ')'.len_utf8();
-                        break;
-                    }
-                }
-                _ => {}
+            if ch == ')' && qs.depth == 0 {
+                end = start + off + ')'.len_utf8();
+                break;
             }
         }
 
@@ -290,73 +309,33 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
             from: usize,
             keywords: &[&'a str],
         ) -> Option<(usize, &'a str)> {
-            let mut depth: usize = 0;
-            let mut in_single_quote = false;
-            let mut in_double_quote = false;
-            let mut in_backtick = false;
-            let mut skip_next_single = false;
-
+            let mut qs = QuoteDepthState::default();
             for (i, c) in text[from..].char_indices() {
                 let abs_pos = from + i;
-
-                if in_single_quote {
-                    if skip_next_single {
-                        skip_next_single = false;
-                        continue;
-                    }
-                    if c == '\\' {
-                        skip_next_single = true;
-                        continue;
-                    }
-                    if c == '\'' {
-                        in_single_quote = false;
-                    }
+                if !qs.advance(c) {
                     continue;
                 }
-                if in_double_quote {
-                    if c == '"' {
-                        in_double_quote = false;
-                    }
-                    continue;
-                }
-                if in_backtick {
-                    if c == '`' {
-                        in_backtick = false;
-                    }
-                    continue;
-                }
-                match c {
-                    '(' => depth += 1,
-                    ')' => depth = depth.saturating_sub(1),
-                    // Track quotes/backticks at any depth so special chars inside
-                    // SOURCE credentials or backtick-quoted identifiers don't
-                    // corrupt depth tracking or trigger false keyword matches.
-                    '\'' => in_single_quote = true,
-                    '"' => in_double_quote = true,
-                    '`' => in_backtick = true,
-                    _ if depth == 0 => {
-                        for &kw in keywords {
-                            if text[abs_pos..].starts_with(kw) {
-                                // Require a word boundary before (start of text or non-alnum/underscore)
-                                let prev_ok = text[..abs_pos]
-                                    .chars()
-                                    .next_back()
-                                    .map(|p| !p.is_alphanumeric() && p != '_')
-                                    .unwrap_or(true);
-                                // Require a word boundary after (end or non-alnum/underscore)
-                                let after = abs_pos + kw.len();
-                                let next_ok = text[after..]
-                                    .chars()
-                                    .next()
-                                    .map(|n| !n.is_alphanumeric() && n != '_')
-                                    .unwrap_or(true);
-                                if prev_ok && next_ok {
-                                    return Some((abs_pos, kw));
-                                }
+                if qs.depth == 0 {
+                    for &kw in keywords {
+                        if text[abs_pos..].starts_with(kw) {
+                            // Require a word boundary before (start of text or non-alnum/underscore)
+                            let prev_ok = text[..abs_pos]
+                                .chars()
+                                .next_back()
+                                .map(|p| !p.is_alphanumeric() && p != '_')
+                                .unwrap_or(true);
+                            // Require a word boundary after (end or non-alnum/underscore)
+                            let after = abs_pos + kw.len();
+                            let next_ok = text[after..]
+                                .chars()
+                                .next()
+                                .map(|n| !n.is_alphanumeric() && n != '_')
+                                .unwrap_or(true);
+                            if prev_ok && next_ok {
+                                return Some((abs_pos, kw));
                             }
                         }
                     }
-                    _ => {}
                 }
             }
             None

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -163,11 +163,47 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
         }
 
         let col_block = ddl[start..end].to_string();
-        let clauses: Vec<String> = ddl[end..]
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty())
-            .collect();
+
+        // Parse top-level clauses by their keyword prefix rather than splitting by lines.
+        // This handles multi-line clauses like SOURCE(...) that may span multiple lines.
+        let remainder = ddl[end..].trim();
+        let mut clauses = Vec::new();
+        let clause_keywords = ["PRIMARY KEY", "SOURCE", "LAYOUT", "LIFETIME", "SETTINGS"];
+
+        let mut current_pos = 0;
+        while current_pos < remainder.len() {
+            // Find the next clause keyword
+            let next_clause_start = clause_keywords
+                .iter()
+                .filter_map(|&keyword| {
+                    remainder[current_pos..]
+                        .find(keyword)
+                        .map(|pos| (current_pos + pos, keyword))
+                })
+                .min_by_key(|(pos, _)| *pos);
+
+            if let Some((keyword_pos, keyword)) = next_clause_start {
+                // Find where this clause ends (either at the next keyword or end of string)
+                let clause_start = keyword_pos;
+                let clause_end = clause_keywords
+                    .iter()
+                    .filter_map(|&kw| {
+                        remainder[clause_start + keyword.len()..]
+                            .find(kw)
+                            .map(|pos| clause_start + keyword.len() + pos)
+                    })
+                    .min()
+                    .unwrap_or(remainder.len());
+
+                let clause_text = remainder[clause_start..clause_end].trim();
+                if !clause_text.is_empty() {
+                    clauses.push(clause_text.to_string());
+                }
+                current_pos = clause_end;
+            } else {
+                break;
+            }
+        }
 
         (col_block, clauses)
     }
@@ -2228,9 +2264,10 @@ mod tests {
 
         // Desired DDL generated from the infra map dict
         let desired_ddl = dict.to_create_if_not_exists_sql();
-        // Simulate a drifted CH definition (extra column added manually)
+        // Simulate a drifted CH definition: extra column added inside the column block
+        // (dictionary columns live inside the parens, not between ) and PRIMARY KEY)
         let drifted_ddl =
-            desired_ddl.replace("PRIMARY KEY", "    `extra_col` String,\nPRIMARY KEY");
+            desired_ddl.replace("`id` UInt64", "`id` UInt64,\n    `extra_col` String");
         // Simulate SHOW CREATE DICTIONARY output (no IF NOT EXISTS)
         let actual_ddl =
             drifted_ddl.replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY");

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -214,6 +214,7 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
             let mut depth: usize = 0;
             let mut in_single_quote = false;
             let mut in_double_quote = false;
+            let mut in_backtick = false;
 
             for (i, c) in text[from..].char_indices() {
                 let abs_pos = from + i;
@@ -230,13 +231,21 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
                     }
                     continue;
                 }
+                if in_backtick {
+                    if c == '`' {
+                        in_backtick = false;
+                    }
+                    continue;
+                }
                 match c {
                     '(' => depth += 1,
                     ')' => depth = depth.saturating_sub(1),
-                    // Track quotes at any depth so a ')' inside SOURCE(MYSQL(PASSWORD 'p@ss)word'))
-                    // does not corrupt the depth counter.
+                    // Track quotes/backticks at any depth so special chars inside
+                    // SOURCE credentials or backtick-quoted identifiers don't
+                    // corrupt depth tracking or trigger false keyword matches.
                     '\'' => in_single_quote = true,
                     '"' => in_double_quote = true,
+                    '`' => in_backtick = true,
                     _ if depth == 0 => {
                         for &kw in keywords {
                             if text[abs_pos..].starts_with(kw) {
@@ -2352,6 +2361,15 @@ mod tests {
         // A SOURCE credential containing ')' must not corrupt clause boundary detection.
         let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'p@ss)word' DB 'mydb' TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_backtick_keyword_identifier() {
+        // A column named `SOURCE` (a reserved keyword) in PRIMARY KEY must not be
+        // mistaken for the SOURCE clause — backtick-quoted identifiers must be skipped.
+        let actual = "CREATE DICTIONARY `db`.`d` (\n    `SOURCE` UInt64\n)\nPRIMARY KEY `SOURCE`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        let desired = "CREATE DICTIONARY IF NOT EXISTS `db`.`d` (\n    `SOURCE` UInt64\n)\nPRIMARY KEY `SOURCE`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(actual, desired));
     }
 
     // ─── Structural mismatch detection tests ───────────────────────────────

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -152,11 +152,12 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
 
         // Walk the DDL from the opening `(` tracking depth to find the
         // matching `)` that closes the column list.
-        // Quote-aware: a `)` inside a DEFAULT value like `DEFAULT ')'` must not
-        // prematurely end the column block.
+        // Quote-aware: a `)` inside a quoted value (single, double, or backtick)
+        // must not prematurely end the column block.
         let mut depth = 0usize;
         let mut in_single = false;
         let mut in_double = false;
+        let mut in_backtick = false;
         let mut end = start;
         for (off, ch) in ddl[start..].char_indices() {
             if in_single {
@@ -171,9 +172,16 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
                 }
                 continue;
             }
+            if in_backtick {
+                if ch == '`' {
+                    in_backtick = false;
+                }
+                continue;
+            }
             match ch {
                 '\'' => in_single = true,
                 '"' => in_double = true,
+                '`' => in_backtick = true,
                 '(' => depth += 1,
                 ')' => {
                     depth -= 1;
@@ -2360,6 +2368,14 @@ mod tests {
     fn test_dicts_ddl_equivalent_source_password_with_paren() {
         // A SOURCE credential containing ')' must not corrupt clause boundary detection.
         let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'p@ss)word' DB 'mydb' TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_column_backtick_identifier_with_paren() {
+        // A backtick-quoted column identifier containing ')' must not prematurely
+        // close the column block (e.g. `col)name` is unusual but valid ClickHouse DDL).
+        let ddl = "CREATE DICTIONARY `db`.`d` (\n    `col)name` UInt64\n)\nPRIMARY KEY `col)name`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         assert!(dicts_ddl_equivalent(ddl, ddl));
     }
 

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -134,6 +134,12 @@ fn normalize_database(db: &Option<String>, default_database: &str) -> String {
 ///     our generated DDL (LAYOUT before LIFETIME) and ClickHouse's SHOW CREATE
 ///     output (LIFETIME before LAYOUT)
 ///
+/// Recognised top-level clauses: `PRIMARY KEY`, `SOURCE`, `LAYOUT`, `LIFETIME`,
+/// `INVALIDATE_QUERY`, `SETTINGS`, `COMMENT`. Clause boundaries are detected with
+/// a depth/quote-aware scanner so keywords inside parentheses or quoted strings
+/// (e.g. an `INVALIDATE_QUERY` body containing the word `SETTINGS`) are not
+/// mistaken for clause starts.
+///
 /// **Limitation**: identifier quoting and type-alias differences (e.g.
 /// `Int64` vs `Int64`) are preserved as-is; ClickHouse and our generator both
 /// use backtick-quoted identifiers so these should agree in practice.
@@ -164,44 +170,102 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
 
         let col_block = ddl[start..end].to_string();
 
-        // Parse top-level clauses by their keyword prefix rather than splitting by lines.
-        // This handles multi-line clauses like SOURCE(...) that may span multiple lines.
+        // Parse top-level clauses by keyword prefix using a depth/quote-aware scanner.
+        // Skips keyword matches inside parentheses or quoted strings so that e.g.
+        // a SOURCE url containing "LIFETIME" or an INVALIDATE_QUERY containing "SETTINGS"
+        // never splits a clause incorrectly.
         let remainder = ddl[end..].trim();
-        let mut clauses = Vec::new();
-        let clause_keywords = ["PRIMARY KEY", "SOURCE", "LAYOUT", "LIFETIME", "SETTINGS"];
+        let clause_keywords: &[&str] = &[
+            "PRIMARY KEY",
+            "SOURCE",
+            "LAYOUT",
+            "LIFETIME",
+            "INVALIDATE_QUERY",
+            "SETTINGS",
+            "COMMENT",
+        ];
 
+        // Returns the byte position (in `text`) and keyword for the first
+        // top-level keyword occurrence at or after `from`, skipping over
+        // parenthesised content and single/double-quoted strings.
+        fn find_top_level_keyword<'a>(
+            text: &str,
+            from: usize,
+            keywords: &[&'a str],
+        ) -> Option<(usize, &'a str)> {
+            let mut depth: usize = 0;
+            let mut in_single_quote = false;
+            let mut in_double_quote = false;
+
+            for (i, c) in text[from..].char_indices() {
+                let abs_pos = from + i;
+
+                if in_single_quote {
+                    if c == '\'' {
+                        in_single_quote = false;
+                    }
+                    continue;
+                }
+                if in_double_quote {
+                    if c == '"' {
+                        in_double_quote = false;
+                    }
+                    continue;
+                }
+                match c {
+                    '(' => depth += 1,
+                    ')' => depth = depth.saturating_sub(1),
+                    '\'' if depth == 0 => in_single_quote = true,
+                    '"' if depth == 0 => in_double_quote = true,
+                    _ if depth == 0 => {
+                        for &kw in keywords {
+                            if text[abs_pos..].starts_with(kw) {
+                                // Require a word boundary before (start or non-alnum/underscore)
+                                let prev_ok = abs_pos == from
+                                    || text[..abs_pos]
+                                        .chars()
+                                        .next_back()
+                                        .map(|p| !p.is_alphanumeric() && p != '_')
+                                        .unwrap_or(true);
+                                // Require a word boundary after (end or non-alnum/underscore)
+                                let after = abs_pos + kw.len();
+                                let next_ok = text[after..]
+                                    .chars()
+                                    .next()
+                                    .map(|n| !n.is_alphanumeric() && n != '_')
+                                    .unwrap_or(true);
+                                if prev_ok && next_ok {
+                                    return Some((abs_pos, kw));
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            None
+        }
+
+        let mut clauses = Vec::new();
         let mut current_pos = 0;
         while current_pos < remainder.len() {
-            // Find the next clause keyword
-            let next_clause_start = clause_keywords
-                .iter()
-                .filter_map(|&keyword| {
-                    remainder[current_pos..]
-                        .find(keyword)
-                        .map(|pos| (current_pos + pos, keyword))
-                })
-                .min_by_key(|(pos, _)| *pos);
-
-            if let Some((keyword_pos, keyword)) = next_clause_start {
-                // Find where this clause ends (either at the next keyword or end of string)
-                let clause_start = keyword_pos;
-                let clause_end = clause_keywords
-                    .iter()
-                    .filter_map(|&kw| {
-                        remainder[clause_start + keyword.len()..]
-                            .find(kw)
-                            .map(|pos| clause_start + keyword.len() + pos)
-                    })
-                    .min()
+            match find_top_level_keyword(remainder, current_pos, clause_keywords) {
+                None => break,
+                Some((clause_start, keyword)) => {
+                    let clause_end = find_top_level_keyword(
+                        remainder,
+                        clause_start + keyword.len(),
+                        clause_keywords,
+                    )
+                    .map(|(pos, _)| pos)
                     .unwrap_or(remainder.len());
 
-                let clause_text = remainder[clause_start..clause_end].trim();
-                if !clause_text.is_empty() {
-                    clauses.push(clause_text.to_string());
+                    let clause_text = remainder[clause_start..clause_end].trim();
+                    if !clause_text.is_empty() {
+                        clauses.push(clause_text.to_string());
+                    }
+                    current_pos = clause_end;
                 }
-                current_pos = clause_end;
-            } else {
-                break;
             }
         }
 

--- a/apps/framework-cli/src/framework/core/infra_reality_checker.rs
+++ b/apps/framework-cli/src/framework/core/infra_reality_checker.rs
@@ -220,9 +220,18 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
         let mut in_single = false;
         let mut in_double = false;
         let mut in_backtick = false;
+        let mut skip_next_single = false;
         let mut end = start;
         for (off, ch) in ddl[start..].char_indices() {
             if in_single {
+                if skip_next_single {
+                    skip_next_single = false;
+                    continue;
+                }
+                if ch == '\\' {
+                    skip_next_single = true;
+                    continue;
+                }
                 if ch == '\'' {
                     in_single = false;
                 }
@@ -285,11 +294,20 @@ fn dicts_ddl_equivalent(actual_ddl: &str, desired_ddl: &str) -> bool {
             let mut in_single_quote = false;
             let mut in_double_quote = false;
             let mut in_backtick = false;
+            let mut skip_next_single = false;
 
             for (i, c) in text[from..].char_indices() {
                 let abs_pos = from + i;
 
                 if in_single_quote {
+                    if skip_next_single {
+                        skip_next_single = false;
+                        continue;
+                    }
+                    if c == '\\' {
+                        skip_next_single = true;
+                        continue;
+                    }
                     if c == '\'' {
                         in_single_quote = false;
                     }
@@ -2436,6 +2454,24 @@ mod tests {
     fn test_dicts_ddl_equivalent_source_password_with_paren() {
         // A SOURCE credential containing ')' must not corrupt clause boundary detection.
         let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'p@ss)word' DB 'mydb' TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_column_default_escaped_quote_with_paren() {
+        // A column DEFAULT whose value contains a backslash-escaped single quote
+        // followed by ')' must not prematurely close the column block. Without the
+        // backslash-skip fix the scanner exits in_single at the escaped quote and
+        // then sees ')' outside any string, corrupting depth tracking.
+        let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64,\n    `status` String DEFAULT '\\')'  \n)\nPRIMARY KEY `id`\nSOURCE(CLICKHOUSE(TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
+        assert!(dicts_ddl_equivalent(ddl, ddl));
+    }
+
+    #[test]
+    fn test_dicts_ddl_equivalent_source_password_escaped_quote_with_paren() {
+        // A SOURCE credential containing a backslash-escaped single quote followed
+        // by ')' must not corrupt clause boundary detection in find_top_level_keyword.
+        let ddl = "CREATE DICTIONARY `db`.`d` (\n    `id` UInt64\n)\nPRIMARY KEY `id`\nSOURCE(MYSQL(HOST 'localhost' PORT 3306 USER 'user' PASSWORD 'p@ss\\')word' DB 'mydb' TABLE 'src'))\nLAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)";
         assert!(dicts_ddl_equivalent(ddl, ddl));
     }
 

--- a/apps/framework-cli/src/framework/core/infrastructure/dictionary.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/dictionary.rs
@@ -850,7 +850,7 @@ impl DictionaryLifetime {
     pub fn to_ddl(&self) -> String {
         match self {
             DictionaryLifetime::Static => "LIFETIME(0)".to_string(),
-            DictionaryLifetime::Single { seconds } => format!("LIFETIME({})", seconds),
+            DictionaryLifetime::Single { seconds } => format!("LIFETIME(MIN 0 MAX {})", seconds),
             DictionaryLifetime::Range(r) => {
                 format!("LIFETIME(MIN {} MAX {})", r.min, r.max)
             }
@@ -2003,7 +2003,7 @@ mod tests {
     fn test_single_lifetime_ddl() {
         assert_eq!(
             DictionaryLifetime::Single { seconds: 3600 }.to_ddl(),
-            "LIFETIME(3600)"
+            "LIFETIME(MIN 0 MAX 3600)"
         );
     }
 

--- a/apps/framework-cli/src/framework/core/infrastructure/dictionary.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/dictionary.rs
@@ -850,7 +850,7 @@ impl DictionaryLifetime {
     pub fn to_ddl(&self) -> String {
         match self {
             DictionaryLifetime::Static => "LIFETIME(0)".to_string(),
-            DictionaryLifetime::Single { seconds } => format!("LIFETIME(MIN 0 MAX {})", seconds),
+            DictionaryLifetime::Single { seconds } => format!("LIFETIME({})", seconds),
             DictionaryLifetime::Range(r) => {
                 format!("LIFETIME(MIN {} MAX {})", r.min, r.max)
             }
@@ -2003,7 +2003,7 @@ mod tests {
     fn test_single_lifetime_ddl() {
         assert_eq!(
             DictionaryLifetime::Single { seconds: 3600 }.to_ddl(),
-            "LIFETIME(MIN 0 MAX 3600)"
+            "LIFETIME(3600)"
         );
     }
 

--- a/apps/framework-cli/src/framework/core/mod.rs
+++ b/apps/framework-cli/src/framework/core/mod.rs
@@ -37,3 +37,6 @@ pub mod plan_validator;
 pub mod prompt_bridge;
 pub mod state_storage;
 pub mod version_bump;
+
+#[cfg(test)]
+pub(crate) mod test_helpers;

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -2032,10 +2032,9 @@ mod tests {
             .unwrap()
             .to_create_if_not_exists_sql();
         // Drifted DDL: LIFETIME changed from 300 to 600
-        // Note: DictionaryLifetime::Single generates "LIFETIME(300)", not "LIFETIME(MIN 0 MAX 300)"
         let drifted_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
-            .replace("LIFETIME(300)", "LIFETIME(600)");
+            .replace("LIFETIME(MIN 0 MAX 300)", "LIFETIME(MIN 0 MAX 600)");
 
         let mut ddls = std::collections::HashMap::new();
         ddls.insert(format!("{}\x00{}", project_db, dict_name), drifted_ddl);

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -629,7 +629,31 @@ pub async fn reconcile_with_reality<T: OlapOperations + Sync>(
         );
     }
 
-    // Dictionaries have no mismatched entries (presence/absence only).
+    // Remove structurally mismatched dicts from the reconciled map so the diff
+    // against the target produces an Added change.  execute_create_dictionary uses
+    // CREATE OR REPLACE DICTIONARY, which overwrites the drifted CH definition.
+    for change in discrepancies.mismatched_dictionaries {
+        if let OlapChange::OlapDictionary(Change::Updated { before, .. }) = change {
+            let default_db = &reconciled_map.default_database;
+            let dict_db = before.database.as_deref().unwrap_or(default_db.as_str());
+            let dict_name = &before.name;
+            let key = reconciled_map
+                .olap_dictionaries
+                .iter()
+                .find(|(_, d)| {
+                    d.name == *dict_name
+                        && d.database.as_deref().unwrap_or(default_db.as_str()) == dict_db
+                })
+                .map(|(k, _)| k.clone());
+            if let Some(k) = key {
+                debug!(
+                    "Removing structurally mismatched dictionary '{}' to force reconciliation",
+                    k
+                );
+                reconciled_map.olap_dictionaries.remove(&k);
+            }
+        }
+    }
 
     info!("Infrastructure map successfully reconciled with actual database state");
     Ok(reconciled_map)
@@ -962,6 +986,8 @@ mod tests {
         tables: Vec<Table>,
         sql_resources: Vec<SqlResource>,
         dictionaries: Vec<String>,
+        /// DDL returned by show_create_dictionary, keyed by "db\x00name"
+        dictionary_ddls: std::collections::HashMap<String, String>,
     }
 
     #[async_trait]
@@ -994,6 +1020,15 @@ mod tests {
 
         async fn list_dictionaries(&self, _db_name: &str) -> Result<Vec<String>, OlapChangesError> {
             Ok(self.dictionaries.clone())
+        }
+
+        async fn show_create_dictionary(
+            &self,
+            db_name: &str,
+            dict_name: &str,
+        ) -> Result<String, OlapChangesError> {
+            let key = format!("{}\x00{}", db_name, dict_name);
+            Ok(self.dictionary_ddls.get(&key).cloned().unwrap_or_default())
         }
     }
 
@@ -1091,6 +1126,7 @@ mod tests {
             tables: vec![table.clone()],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create empty infrastructure map (no tables)
@@ -1131,6 +1167,7 @@ mod tests {
                 tables: vec![table.clone()],
                 sql_resources: vec![],
                 dictionaries: vec![],
+                dictionary_ddls: std::collections::HashMap::new(),
             },
         )
         .await
@@ -1160,6 +1197,7 @@ mod tests {
                 tables: vec![table.clone()],
                 sql_resources: vec![],
                 dictionaries: vec![],
+                dictionary_ddls: std::collections::HashMap::new(),
             },
         )
         .await
@@ -1179,6 +1217,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create infrastructure map with one table
@@ -1208,6 +1247,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let filter = ReconciliationFilter {
@@ -1263,6 +1303,7 @@ mod tests {
             }],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create infrastructure map with the infra table (no extra column)
@@ -1295,6 +1336,7 @@ mod tests {
             }],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let filter = ReconciliationFilter {
@@ -1331,6 +1373,7 @@ mod tests {
             tables: vec![table.clone()],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create infrastructure map with the same table
@@ -1359,6 +1402,7 @@ mod tests {
             tables: vec![table.clone()],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let filter = ReconciliationFilter {
@@ -1425,6 +1469,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let empty_filter = ReconciliationFilter {
@@ -1489,6 +1534,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let empty_filter = ReconciliationFilter {
@@ -1588,6 +1634,7 @@ mod tests {
             tables: vec![table_from_reality],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create infrastructure map with the table including cluster_name
@@ -1654,6 +1701,7 @@ mod tests {
             tables: vec![reality_table.clone()],
             sql_resources: vec![],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create infrastructure map with the infra table
@@ -1716,6 +1764,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![sql_resource.clone()],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let infra_map = InfrastructureMap::default();
@@ -1769,6 +1818,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![view_a.clone(), view_b.clone()],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         let infra_map = InfrastructureMap::default();
@@ -1828,6 +1878,7 @@ mod tests {
             tables: vec![],
             sql_resources: vec![reality_view.clone()],
             dictionaries: vec![],
+            dictionary_ddls: std::collections::HashMap::new(),
         };
 
         // Create infra map with the existing view
@@ -2147,6 +2198,167 @@ mod tests {
         assert!(
             de1 < cu,
             "Events_1_0 drop ({de1}) must come before Users_1_0 create ({cu})"
+        );
+    }
+
+    // ─── Dictionary reconciliation tests ────────────────────────────────────
+
+    fn make_test_dict(
+        name: &str,
+    ) -> crate::framework::core::infrastructure::dictionary::OlapDictionary {
+        use crate::framework::core::infrastructure::dictionary::{
+            DictionaryColumn, DictionaryLayout, DictionaryLifetime, DictionarySource,
+            DictionaryTableSource, OlapDictionary,
+        };
+        use crate::framework::core::partial_infrastructure_map::LifeCycle;
+        OlapDictionary {
+            name: name.to_string(),
+            database: None,
+            cluster_name: None,
+            source: DictionarySource::Table(DictionaryTableSource {
+                table: "src".to_string(),
+                database: None,
+                where_clause: None,
+                invalidate_query: None,
+            }),
+            primary_key: vec!["id".to_string()],
+            columns: vec![DictionaryColumn {
+                name: "id".to_string(),
+                type_string: "UInt64".to_string(),
+                default_value: None,
+                expression: None,
+                is_injective: None,
+                is_hierarchical: None,
+                is_object_id: None,
+                comment: None,
+            }],
+            layout: DictionaryLayout::Hashed {
+                initial_array_size: None,
+                max_load_factor: None,
+            },
+            lifetime: DictionaryLifetime::Single { seconds: 300 },
+            invalidate_query: None,
+            settings: std::collections::HashMap::new(),
+            comment: None,
+            life_cycle: LifeCycle::FullyManaged,
+            version: None,
+            metadata: None,
+        }
+    }
+
+    fn make_infra_map_with_dict(
+        dict_name: &str,
+    ) -> crate::framework::core::infrastructure_map::InfrastructureMap {
+        use crate::framework::core::infrastructure_map::InfrastructureMap;
+        let mut map = InfrastructureMap::empty_from_project(&create_test_project());
+        let dict = make_test_dict(dict_name);
+        let key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict_name);
+        map.olap_dictionaries.insert(key, dict);
+        map
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_mismatched_dict_removed_from_map() {
+        // A dict that exists in reality but with drifted DDL should be removed
+        // from the reconciled map so that the subsequent diff generates an Added change.
+        let project = create_test_project();
+        let infra_map = make_infra_map_with_dict("dict_foo");
+        let dict_name = "dict_foo";
+        let project_db = &project.clickhouse_config.db_name; // "test"
+
+        // The desired DDL (from the map)
+        let desired_ddl = infra_map
+            .olap_dictionaries
+            .values()
+            .next()
+            .unwrap()
+            .to_create_if_not_exists_sql();
+        // Drifted DDL: LIFETIME changed from 300 to 600
+        // Note: DictionaryLifetime::Single generates "LIFETIME(300)", not "LIFETIME(MIN 0 MAX 300)"
+        let drifted_ddl = desired_ddl
+            .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
+            .replace("LIFETIME(300)", "LIFETIME(600)");
+
+        let mut ddls = std::collections::HashMap::new();
+        ddls.insert(format!("{}\x00{}", project_db, dict_name), drifted_ddl);
+
+        let mock_client = MockOlapClient {
+            tables: vec![],
+            sql_resources: vec![],
+            dictionaries: vec![dict_name.to_string()],
+            dictionary_ddls: ddls,
+        };
+
+        let filter = ReconciliationFilter {
+            table_ids: HashSet::new(),
+            sql_resource_ids: HashSet::new(),
+            materialized_view_ids: HashSet::new(),
+            view_ids: HashSet::new(),
+            select_row_policy_ids: HashSet::new(),
+            dictionary_ids: HashSet::new(),
+        };
+        let reconciled = reconcile_with_reality(&project, &infra_map, &filter, mock_client)
+            .await
+            .unwrap();
+
+        // The mismatched dict must be absent from the reconciled map so the diff
+        // against the target map will generate an Added change.
+        assert!(
+            reconciled.olap_dictionaries.is_empty(),
+            "mismatched dict should be removed from reconciled map, got: {:?}",
+            reconciled.olap_dictionaries.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_matched_dict_stays_in_map() {
+        // A dict whose DDL matches reality must remain in the reconciled map.
+        let project = create_test_project();
+        let infra_map = make_infra_map_with_dict("dict_bar");
+        let dict_name = "dict_bar";
+        let project_db = &project.clickhouse_config.db_name;
+
+        let desired_ddl = infra_map
+            .olap_dictionaries
+            .values()
+            .next()
+            .unwrap()
+            .to_create_if_not_exists_sql();
+        // Simulate SHOW CREATE DICTIONARY: same content, LAYOUT/LIFETIME swapped, no IF NOT EXISTS
+        // Note: DictionaryLifetime::Single generates "LIFETIME(300)", not "LIFETIME(MIN 0 MAX 300)"
+        let actual_ddl = desired_ddl
+            .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
+            .replace(
+                "LAYOUT(HASHED())\nLIFETIME(300)",
+                "LIFETIME(300)\nLAYOUT(HASHED())",
+            );
+
+        let mut ddls = std::collections::HashMap::new();
+        ddls.insert(format!("{}\x00{}", project_db, dict_name), actual_ddl);
+
+        let mock_client = MockOlapClient {
+            tables: vec![],
+            sql_resources: vec![],
+            dictionaries: vec![dict_name.to_string()],
+            dictionary_ddls: ddls,
+        };
+
+        let filter = ReconciliationFilter {
+            table_ids: HashSet::new(),
+            sql_resource_ids: HashSet::new(),
+            materialized_view_ids: HashSet::new(),
+            view_ids: HashSet::new(),
+            select_row_policy_ids: HashSet::new(),
+            dictionary_ids: HashSet::new(),
+        };
+        let reconciled = reconcile_with_reality(&project, &infra_map, &filter, mock_client)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            reconciled.olap_dictionaries.len(),
+            1,
+            "matched dict should remain in reconciled map"
         );
     }
 }

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -2081,12 +2081,11 @@ mod tests {
             .unwrap()
             .to_create_if_not_exists_sql();
         // Simulate SHOW CREATE DICTIONARY: same content, LAYOUT/LIFETIME swapped, no IF NOT EXISTS
-        // Note: DictionaryLifetime::Single generates "LIFETIME(300)", not "LIFETIME(MIN 0 MAX 300)"
         let actual_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
             .replace(
-                "LAYOUT(HASHED())\nLIFETIME(300)",
-                "LIFETIME(300)\nLAYOUT(HASHED())",
+                "LAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)",
+                "LIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())",
             );
 
         let mut ddls = std::collections::HashMap::new();

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -2031,10 +2031,11 @@ mod tests {
             .next()
             .unwrap()
             .to_create_if_not_exists_sql();
-        // Drifted DDL: LIFETIME changed from 300 to 600
+        // Drifted DDL: simulate SHOW CREATE where LIFETIME changed from 300 to 600.
+        // ClickHouse returns the long form LIFETIME(MIN 0 MAX N), so drifted DDL uses that format.
         let drifted_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
-            .replace("LIFETIME(MIN 0 MAX 300)", "LIFETIME(MIN 0 MAX 600)");
+            .replace("LIFETIME(300)", "LIFETIME(MIN 0 MAX 600)");
 
         let mut ddls = std::collections::HashMap::new();
         ddls.insert(format!("{}\x00{}", project_db, dict_name), drifted_ddl);
@@ -2080,11 +2081,12 @@ mod tests {
             .next()
             .unwrap()
             .to_create_if_not_exists_sql();
-        // Simulate SHOW CREATE DICTIONARY: same content, LAYOUT/LIFETIME swapped, no IF NOT EXISTS
+        // Simulate SHOW CREATE DICTIONARY: strip IF NOT EXISTS, swap LAYOUT/LIFETIME order,
+        // and normalize LIFETIME(N) → LIFETIME(MIN 0 MAX N) as ClickHouse does.
         let actual_ddl = desired_ddl
             .replace("CREATE DICTIONARY IF NOT EXISTS", "CREATE DICTIONARY")
             .replace(
-                "LAYOUT(HASHED())\nLIFETIME(MIN 0 MAX 300)",
+                "LAYOUT(HASHED())\nLIFETIME(300)",
                 "LIFETIME(MIN 0 MAX 300)\nLAYOUT(HASHED())",
             );
 

--- a/apps/framework-cli/src/framework/core/plan.rs
+++ b/apps/framework-cli/src/framework/core/plan.rs
@@ -968,153 +968,9 @@ pub async fn plan_changes(
 mod tests {
     use super::*;
     use crate::framework::core::infrastructure::sql_resource::SqlResource;
-    use crate::framework::core::infrastructure::table::{
-        Column, ColumnType, IntType, OrderBy, Table,
-    };
-    use crate::framework::core::infrastructure_map::{PrimitiveSignature, PrimitiveTypes};
-    use crate::framework::core::partial_infrastructure_map::LifeCycle;
-    use crate::framework::versions::Version;
-    use crate::infrastructure::olap::clickhouse::queries::ClickhouseEngine;
-    use crate::infrastructure::olap::clickhouse::TableWithUnsupportedType;
-    use crate::infrastructure::olap::OlapChangesError;
-    use crate::infrastructure::olap::OlapOperations;
-    use async_trait::async_trait;
+    use crate::framework::core::infrastructure::table::{Column, ColumnType, Table};
+    use crate::framework::core::test_helpers::*;
     use protobuf::Message;
-
-    // Mock OLAP client for testing
-    struct MockOlapClient {
-        tables: Vec<Table>,
-        sql_resources: Vec<SqlResource>,
-        dictionaries: Vec<String>,
-        /// DDL returned by show_create_dictionary, keyed by "db\x00name"
-        dictionary_ddls: std::collections::HashMap<String, String>,
-    }
-
-    #[async_trait]
-    impl OlapOperations for MockOlapClient {
-        async fn list_tables(
-            &self,
-            _db_name: &str,
-            _project: &Project,
-        ) -> Result<(Vec<Table>, Vec<TableWithUnsupportedType>), OlapChangesError> {
-            Ok((self.tables.clone(), vec![]))
-        }
-
-        async fn list_sql_resources(
-            &self,
-            _db_name: &str,
-            _default_database: &str,
-        ) -> Result<Vec<SqlResource>, OlapChangesError> {
-            Ok(self.sql_resources.clone())
-        }
-
-        async fn list_row_policies(
-            &self,
-            _db_name: &str,
-        ) -> Result<
-            Vec<crate::framework::core::infrastructure::select_row_policy::SelectRowPolicy>,
-            OlapChangesError,
-        > {
-            Ok(vec![])
-        }
-
-        async fn list_dictionaries(&self, _db_name: &str) -> Result<Vec<String>, OlapChangesError> {
-            Ok(self.dictionaries.clone())
-        }
-
-        async fn show_create_dictionary(
-            &self,
-            db_name: &str,
-            dict_name: &str,
-        ) -> Result<String, OlapChangesError> {
-            let key = format!("{}\x00{}", db_name, dict_name);
-            Ok(self.dictionary_ddls.get(&key).cloned().unwrap_or_default())
-        }
-    }
-
-    // Helper function to create a test table
-    fn create_test_table(name: &str) -> Table {
-        Table {
-            name: name.to_string(),
-            columns: vec![Column {
-                name: "id".to_string(),
-                data_type: ColumnType::Int(IntType::Int64),
-                required: true,
-                unique: true,
-                primary_key: true,
-                default: None,
-                annotations: vec![],
-                comment: None,
-                ttl: None,
-                codec: None,
-                materialized: None,
-                alias: None,
-            }],
-            order_by: OrderBy::Fields(vec!["id".to_string()]),
-            partition_by: None,
-            sample_by: None,
-            engine: ClickhouseEngine::MergeTree,
-            version: Some(Version::from_string("1.0.0".to_string())),
-            source_primitive: PrimitiveSignature {
-                name: "test".to_string(),
-                primitive_type: PrimitiveTypes::DataModel,
-            },
-            metadata: None,
-            life_cycle: LifeCycle::FullyManaged,
-            engine_params_hash: None,
-            table_settings_hash: None,
-            table_settings: None,
-            indexes: vec![],
-            projections: vec![],
-            constraints: vec![],
-            database: None,
-            table_ttl_setting: None,
-            cluster_name: None,
-            primary_key_expression: None,
-            seed_filter: Default::default(),
-        }
-    }
-
-    // Helper function to create a test project
-    fn create_test_project() -> Project {
-        Project {
-            language: crate::framework::languages::SupportedLanguages::Typescript,
-            redpanda_config: crate::infrastructure::stream::kafka::models::KafkaConfig::default(),
-            clickhouse_config: crate::infrastructure::olap::clickhouse::ClickHouseConfig {
-                db_name: "test".to_string(),
-                user: "test".to_string(),
-                password: "test".to_string(),
-                use_ssl: false,
-                host: "localhost".to_string(),
-                host_port: 18123,
-                native_port: 9000,
-                ..Default::default()
-            },
-            http_server_config: crate::cli::local_webserver::LocalWebserverConfig::default(),
-            redis_config: crate::infrastructure::redis::redis_client::RedisConfig::default(),
-            git_config: crate::utilities::git::GitConfig::default(),
-            temporal_config:
-                crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
-            state_config: crate::project::StateConfig::default(),
-            migration_config: crate::project::MigrationConfig::default(),
-            language_project_config: crate::project::LanguageProjectConfig::default(),
-            project_location: std::path::PathBuf::new(),
-            is_production: false,
-            log_payloads: false,
-            supported_old_versions: std::collections::HashMap::new(),
-            jwt: None,
-            authentication: crate::project::AuthenticationConfig::default(),
-
-            features: crate::project::ProjectFeatures::default(),
-            load_infra: None,
-
-            typescript_config: crate::project::TypescriptConfig::default(),
-            source_dir: crate::project::default_source_dir(),
-            docker_config: crate::project::DockerConfig::default(),
-            watcher_config: crate::cli::watcher::WatcherConfig::default(),
-            dev: crate::project::DevConfig::default(),
-        }
-    }
 
     #[tokio::test]
     async fn test_reconcile_with_reality_unmapped_table() {
@@ -1124,9 +980,7 @@ mod tests {
         // Create mock OLAP client with one table
         let mock_client = MockOlapClient {
             tables: vec![table.clone()],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create empty infrastructure map (no tables)
@@ -1165,9 +1019,7 @@ mod tests {
             &empty_filter,
             MockOlapClient {
                 tables: vec![table.clone()],
-                sql_resources: vec![],
-                dictionaries: vec![],
-                dictionary_ddls: std::collections::HashMap::new(),
+                ..Default::default()
             },
         )
         .await
@@ -1195,9 +1047,7 @@ mod tests {
             &filter_with_table,
             MockOlapClient {
                 tables: vec![table.clone()],
-                sql_resources: vec![],
-                dictionaries: vec![],
-                dictionary_ddls: std::collections::HashMap::new(),
+                ..Default::default()
             },
         )
         .await
@@ -1213,12 +1063,7 @@ mod tests {
         let table = create_test_table("missing_table");
 
         // Create mock OLAP client with no tables
-        let mock_client = MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
-        };
+        let mock_client = MockOlapClient::default();
 
         // Create infrastructure map with one table
         let mut infra_map = InfrastructureMap::default();
@@ -1243,12 +1088,7 @@ mod tests {
         assert_eq!(discrepancies.missing_tables[0], "missing_table");
 
         // Create another mock client for the reconciliation
-        let reconcile_mock_client = MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
-        };
+        let reconcile_mock_client = MockOlapClient::default();
 
         let filter = ReconciliationFilter {
             table_ids: HashSet::new(),
@@ -1301,9 +1141,7 @@ mod tests {
                 database: Some(db_name.clone()),
                 ..actual_table.clone()
             }],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create infrastructure map with the infra table (no extra column)
@@ -1334,9 +1172,7 @@ mod tests {
                 database: Some(db_name.clone()),
                 ..actual_table.clone()
             }],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         let filter = ReconciliationFilter {
@@ -1371,9 +1207,7 @@ mod tests {
         // Create mock OLAP client with the table
         let mock_client = MockOlapClient {
             tables: vec![table.clone()],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create infrastructure map with the same table
@@ -1400,9 +1234,7 @@ mod tests {
         // Create another mock client for reconciliation
         let reconcile_mock_client = MockOlapClient {
             tables: vec![table.clone()],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         let filter = ReconciliationFilter {
@@ -1465,12 +1297,7 @@ mod tests {
         );
 
         // Also verify that reconciliation preserves the database name
-        let mock_client = MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
-        };
+        let mock_client = MockOlapClient::default();
 
         let empty_filter = ReconciliationFilter {
             table_ids: HashSet::new(),
@@ -1530,12 +1357,7 @@ mod tests {
         );
 
         // Now test reconciliation - this is where the fix should be applied
-        let mock_client = MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
-        };
+        let mock_client = MockOlapClient::default();
 
         let empty_filter = ReconciliationFilter {
             table_ids: HashSet::new(),
@@ -1632,9 +1454,7 @@ mod tests {
 
         let mock_client = MockOlapClient {
             tables: vec![table_from_reality],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create infrastructure map with the table including cluster_name
@@ -1699,9 +1519,7 @@ mod tests {
         // Create mock OLAP client with the reality table
         let mock_client = MockOlapClient {
             tables: vec![reality_table.clone()],
-            sql_resources: vec![],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create infrastructure map with the infra table
@@ -1761,10 +1579,8 @@ mod tests {
         };
 
         let mock_client = MockOlapClient {
-            tables: vec![],
             sql_resources: vec![sql_resource.clone()],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         let infra_map = InfrastructureMap::default();
@@ -1815,10 +1631,8 @@ mod tests {
         };
 
         let mock_client = MockOlapClient {
-            tables: vec![],
             sql_resources: vec![view_a.clone(), view_b.clone()],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         let infra_map = InfrastructureMap::default();
@@ -1875,10 +1689,8 @@ mod tests {
         };
 
         let mock_client = MockOlapClient {
-            tables: vec![],
             sql_resources: vec![reality_view.clone()],
-            dictionaries: vec![],
-            dictionary_ddls: std::collections::HashMap::new(),
+            ..Default::default()
         };
 
         // Create infra map with the existing view
@@ -2203,60 +2015,6 @@ mod tests {
 
     // ─── Dictionary reconciliation tests ────────────────────────────────────
 
-    fn make_test_dict(
-        name: &str,
-    ) -> crate::framework::core::infrastructure::dictionary::OlapDictionary {
-        use crate::framework::core::infrastructure::dictionary::{
-            DictionaryColumn, DictionaryLayout, DictionaryLifetime, DictionarySource,
-            DictionaryTableSource, OlapDictionary,
-        };
-        use crate::framework::core::partial_infrastructure_map::LifeCycle;
-        OlapDictionary {
-            name: name.to_string(),
-            database: None,
-            cluster_name: None,
-            source: DictionarySource::Table(DictionaryTableSource {
-                table: "src".to_string(),
-                database: None,
-                where_clause: None,
-                invalidate_query: None,
-            }),
-            primary_key: vec!["id".to_string()],
-            columns: vec![DictionaryColumn {
-                name: "id".to_string(),
-                type_string: "UInt64".to_string(),
-                default_value: None,
-                expression: None,
-                is_injective: None,
-                is_hierarchical: None,
-                is_object_id: None,
-                comment: None,
-            }],
-            layout: DictionaryLayout::Hashed {
-                initial_array_size: None,
-                max_load_factor: None,
-            },
-            lifetime: DictionaryLifetime::Single { seconds: 300 },
-            invalidate_query: None,
-            settings: std::collections::HashMap::new(),
-            comment: None,
-            life_cycle: LifeCycle::FullyManaged,
-            version: None,
-            metadata: None,
-        }
-    }
-
-    fn make_infra_map_with_dict(
-        dict_name: &str,
-    ) -> crate::framework::core::infrastructure_map::InfrastructureMap {
-        use crate::framework::core::infrastructure_map::InfrastructureMap;
-        let mut map = InfrastructureMap::empty_from_project(&create_test_project());
-        let dict = make_test_dict(dict_name);
-        let key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict_name);
-        map.olap_dictionaries.insert(key, dict);
-        map
-    }
-
     #[tokio::test]
     async fn test_reconcile_mismatched_dict_removed_from_map() {
         // A dict that exists in reality but with drifted DDL should be removed
@@ -2283,10 +2041,9 @@ mod tests {
         ddls.insert(format!("{}\x00{}", project_db, dict_name), drifted_ddl);
 
         let mock_client = MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
             dictionaries: vec![dict_name.to_string()],
             dictionary_ddls: ddls,
+            ..Default::default()
         };
 
         let filter = ReconciliationFilter {
@@ -2337,10 +2094,9 @@ mod tests {
         ddls.insert(format!("{}\x00{}", project_db, dict_name), actual_ddl);
 
         let mock_client = MockOlapClient {
-            tables: vec![],
-            sql_resources: vec![],
             dictionaries: vec![dict_name.to_string()],
             dictionary_ddls: ddls,
+            ..Default::default()
         };
 
         let filter = ReconciliationFilter {

--- a/apps/framework-cli/src/framework/core/test_helpers.rs
+++ b/apps/framework-cli/src/framework/core/test_helpers.rs
@@ -1,0 +1,261 @@
+// Test utilities shared across framework::core test modules.
+// Exposed via `#[cfg(test)] pub(crate) mod test_helpers;` in mod.rs so this
+// file is only compiled during test builds.
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::framework::core::infrastructure::consumption_webserver::ConsumptionApiWebServer;
+use crate::framework::core::infrastructure::dictionary::{
+    DictionaryColumn, DictionaryLayout, DictionaryLifetime, DictionarySource,
+    DictionaryTableSource, OlapDictionary,
+};
+use crate::framework::core::infrastructure::select_row_policy::SelectRowPolicy;
+use crate::framework::core::infrastructure::sql_resource::SqlResource;
+use crate::framework::core::infrastructure::table::{Column, ColumnType, IntType, OrderBy, Table};
+use crate::framework::core::infrastructure_map::{
+    InfrastructureMap, PrimitiveSignature, PrimitiveTypes,
+};
+use crate::framework::core::partial_infrastructure_map::LifeCycle;
+use crate::framework::versions::Version;
+use crate::infrastructure::olap::clickhouse::config::DEFAULT_DATABASE_NAME;
+use crate::infrastructure::olap::clickhouse::queries::ClickhouseEngine;
+use crate::infrastructure::olap::clickhouse::TableWithUnsupportedType;
+use crate::infrastructure::olap::{OlapChangesError, OlapOperations};
+use crate::project::Project;
+
+// ─── Mock OLAP client ────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct MockOlapClient {
+    pub tables: Vec<Table>,
+    pub sql_resources: Vec<SqlResource>,
+    pub row_policies: Vec<SelectRowPolicy>,
+    pub dictionaries: Vec<String>,
+    /// DDL returned by `show_create_dictionary`, keyed by `"db\x00name"`
+    pub dictionary_ddls: HashMap<String, String>,
+}
+
+impl MockOlapClient {
+    pub fn ddl_key(db: &str, name: &str) -> String {
+        format!("{}\x00{}", db, name)
+    }
+}
+
+#[async_trait]
+impl OlapOperations for MockOlapClient {
+    async fn list_tables(
+        &self,
+        _db_name: &str,
+        _project: &Project,
+    ) -> Result<(Vec<Table>, Vec<TableWithUnsupportedType>), OlapChangesError> {
+        Ok((self.tables.clone(), vec![]))
+    }
+
+    async fn list_sql_resources(
+        &self,
+        _db_name: &str,
+        _default_database: &str,
+    ) -> Result<Vec<SqlResource>, OlapChangesError> {
+        Ok(self.sql_resources.clone())
+    }
+
+    async fn list_row_policies(
+        &self,
+        _db_name: &str,
+    ) -> Result<Vec<SelectRowPolicy>, OlapChangesError> {
+        Ok(self.row_policies.clone())
+    }
+
+    async fn list_dictionaries(&self, _db_name: &str) -> Result<Vec<String>, OlapChangesError> {
+        Ok(self.dictionaries.clone())
+    }
+
+    async fn show_create_dictionary(
+        &self,
+        db_name: &str,
+        dict_name: &str,
+    ) -> Result<String, OlapChangesError> {
+        let key = MockOlapClient::ddl_key(db_name, dict_name);
+        Ok(self.dictionary_ddls.get(&key).cloned().unwrap_or_default())
+    }
+}
+
+// ─── Project ─────────────────────────────────────────────────────────────────
+
+pub fn create_test_project() -> Project {
+    Project {
+        language: crate::framework::languages::SupportedLanguages::Typescript,
+        redpanda_config: crate::infrastructure::stream::kafka::models::KafkaConfig::default(),
+        clickhouse_config: crate::infrastructure::olap::clickhouse::ClickHouseConfig {
+            db_name: "test".to_string(),
+            user: "test".to_string(),
+            password: "test".to_string(),
+            use_ssl: false,
+            host: "localhost".to_string(),
+            host_port: 18123,
+            native_port: 9000,
+            ..Default::default()
+        },
+        http_server_config: crate::cli::local_webserver::LocalWebserverConfig::default(),
+        redis_config: crate::infrastructure::redis::redis_client::RedisConfig::default(),
+        git_config: crate::utilities::git::GitConfig::default(),
+        temporal_config: crate::infrastructure::orchestration::temporal::TemporalConfig::default(),
+        state_config: crate::project::StateConfig::default(),
+        migration_config: crate::project::MigrationConfig::default(),
+        language_project_config: crate::project::LanguageProjectConfig::default(),
+        project_location: std::path::PathBuf::new(),
+        is_production: false,
+        log_payloads: false,
+        supported_old_versions: HashMap::new(),
+        jwt: None,
+        authentication: crate::project::AuthenticationConfig::default(),
+        features: crate::project::ProjectFeatures::default(),
+        load_infra: None,
+        typescript_config: crate::project::TypescriptConfig::default(),
+        source_dir: crate::project::default_source_dir(),
+        docker_config: crate::project::DockerConfig::default(),
+        watcher_config: crate::cli::watcher::WatcherConfig::default(),
+        dev: crate::project::DevConfig::default(),
+    }
+}
+
+// ─── Table ───────────────────────────────────────────────────────────────────
+
+pub fn create_test_table(name: &str) -> Table {
+    Table {
+        name: name.to_string(),
+        columns: vec![Column {
+            name: "id".to_string(),
+            data_type: ColumnType::Int(IntType::Int64),
+            required: true,
+            unique: true,
+            primary_key: true,
+            default: None,
+            annotations: vec![],
+            comment: None,
+            ttl: None,
+            codec: None,
+            materialized: None,
+            alias: None,
+        }],
+        order_by: OrderBy::Fields(vec!["id".to_string()]),
+        partition_by: None,
+        sample_by: None,
+        engine: ClickhouseEngine::MergeTree,
+        version: Some(Version::from_string("1.0.0".to_string())),
+        source_primitive: PrimitiveSignature {
+            name: "test".to_string(),
+            primitive_type: PrimitiveTypes::DataModel,
+        },
+        metadata: None,
+        life_cycle: LifeCycle::FullyManaged,
+        engine_params_hash: None,
+        table_settings_hash: None,
+        table_settings: None,
+        indexes: vec![],
+        projections: vec![],
+        constraints: vec![],
+        database: None,
+        table_ttl_setting: None,
+        cluster_name: None,
+        primary_key_expression: None,
+        seed_filter: Default::default(),
+    }
+}
+
+// ─── InfrastructureMap ───────────────────────────────────────────────────────
+
+/// Empty map with `default_database = DEFAULT_DATABASE_NAME ("local")`.
+/// Used for reality-checker tests where the project DB doesn't need to match.
+pub fn make_empty_infra_map() -> InfrastructureMap {
+    InfrastructureMap {
+        default_database: DEFAULT_DATABASE_NAME.to_string(),
+        topics: HashMap::new(),
+        api_endpoints: HashMap::new(),
+        tables: HashMap::new(),
+        dmv1_views: HashMap::new(),
+        topic_to_table_sync_processes: HashMap::new(),
+        topic_to_topic_sync_processes: HashMap::new(),
+        function_processes: HashMap::new(),
+        consumption_api_web_server: ConsumptionApiWebServer {},
+        orchestration_workers: HashMap::new(),
+        sql_resources: HashMap::new(),
+        workflows: HashMap::new(),
+        web_apps: HashMap::new(),
+        materialized_views: HashMap::new(),
+        views: HashMap::new(),
+        select_row_policies: HashMap::new(),
+        moose_version: None,
+        olap_dictionaries: Default::default(),
+    }
+}
+
+/// Map pre-populated with one dictionary, keyed as `"{DEFAULT_DATABASE_NAME}_{dict_name}"`.
+/// After `reconcile_with_reality` calls `fixup_default_db`, the key is updated to use
+/// the project's actual DB name.
+pub fn make_infra_map_with_dict(dict_name: &str) -> InfrastructureMap {
+    let mut map = InfrastructureMap::empty_from_project(&create_test_project());
+    let dict = make_test_dict(dict_name);
+    let key = format!("{}_{}", DEFAULT_DATABASE_NAME, dict_name);
+    map.olap_dictionaries.insert(key, dict);
+    map
+}
+
+// ─── MockOlapClient factories ────────────────────────────────────────────────
+
+pub fn make_simple_mock(dictionaries: Vec<String>) -> MockOlapClient {
+    MockOlapClient {
+        dictionaries,
+        ..Default::default()
+    }
+}
+
+pub fn make_mock_with_ddls(
+    dictionaries: Vec<String>,
+    dictionary_ddls: HashMap<String, String>,
+) -> MockOlapClient {
+    MockOlapClient {
+        dictionaries,
+        dictionary_ddls,
+        ..Default::default()
+    }
+}
+
+// ─── OlapDictionary ──────────────────────────────────────────────────────────
+
+pub fn make_test_dict(name: &str) -> OlapDictionary {
+    OlapDictionary {
+        name: name.to_string(),
+        database: None,
+        cluster_name: None,
+        source: DictionarySource::Table(DictionaryTableSource {
+            table: "src".to_string(),
+            database: None,
+            where_clause: None,
+            invalidate_query: None,
+        }),
+        primary_key: vec!["id".to_string()],
+        columns: vec![DictionaryColumn {
+            name: "id".to_string(),
+            type_string: "UInt64".to_string(),
+            default_value: None,
+            expression: None,
+            is_injective: None,
+            is_hierarchical: None,
+            is_object_id: None,
+            comment: None,
+        }],
+        layout: DictionaryLayout::Hashed {
+            initial_array_size: None,
+            max_load_factor: None,
+        },
+        lifetime: DictionaryLifetime::Single { seconds: 300 },
+        invalidate_query: None,
+        settings: HashMap::new(),
+        comment: None,
+        life_cycle: LifeCycle::FullyManaged,
+        version: None,
+        metadata: None,
+    }
+}

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -2069,22 +2069,18 @@ async fn execute_drop_row_policy(
     Ok(())
 }
 
-/// Execute a CREATE DICTIONARY IF NOT EXISTS operation.
+/// Shared implementation for create and replace dictionary operations.
 ///
 /// Dictionary DDL can contain credentials (PASSWORD, SECRET_ACCESS_KEY, etc.) in the
 /// SOURCE clause. We bypass `run_query` (which logs the SQL at debug level) and call
 /// `build_query(...).execute()` directly so the raw SQL is never written to logs.
-async fn execute_create_dictionary(
-    _db_name: &str,
+async fn execute_dictionary_upsert(
+    operation: &str,
     dict: &crate::infrastructure::olap::clickhouse::dictionary::OlapDictionary,
     client: &ConfiguredDBClient,
 ) -> Result<(), ClickhouseChangesError> {
-    // Use CREATE OR REPLACE so that a structurally mismatched dict (detected by
-    // check_reality and removed from the reconciled map) gets overwritten rather
-    // than silently skipped by IF NOT EXISTS.
     let sql = dict.to_replace_sql();
-    // Log the operation without the SQL body to avoid leaking credentials.
-    tracing::debug!("Creating dictionary: {} (SQL redacted)", dict.name);
+    tracing::debug!("{} dictionary: {} (SQL redacted)", operation, dict.name);
     build_query(&client.client, &sql)
         .execute()
         .await
@@ -2095,27 +2091,23 @@ async fn execute_create_dictionary(
     Ok(())
 }
 
-/// Execute a CREATE OR REPLACE DICTIONARY operation.
-///
-/// Dictionary DDL can contain credentials (PASSWORD, SECRET_ACCESS_KEY, etc.) in the
-/// SOURCE clause. We bypass `run_query` (which logs the SQL at debug level) and call
-/// `build_query(...).execute()` directly so the raw SQL is never written to logs.
+// Use CREATE OR REPLACE for both create and replace — structurally mismatched dicts
+// are removed from the reconciled map by check_reality so that the subsequent diff
+// generates an Added change, which this function resolves via CREATE OR REPLACE.
+async fn execute_create_dictionary(
+    _db_name: &str,
+    dict: &crate::infrastructure::olap::clickhouse::dictionary::OlapDictionary,
+    client: &ConfiguredDBClient,
+) -> Result<(), ClickhouseChangesError> {
+    execute_dictionary_upsert("Creating", dict, client).await
+}
+
 async fn execute_replace_dictionary(
     _db_name: &str,
     dict: &crate::infrastructure::olap::clickhouse::dictionary::OlapDictionary,
     client: &ConfiguredDBClient,
 ) -> Result<(), ClickhouseChangesError> {
-    let sql = dict.to_replace_sql();
-    // Log the operation without the SQL body to avoid leaking credentials.
-    tracing::debug!("Replacing dictionary: {} (SQL redacted)", dict.name);
-    build_query(&client.client, &sql)
-        .execute()
-        .await
-        .map_err(|e| ClickhouseChangesError::ClickhouseClient {
-            error: e,
-            resource: Some(dict.name.clone()),
-        })?;
-    Ok(())
+    execute_dictionary_upsert("Replacing", dict, client).await
 }
 
 /// Execute a DROP DICTIONARY IF EXISTS operation.

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse/mod.rs
@@ -2079,7 +2079,10 @@ async fn execute_create_dictionary(
     dict: &crate::infrastructure::olap::clickhouse::dictionary::OlapDictionary,
     client: &ConfiguredDBClient,
 ) -> Result<(), ClickhouseChangesError> {
-    let sql = dict.to_create_if_not_exists_sql();
+    // Use CREATE OR REPLACE so that a structurally mismatched dict (detected by
+    // check_reality and removed from the reconciled map) gets overwritten rather
+    // than silently skipped by IF NOT EXISTS.
+    let sql = dict.to_replace_sql();
     // Log the operation without the SQL body to avoid leaking credentials.
     tracing::debug!("Creating dictionary: {} (SQL redacted)", dict.name);
     build_query(&client.client, &sql)
@@ -3429,6 +3432,38 @@ impl OlapOperations for ConfiguredDBClient {
             names.len()
         );
         Ok(names)
+    }
+
+    async fn show_create_dictionary(
+        &self,
+        db_name: &str,
+        dict_name: &str,
+    ) -> Result<String, OlapChangesError> {
+        #[derive(clickhouse::Row, serde::Deserialize)]
+        struct ShowCreateRow {
+            statement: String,
+        }
+
+        let qualified_name = format!("`{}`.`{}`", db_name, dict_name);
+        let sql = format!("SHOW CREATE DICTIONARY {qualified_name}");
+
+        let mut cursor = self
+            .client
+            .query(&sql)
+            .fetch::<ShowCreateRow>()
+            .map_err(|e| OlapChangesError::DatabaseError(e.to_string()))?;
+
+        match cursor
+            .next()
+            .await
+            .map_err(|e| OlapChangesError::DatabaseError(e.to_string()))?
+        {
+            Some(row) => Ok(row.statement),
+            None => Err(OlapChangesError::DatabaseError(format!(
+                "SHOW CREATE DICTIONARY returned no rows for `{}`.`{}`",
+                db_name, dict_name
+            ))),
+        }
     }
 
     /// Normalizes SQL using ClickHouse's native formatQuerySingleLine function.

--- a/apps/framework-cli/src/infrastructure/olap/mod.rs
+++ b/apps/framework-cli/src/infrastructure/olap/mod.rs
@@ -111,8 +111,8 @@ pub trait OlapOperations {
 
     /// Retrieves the names of all dictionaries present in the given database.
     ///
-    /// Used for reality checking — presence/absence only; full schema diffing is
-    /// handled by comparing `SHOW CREATE DICTIONARY` output via `normalize_sql`.
+    /// Used for reality checking — presence/absence only; structural diffing is
+    /// done separately via `show_create_dictionary`.
     ///
     /// # Arguments
     /// * `db_name` - The name of the database to list dictionaries from
@@ -120,6 +120,23 @@ pub trait OlapOperations {
     /// # Returns
     /// * `Result<Vec<String>, OlapChangesError>` - Dictionary names found in the database
     async fn list_dictionaries(&self, db_name: &str) -> Result<Vec<String>, OlapChangesError>;
+
+    /// Returns the `CREATE DICTIONARY` DDL for an existing dictionary.
+    ///
+    /// Used for structural comparison in reality checking — comparing the actual
+    /// ClickHouse definition against the infra map definition to detect drift.
+    ///
+    /// # Arguments
+    /// * `db_name` - The database containing the dictionary
+    /// * `dict_name` - The dictionary name
+    ///
+    /// # Returns
+    /// * `Result<String, OlapChangesError>` - The CREATE DICTIONARY DDL string
+    async fn show_create_dictionary(
+        &self,
+        db_name: &str,
+        dict_name: &str,
+    ) -> Result<String, OlapChangesError>;
 
     /// Normalizes SQL using the database's native formatting.
     ///


### PR DESCRIPTION
## Summary

- Implements ENG-2765 step 3: structurally compare dictionaries present in both the infra map and ClickHouse via `SHOW CREATE DICTIONARY`
- Mismatched dicts are removed from the reconciled map so the subsequent diff generates an `Added` change, resolved by `CREATE OR REPLACE DICTIONARY` on next apply
- Switched `execute_create_dictionary` from `IF NOT EXISTS` to `OR REPLACE` to overwrite drifted CH definitions without a manual drop

## Changes

- **`OlapOperations` trait / ClickHouse impl**: new `show_create_dictionary(db, name)` method
- **`dicts_ddl_equivalent()`**: DDL body comparator that sorts post-column clauses (PRIMARY KEY, SOURCE, LAYOUT, LIFETIME) to tolerate ordering differences between our generator and `SHOW CREATE DICTIONARY` output
- **`check_reality()`**: replaces the `Vec::new()` placeholder with a full mismatch-detection loop
- **`reconcile_with_reality()`**: removes structurally mismatched dicts from the reconciled map

## Test plan

- [ ] `cargo test test_dict` — 19 dictionary tests pass (4 DDL-equivalence, 3 detection, 12 existing)
- [ ] `cargo test test_reconcile` — 11 reconciliation tests pass (2 new dict tests)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new dictionary DDL introspection/comparison logic and changes dictionary creation to `CREATE OR REPLACE`, which can overwrite existing definitions; parsing edge-cases or false positives could trigger unexpected replaces.
> 
> **Overview**
> Adds **structural mismatch detection for ClickHouse dictionaries** during `check_reality()` by fetching `SHOW CREATE DICTIONARY` and comparing it against infra-map generated DDL (with whitespace normalization, clause reordering tolerance, LIFETIME short/long-form normalization, and ClickHouse Cloud `[HIDDEN]` secret substitution).
> 
> Updates reconciliation so **mismatched dictionaries are removed from the reconciled map**, causing the next diff to recreate them, and switches dictionary creation to use **`CREATE OR REPLACE DICTIONARY`** for both create/replace paths to overwrite drifted definitions without manual drops.
> 
> Extends the `OlapOperations` trait + ClickHouse implementation with `show_create_dictionary()`, and refactors tests by introducing shared `test_helpers` (mock OLAP client now supports per-dictionary DDL) plus new unit tests covering DDL equivalence and mismatch/reconcile behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00010bfd649d09ff1cb4b7063b6a1f419b400824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->