### PR TITLE
fix(cli): prefer IPv4 when binding webserver to "localhost"

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -2566,10 +2566,24 @@ impl Webserver {
     }
 
     async fn get_socket(&self, port: u16) -> SocketAddr {
-        tokio::net::lookup_host(format!("{}:{}", self.host, port))
-            .await
-            .unwrap()
-            .next()
+        // Prefer IPv4 when `host` resolves to both. On Debian-family systems
+        // /etc/hosts lists `::1 localhost` first, so a naive `.next()` ends up
+        // binding only to `[::1]` — which silently breaks clients that resolve
+        // `localhost` to 127.0.0.1 first (notably Node's `fetch`, which the
+        // DEC Bench asserter uses). Sticking to IPv4 also matches what every
+        // other moose-spawned listener (devkafka, devredis, the moose-runner
+        // child, the spawned ClickHouse and Temporal subprocesses) does, so
+        // bind ABI is consistent across the dev stack.
+        let candidates: Vec<SocketAddr> =
+            tokio::net::lookup_host(format!("{}:{}", self.host, port))
+                .await
+                .unwrap()
+                .collect();
+        candidates
+            .iter()
+            .find(|a| a.is_ipv4())
+            .copied()
+            .or_else(|| candidates.first().copied())
             .unwrap()
     }
     pub async fn socket(&self) -> SocketAddr {


### PR DESCRIPTION
`tokio::net::lookup_host("localhost:<port>")` returns both 127.0.0.1 and ::1 on Debian-family systems. The previous `.next().unwrap()` took whichever came first — typically [::1] — which silently broke clients that resolve `localhost` to 127.0.0.1 first (notably Node's `fetch`, used by DEC Bench's assertion runner).

Symptom: `moose dev` listens on [::1]:4000, but `fetch("http://localhost:4000")` hits 127.0.0.1 → ECONNREFUSED → assertion falls through to whatever else binds 8080 (Temporal UI's SvelteKit catch-all SPA, returning text/html for any path) → robust assertions fail with "valid JSON: false".

Fix: collect all resolved addresses and prefer the first IPv4. Falls back to the first match if no IPv4 is present (so explicit IPv6-only hosts still work). This also matches what every other moose-spawned listener (devkafka, devredis, the moose-runner child, spawned ClickHouse and Temporal subprocesses) already binds to.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to dev webserver socket selection; behavior only changes when a hostname resolves to both IPv4 and IPv6, with a safe fallback to the first resolved address if no IPv4 is available.
> 
> **Overview**
> Fixes local CLI webserver binding when `localhost` resolves to both IPv4 and IPv6 by collecting all `lookup_host` results and **preferring an IPv4 address** instead of blindly taking the first entry.
> 
> This prevents the server from binding only to `::1` on Debian-family systems (avoiding connection failures for clients that resolve `localhost` to `127.0.0.1`), while still falling back to the first resolved address for IPv6-only hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c6573da8fd2416f7fc1a4aefe8a44ce7a70dc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->