### PR TITLE
feat(cli): flag-first moose init and template recovery (514-1408)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,3 +112,14 @@ When working with MooseStack data models, ClickHouse schemas, queries, or config
 Each rule includes MooseStack TypeScript/Python examples. When reviewing or implementing ClickHouse-related code, read relevant rule files and cite specific rules in your guidance.
 
 To install the skill: `514 agent init`
+
+## Learned User Preferences
+
+- Promote flag-first `moose init` in docs and examples: `moose init --name <name> --template <template>`; treat legacy `moose init <name> [template]` as backward-compatible only, not the primary or help-example style.
+- For `moose init --help`, show flag-based examples in the main promoted/after-help text; do not present positional forms as the recommended invocations even when the parser still accepts them.
+- For `moose dev` failures, show `moose dev --dockerless` when the runtime is actually unavailable; do not suggest dockerless for unrelated infra failures (avoid error-text matching that fires on timeout or generic troubleshooting copy).
+- When improving agent success on init, account for agents copying `moose harness init` patterns (e.g. `--template=...`) onto plain `moose init`—keep CLI, help, and docs aligned on flag syntax and valid template slugs.
+
+## Learned Workspace Facts
+
+- `moose init` is more discoverable at the top level than `moose harness init`, but harness init is the fuller agent setup path; documentation and help should make the two consistent on flags and template discovery (`moose template list`, `moose template list --json`).

--- a/apps/framework-cli-e2e/test/seed-filter.test.ts
+++ b/apps/framework-cli-e2e/test/seed-filter.test.ts
@@ -99,7 +99,7 @@ describe("moose seed clickhouse with seedFilter", function () {
     // 1. Init project from play.clickhouse.com (git_clickhouse database - only 3 tables)
     testLogger.info("Initializing project from play.clickhouse.com...");
     const initResult = await execAsync(
-      `"${CLI_PATH}" init test-seed-filter typescript-empty --from-remote "${REMOTE_HTTPS_URL}" --location "${testProjectDir}"`,
+      `"${CLI_PATH}" init --name test-seed-filter --template typescript-empty --from-remote "${REMOTE_HTTPS_URL}" --location "${testProjectDir}"`,
     );
     testLogger.debug("Init output:", initResult.stdout);
 

--- a/apps/framework-cli-e2e/test/utils/project-setup.ts
+++ b/apps/framework-cli-e2e/test/utils/project-setup.ts
@@ -102,7 +102,7 @@ export const setupTypeScriptProject = async (
   log.info(`Initializing TypeScript project with ${templateName} template`);
   try {
     const result = await execAsync(
-      `"${cliPath}" init ${appName} ${templateName} --location "${projectDir}"`,
+      `"${cliPath}" init --name ${appName} --template ${templateName} --location "${projectDir}"`,
       { env },
     );
     log.debug("CLI init stdout", { stdout: result.stdout });
@@ -166,7 +166,7 @@ export const setupPythonProject = async (
   log.info(`Initializing Python project with ${templateName} template`);
   try {
     const result = await execAsync(
-      `"${cliPath}" init ${appName} ${templateName} --location "${projectDir}"`,
+      `"${cliPath}" init --name ${appName} --template ${templateName} --location "${projectDir}"`,
       { env },
     );
     log.debug("CLI init stdout", { stdout: result.stdout });

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -484,19 +484,31 @@ pub async fn top_command_handler(
     match commands {
         Commands::Init {
             name,
-            location,
+            name_option,
             template,
+            template_option,
+            location,
             no_fail_already_exists,
             from_remote,
             custom_dockerfile,
         } => {
+            let project_name = name_option.as_deref().or(name.as_deref()).ok_or_else(|| {
+                RoutineFailure::error(Message {
+                    action: "Init".to_string(),
+                    details:
+                        "Project name is required (use --name <NAME> or the legacy positional)."
+                            .to_string(),
+                })
+            })?;
+            let template_from_args = template_option.as_ref().or(template.as_ref());
+
             info!(
                 "Running init command with name: {}, location: {:?}, template: {:?}, custom_dockerfile: {}",
-                name, location, template, custom_dockerfile
+                project_name, location, template_from_args, custom_dockerfile
             );
 
             // Determine template, prompting when needed.
-            let template = match template {
+            let template = match template_from_args {
                 Some(t) => t.to_lowercase(),
                 None => {
                     display::show_message_wrapper(
@@ -510,21 +522,21 @@ pub async fn top_command_handler(
                 }
             };
 
-            let dir_path = Path::new(location.as_deref().unwrap_or(name));
+            let dir_path = Path::new(location.as_deref().unwrap_or(project_name));
 
             let capture_handle = crate::utilities::capture::capture_usage(
                 ActivityType::InitTemplateCommand,
-                Some(name.to_string()),
+                Some(project_name.to_string()),
                 &settings,
                 machine_id.clone(),
                 HashMap::from([("template".to_string(), template.to_string())]),
             );
 
-            check_project_name(name)?;
+            check_project_name(project_name)?;
 
             let project_outcome = initialize_project(&ProjectInitOptions {
                 template: &template,
-                project_name: name,
+                project_name,
                 dir_path,
                 no_fail_already_exists: *no_fail_already_exists,
                 custom_dockerfile: *custom_dockerfile,

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -3,19 +3,65 @@
 
 use std::path::PathBuf;
 
-use clap::{Args, Subcommand};
+use clap::{ArgGroup, Args, Subcommand};
+
+const MOOSE_INIT_AFTER_LONG_HELP: &str = "Examples (preferred):
+  moose init --name my-app
+  moose init --name my-app --template typescript
+  moose init --name my-app --template=typescript
+  moose init --name my-app --template typescript --location ./sandbox
+  moose init --name my-project --template typescript-empty --from-remote <CONNECTION-STRING>
+  moose init --name my-project --template python-empty --from-remote
+
+Positional <NAME> and [TEMPLATE] are still accepted for backward compatibility but are hidden from
+this help output; prefer --name and --template in scripts and agent workflows.
+
+Template catalog:
+  moose template list
+  moose template list --json
+
+Arg-driven init is non-interactive when --template is provided, or when stdin is not a terminal:
+omitted --template in other cases will prompt to select a template (TTY only).";
 
 #[derive(Subcommand)]
 pub enum Commands {
     // Initializes the developer environment with all the necessary directories including temporary ones for data storage
     /// Initialize a new project
-    #[command(visible_alias = "i")]
+    #[command(
+        visible_alias = "i",
+        after_long_help = MOOSE_INIT_AFTER_LONG_HELP,
+        group(
+            ArgGroup::new("init_project_name")
+                .id("init_project_name")
+                .args(["name", "name_option"])
+                .required(true)
+        ),
+        group(
+            ArgGroup::new("init_template_input")
+                .id("init_template_input")
+                .args(["template", "template_option"])
+        )
+    )]
     Init {
-        /// Name of your app or service
-        name: String,
+        /// [Deprecated] Use `--name` instead. Hidden from help; still parsed for compatibility.
+        #[arg(hide = true)]
+        name: Option<String>,
 
-        /// Template to use for the project
+        /// Name of your app or service
+        #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
+        name_option: Option<String>,
+
+        /// [Deprecated] Use `--template` instead. Hidden from help; still parsed for compatibility.
+        #[arg(hide = true, conflicts_with = "template_option")]
         template: Option<String>,
+
+        /// Template to use (run `moose template list` to see the catalog). Omit to select interactively (TTY only)
+        #[arg(
+            long = "template",
+            value_name = "TEMPLATE",
+            conflicts_with = "template"
+        )]
+        template_option: Option<String>,
 
         /// Location of your app or service
         #[arg(short, long)]

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -13,8 +13,8 @@ const MOOSE_INIT_AFTER_LONG_HELP: &str = "Examples (preferred):
   moose init --name my-project --template typescript-empty --from-remote <CONNECTION-STRING>
   moose init --name my-project --template python-empty --from-remote
 
-Positional <NAME> and [TEMPLATE] are still accepted for backward compatibility but are hidden from
-this help output; prefer --name and --template in scripts and agent workflows.
+Legacy positional name and template arguments are still accepted for backward compatibility but are
+hidden from this help output; prefer --name and --template in scripts and agent workflows.
 
 Template catalog:
   moose template list

--- a/apps/framework-cli/src/cli/routines/templates.rs
+++ b/apps/framework-cli/src/cli/routines/templates.rs
@@ -284,7 +284,7 @@ pub async fn get_template_config(
         return Err(RoutineFailure::error(Message {
             action: "Template".to_string(),
             details: format!(
-                "Template '{}' not found. Available templates:\n{}\n\nLooking for a full example app? Check https://github.com/514-labs/moosestack/tree/main/examples",
+                "Template '{}' not found. Available templates:\n{}\n\nList templates (including machine-readable JSON for agents and scripts):\n  moose template list\n  moose template list --json\n\nLooking for a full example app? Check https://github.com/514-labs/moosestack/tree/main/examples",
                 template_name,
                 available_templates.join("\n")
             ),

--- a/apps/framework-cli/tests/cli_init.rs
+++ b/apps/framework-cli/tests/cli_init.rs
@@ -100,7 +100,109 @@ fn init_help_does_not_list_language_flag() -> Result<(), Box<dyn std::error::Err
         .assert()
         .success()
         .stdout(predicate::str::contains("--language").not())
-        .stdout(predicate::str::contains("[TEMPLATE]"));
+        .stdout(predicate::str::contains("[TEMPLATE]"))
+        .stdout(predicate::str::contains("Examples (preferred):"))
+        .stdout(predicate::str::contains(
+            "--name my-app --template typescript",
+        ));
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial(init)]
+fn can_run_cli_init_with_flag_name_and_template() -> Result<(), Box<dyn std::error::Error>> {
+    ensure_test_environment();
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    std::fs::remove_dir(&temp)?;
+    let dir: &str = temp.path().to_str().unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
+
+    cmd.arg("init")
+        .arg("--name")
+        .arg("flag-app")
+        .arg("--template")
+        .arg("typescript")
+        .arg("-l")
+        .arg(dir);
+
+    cmd.assert().success();
+
+    temp.child("package.json").assert(predicate::path::exists());
+    temp.child("app").assert(predicate::path::exists());
+    temp.child("moose.config.toml")
+        .assert(predicate::path::exists());
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial(init)]
+fn can_run_cli_init_with_equals_style_template_flag() -> Result<(), Box<dyn std::error::Error>> {
+    ensure_test_environment();
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    std::fs::remove_dir(&temp)?;
+    let dir: &str = temp.path().to_str().unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
+
+    cmd.arg("init")
+        .arg("equals-app")
+        .arg("--template=typescript")
+        .arg("-l")
+        .arg(dir);
+
+    cmd.assert().success();
+
+    temp.child("package.json").assert(predicate::path::exists());
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial(init)]
+fn init_rejects_positional_and_flag_template_together() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
+
+    cmd.arg("init")
+        .arg("my-app")
+        .arg("typescript")
+        .arg("--template")
+        .arg("python");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"))
+        .stderr(predicate::str::contains("--template"));
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial(init)]
+fn init_with_unknown_template_flag_prints_template_recovery(
+) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_test_environment();
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    std::fs::remove_dir(&temp)?;
+    let dir: &str = temp.path().to_str().unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
+
+    cmd.arg("init")
+        .arg("order-loader")
+        .arg("--template=simple")
+        .arg("-l")
+        .arg(dir);
+
+    cmd.assert().failure().stdout(
+        predicate::str::contains("Template 'simple' not found")
+            .and(predicate::str::contains("moose template list --json")),
+    );
 
     Ok(())
 }

--- a/apps/framework-cli/tests/cli_init.rs
+++ b/apps/framework-cli/tests/cli_init.rs
@@ -100,7 +100,7 @@ fn init_help_does_not_list_language_flag() -> Result<(), Box<dyn std::error::Err
         .assert()
         .success()
         .stdout(predicate::str::contains("--language").not())
-        .stdout(predicate::str::contains("[TEMPLATE]"))
+        .stdout(predicate::str::contains("[TEMPLATE]").not())
         .stdout(predicate::str::contains("Examples (preferred):"))
         .stdout(predicate::str::contains(
             "--name my-app --template typescript",

--- a/apps/framework-cli/tests/cli_init.rs
+++ b/apps/framework-cli/tests/cli_init.rs
@@ -159,6 +159,9 @@ fn can_run_cli_init_with_equals_style_template_flag() -> Result<(), Box<dyn std:
     cmd.assert().success();
 
     temp.child("package.json").assert(predicate::path::exists());
+    temp.child("app").assert(predicate::path::exists());
+    temp.child("moose.config.toml")
+        .assert(predicate::path::exists());
 
     Ok(())
 }
@@ -223,6 +226,12 @@ fn init_with_unknown_template_flag_prints_template_recovery(
         predicate::str::contains("Template 'simple' not found")
             .and(predicate::str::contains("moose template list --json")),
     );
+
+    temp.child("package.json")
+        .assert(predicate::path::missing());
+    temp.child("app").assert(predicate::path::missing());
+    temp.child("moose.config.toml")
+        .assert(predicate::path::missing());
 
     Ok(())
 }

--- a/apps/framework-cli/tests/cli_init.rs
+++ b/apps/framework-cli/tests/cli_init.rs
@@ -150,6 +150,7 @@ fn can_run_cli_init_with_equals_style_template_flag() -> Result<(), Box<dyn std:
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
 
     cmd.arg("init")
+        .arg("--name")
         .arg("equals-app")
         .arg("--template=typescript")
         .arg("-l")
@@ -183,6 +184,24 @@ fn init_rejects_positional_and_flag_template_together() -> Result<(), Box<dyn st
 
 #[test]
 #[serial_test::serial(init)]
+fn init_rejects_positional_and_flag_name_together() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
+
+    cmd.arg("init")
+        .arg("my-app")
+        .arg("--name")
+        .arg("other-name");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"))
+        .stderr(predicate::str::contains("--name"));
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial(init)]
 fn init_with_unknown_template_flag_prints_template_recovery(
 ) -> Result<(), Box<dyn std::error::Error>> {
     ensure_test_environment();
@@ -194,6 +213,7 @@ fn init_with_unknown_template_flag_prints_template_recovery(
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("moose-cli"));
 
     cmd.arg("init")
+        .arg("--name")
         .arg("order-loader")
         .arg("--template=simple")
         .arg("-l")

--- a/apps/framework-docs-v2/content/guides/chat-in-your-app/tutorial.mdx
+++ b/apps/framework-docs-v2/content/guides/chat-in-your-app/tutorial.mdx
@@ -113,7 +113,7 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,514
 <ConditionalContent whenId="starting-point" whenValue="scratch">
 
 ```shell
-moose init <project-name> typescript-mcp
+moose init --name <project-name> --template typescript-mcp
 cd <project-name>
 ```
 
@@ -202,7 +202,7 @@ moose generate hash-token
 <ToggleBlock openText="Show instructions to create one" closeText="Hide instructions">
 Create one first and add it to your `pnpm-workspace.yaml`:
 ```shell
-moose init moosestack-service typescript --location packages/moosestack-service
+moose init --name moosestack-service --template typescript --location packages/moosestack-service
 ```
 ```yaml
 # pnpm-workspace.yaml

--- a/apps/framework-docs-v2/content/guides/data-warehouses.mdx
+++ b/apps/framework-docs-v2/content/guides/data-warehouses.mdx
@@ -377,7 +377,7 @@ moose --version
 Initialize a new MooseStack project:
 
 ```bash
-moose init ecommerce-warehouse typescript
+moose init --name ecommerce-warehouse --template typescript
 cd ecommerce-warehouse
 npm install
 ```

--- a/apps/framework-docs-v2/content/guides/static-report-generation.mdx
+++ b/apps/framework-docs-v2/content/guides/static-report-generation.mdx
@@ -327,7 +327,7 @@ moose --version
 ### Step 2: Initialize project
 
 ```bash
-moose init sales-reports typescript-empty
+moose init --name sales-reports --template typescript-empty
 cd sales-reports
 pnpm install
 ```
@@ -2166,7 +2166,7 @@ If this returns empty `[]`, verify data was ingested and the date range is corre
 
 **Stopping the dev server:** Press `Ctrl+C` in the `moose dev` terminal. Docker containers stop automatically.
 
-**Starting over completely:** Stop `moose dev`, delete the project directory, and run `moose init` again.
+**Starting over completely:** Stop `moose dev`, delete the project directory, and run `moose init` with `--name` and `--template` again.
 
 **Reset data but keep code:** Stop `moose dev`, then remove the project's Docker volumes. **Caution:** `docker volume prune` deletes *all* unused volumes on your machine—not just this project's. Use `docker volume ls` to list volumes, identify yours (typically containing `clickhouse` or `redpanda`), and remove them with `docker volume rm <volume_name>`.
 

--- a/apps/framework-docs-v2/content/guides/test-guides/code-blocks.mdx
+++ b/apps/framework-docs-v2/content/guides/test-guides/code-blocks.mdx
@@ -90,7 +90,7 @@ LIMIT 10;
 ## Shell/Bash Commands
 
 ```shell
-moose init my-project typescript
+moose init --name my-project --template typescript
 cd my-project
 pnpm install
 pnpm dev

--- a/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
+++ b/apps/framework-docs-v2/content/moosestack/configuration/docker.mdx
@@ -99,5 +99,5 @@ moose build --docker --arm64
 You can also enable custom Dockerfile mode during project initialization:
 
 ```bash
-moose init my-app typescript --custom-dockerfile
+moose init --name my-app --template typescript --custom-dockerfile
 ```

--- a/apps/framework-docs-v2/content/moosestack/contribution/documentation.mdx
+++ b/apps/framework-docs-v2/content/moosestack/contribution/documentation.mdx
@@ -107,7 +107,7 @@ npm install @514labs/moose-lib
 
 ````markdown
 ```bash filename="Terminal" animate
-moose init my-project
+moose init --name my-project
 cd my-project
 moose dev
 ```

--- a/apps/framework-docs-v2/content/moosestack/deploying/deploying-on-an-offline-server.mdx
+++ b/apps/framework-docs-v2/content/moosestack/deploying/deploying-on-an-offline-server.mdx
@@ -139,7 +139,7 @@ Create a new Moose project:
 <LanguageTabs>
   <LanguageTabContent value="typescript" label="TypeScript">
 ```bash
-moose init your-project-name ts
+moose init --name your-project-name --template typescript
 cd your-project-name
 ```
 
@@ -150,7 +150,7 @@ npm install  # or yarn install
   </LanguageTabContent>
   <LanguageTabContent value="python" label="Python">
 ```bash
-moose init your-project-name py
+moose init --name your-project-name --template python
 cd your-project-name
 ```
   </LanguageTabContent>

--- a/apps/framework-docs-v2/content/moosestack/deploying/deploying-with-docker-compose.mdx
+++ b/apps/framework-docs-v2/content/moosestack/deploying/deploying-with-docker-compose.mdx
@@ -159,7 +159,7 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose
 Please follow the initialization instructions for your language.
 
 ```bash
-moose init test-ts typescript
+moose init --name test-ts --template typescript
 cd test-ts
 npm install
 ```
@@ -167,7 +167,7 @@ npm install
 or
 
 ```bash
-moose init test-py python
+moose init --name test-py --template python
 cd test-py
 pip install -r requirements.txt
 ```

--- a/apps/framework-docs-v2/content/moosestack/dev/cdc-managed-tables.mdx
+++ b/apps/framework-docs-v2/content/moosestack/dev/cdc-managed-tables.mdx
@@ -42,14 +42,14 @@ The fastest way to get started is with `moose init --from-remote`. This single c
   <LanguageTabContent value="typescript">
 
 ```bash
-moose init my-analytics-app typescript-empty --from-remote "https://user:pass@host:8443/database"
+moose init --name my-analytics-app --template typescript-empty --from-remote "https://user:pass@host:8443/database"
 ```
 
   </LanguageTabContent>
   <LanguageTabContent value="python">
 
 ```bash
-moose init my-analytics-app python-empty --from-remote "https://user:pass@host:8443/database"
+moose init --name my-analytics-app --template python-empty --from-remote "https://user:pass@host:8443/database"
 ```
 
   </LanguageTabContent>
@@ -91,14 +91,14 @@ If you don't want to put credentials in the command, run without the URL:
   <LanguageTabContent value="typescript">
 
 ```bash
-moose init my-analytics-app typescript-empty --from-remote
+moose init --name my-analytics-app --template typescript-empty --from-remote
 ```
 
   </LanguageTabContent>
   <LanguageTabContent value="python">
 
 ```bash
-moose init my-analytics-app python-empty --from-remote
+moose init --name my-analytics-app --template python-empty --from-remote
 ```
 
   </LanguageTabContent>
@@ -551,7 +551,7 @@ ignore_patterns = ["app/external_models.py"]
 
 | Task | Command |
 |:-----|:--------|
-| Start new project from existing ClickHouse | `moose init my-app <template> --from-remote <URL>` |
+| Start new project from existing ClickHouse | `moose init --name my-app --template <template> --from-remote <URL>` |
 | Sync external models after schema change | `moose db pull` |
 | Start local development | `moose dev` |
 | Seed more data locally | `moose seed clickhouse --limit 1000` |

--- a/apps/framework-docs-v2/content/moosestack/getting-started/from-clickhouse.mdx
+++ b/apps/framework-docs-v2/content/moosestack/getting-started/from-clickhouse.mdx
@@ -140,19 +140,19 @@ Use the ClickHouse Playground tab to try it out!
   <LanguageTabContent value="typescript">
 ```bash filename="Initialize new project" copy
 # Option 1: Provide connection string directly
-moose init my-project typescript-empty --from-remote <YOUR_CLICKHOUSE_CONNECTION_STRING>
+moose init --name my-project --template typescript-empty --from-remote <YOUR_CLICKHOUSE_CONNECTION_STRING>
 
 # Option 2: Run without connection string for interactive setup
-moose init my-project typescript-empty --from-remote
+moose init --name my-project --template typescript-empty --from-remote
 ```
   </LanguageTabContent>
   <LanguageTabContent value="python">
 ```bash filename="Initialize new project" copy
 # Option 1: Provide connection string directly
-moose init my-project python-empty --from-remote <YOUR_CLICKHOUSE_CONNECTION_STRING>
+moose init --name my-project --template python-empty --from-remote <YOUR_CLICKHOUSE_CONNECTION_STRING>
 
 # Option 2: Run without connection string for interactive setup
-moose init my-project python-empty --from-remote
+moose init --name my-project --template python-empty --from-remote
 ```
   </LanguageTabContent>
 </LanguageTabs>
@@ -200,13 +200,13 @@ See the section: <a href="#connect-to-your-remote-clickhouse" className="text-bl
 <LanguageTabs>
   <LanguageTabContent value="typescript">
 ```bash filename="Try using the ClickHouse Playground!" copy
-moose init my-project typescript-empty --from-remote https://explorer:@play.clickhouse.com:443/?database=default
+moose init --name my-project --template typescript-empty --from-remote https://explorer:@play.clickhouse.com:443/?database=default
 ```
   </LanguageTabContent>
   <LanguageTabContent value="python">
 ```bash filename="Initialize new project" copy
 # Generate code models from your existing ClickHouse tables
-moose init my-project python-empty --from-remote https://explorer:@play.clickhouse.com:443/?database=default
+moose init --name my-project --template python-empty --from-remote https://explorer:@play.clickhouse.com:443/?database=default
 ```
   </LanguageTabContent>
 </LanguageTabs>

--- a/apps/framework-docs-v2/content/moosestack/getting-started/quickstart.mdx
+++ b/apps/framework-docs-v2/content/moosestack/getting-started/quickstart.mdx
@@ -196,7 +196,7 @@ You should see the moose version number. Do not proceed to Step 2 until `moose -
 <LanguageTabs>
   <LanguageTabContent value="typescript">
 ```bash filename="Terminal" copy
-moose init my-analytics-app typescript
+moose init --name my-analytics-app --template typescript
 ```
 
 You should see output like:
@@ -207,7 +207,7 @@ You should see output like:
   </LanguageTabContent>
   <LanguageTabContent value="python">
   ```bash filename="Terminal" copy
-  moose init my-analytics-app python
+  moose init --name my-analytics-app --template python
   ```
   
   You should see output like:

--- a/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
+++ b/apps/framework-docs-v2/content/moosestack/moose-cli.mdx
@@ -23,15 +23,27 @@ These flags apply to all commands:
 
 ### Init
 Initialize a new project.
+
+**Preferred (flag syntax):**
 ```bash
-moose init <name> [template] [--location <location>] [--from-remote [<connection-string>]] [--custom-dockerfile] [--no-fail-already-exists]
+moose init --name <name> [--template <template>] [--location <location>] [--from-remote [<connection-string>]] [--custom-dockerfile] [--no-fail-already-exists]
 ```
-- `<name>`: Name of your app or service
-- `[template]`: Template to use. Run `moose template list` to see the catalog. Omit to pick interactively.
+
+- `--name <name>`: Name of your app or service
+- `--template <template>`: Template to use. Run `moose template list` (or `moose template list --json` for machine-readable output) to see the catalog. Omit to pick interactively.
 - `--location, -l`: Location for your app or service
 - `--from-remote`: Initialize from a remote database
 - `--custom-dockerfile`: Generate a custom Dockerfile at project root
 - `--no-fail-already-exists`: Allow init in an existing directory
+
+**Deprecated compatibility:** the legacy positional form `moose init <name> [template]` is still supported but omitted from this reference; new scripts, CI, and agent workflows should use `--name` and `--template` instead.
+
+Examples:
+```bash
+moose init --name my-app --template typescript
+moose init --name my-app
+moose init --name my-app --template typescript-empty --from-remote
+```
 
 ### Harness Init
 Initialize a project and set up the developer harness in one flow.

--- a/apps/framework-docs-v2/content/moosestack/olap/alias-columns.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/alias-columns.mdx
@@ -184,7 +184,7 @@ Use the exact field names from your data model. Moose preserves your naming conv
 When using `moose init --from-remote`, ALIAS column definitions are automatically preserved:
 
 ```bash filename="Terminal" copy
-moose init my-app typescript-empty --from-remote
+moose init --name my-app --template typescript-empty --from-remote
 # Generated models include ClickHouseAlias annotations
 ```
 

--- a/apps/framework-docs-v2/content/moosestack/olap/db-pull.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/db-pull.mdx
@@ -138,7 +138,7 @@ moose db pull [--clickhouse-url <URL>] [--file-path <OUTPUT_PATH>]
 ### New project from an existing DB
   If you're starting with an existing ClickHouse database, bootstrap code with `init --from-remote`, then use `db pull` over time to keep external models fresh:
   ```bash filename="Terminal" copy
-  moose init my-project <template> --from-remote $REMOTE_CLICKHOUSE_URL
+  moose init --name my-project --template <template> --from-remote $REMOTE_CLICKHOUSE_URL
   ```
 
   <Callout type="info" title="See the full guide" href="/moosestack/getting-started/from-clickhouse" ctaLabel="Get started">

--- a/apps/framework-docs-v2/content/moosestack/olap/external-tables.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/external-tables.mdx
@@ -92,7 +92,7 @@ cdc_user_table = OlapTable[CdcUserData]("cdc_users", OlapConfig(
 If you don't yet have a Moose project, use init-from-remote to bootstrap models from your existing ClickHouse:
 
 ```bash filename="Terminal" copy
-moose init my-project <template> --from-remote <YOUR_CLICKHOUSE_URL>
+moose init --name my-project --template <template> --from-remote <YOUR_CLICKHOUSE_URL>
 ```
 
 What happens:

--- a/apps/framework-docs-v2/content/moosestack/olap/materialized-columns.mdx
+++ b/apps/framework-docs-v2/content/moosestack/olap/materialized-columns.mdx
@@ -182,7 +182,7 @@ Use the exact field names from your data model. Moose preserves your naming conv
 When using `moose init --from-remote`, MATERIALIZED column definitions are automatically preserved:
 
 ```bash filename="Terminal" copy
-moose init my-app typescript-empty --from-remote
+moose init --name my-app --template typescript-empty --from-remote
 # Generated models include ClickHouseMaterialized annotations
 ```
 

--- a/apps/framework-docs-v2/content/moosestack/release-notes/2025-12-05.mdx
+++ b/apps/framework-docs-v2/content/moosestack/release-notes/2025-12-05.mdx
@@ -86,7 +86,7 @@ New project template demonstrating Fastify framework with Moose, plus fixed WebA
 
 
 ```bash copy
-moose init <project-name> --template fastify
+moose init --name <project-name> --template typescript-fastify
 ```
 
 PR: [#3068](https://github.com/514-labs/moosestack/pull/3068), [#3061](https://github.com/514-labs/moosestack/pull/3061) | Docs: [Fastify integration](/moosestack/app-api-frameworks) | [Fastify template](https://github.com/514-labs/moosestack/tree/main/templates/typescript-fastify)

--- a/apps/framework-docs-v2/content/moosestack/release-notes/2026-04-09.mdx
+++ b/apps/framework-docs-v2/content/moosestack/release-notes/2026-04-09.mdx
@@ -42,7 +42,7 @@ import { Callout } from "@/components/mdx";
   Docs: [Planned Migrations](/moosestack/migrate/planned-migrations)
 
 ### Bug Fixes
-- `moose init` no longer requires a `--language` flag — the language is inferred from the template. Template is now a positional argument alongside the project name. ([@callicles](https://github.com/callicles))
+- `moose init` no longer requires a `--language` flag — the language is inferred from the template. Use `--name` and `--template` to select the project and template; a legacy positional form is still supported for compatibility. ([@callicles](https://github.com/callicles))
 
 
 - Fix `moose harness init --from-remote` failing when used with templates in nested moose project directories. ([@callicles](https://github.com/callicles)) (thanks [@nklmish](https://github.com/nklmish) for reporting)

--- a/apps/framework-docs-v2/content/shared/examples/setup-example.mdx
+++ b/apps/framework-docs-v2/content/shared/examples/setup-example.mdx
@@ -9,7 +9,7 @@ Follow these steps to get started:
   bullets={[
     {
       title: "Initialize project",
-      description: "Run moose init to create a new project"
+      description: "Run moose init --name <project> --template <template> to create a new project"
     },
     {
       title: "Start services",

--- a/apps/framework-docs-v2/content/shared/existing-app/moose-init-workspace-ts-pnpm.mdx
+++ b/apps/framework-docs-v2/content/shared/existing-app/moose-init-workspace-ts-pnpm.mdx
@@ -4,7 +4,7 @@ From your monorepo, `cd` to the directory where you want the Moose project folde
 
 ```bash title="Terminal" copy
 cd <path-in-your-monorepo>
-moose init moose typescript-empty
+moose init --name moose --template typescript-empty
 ```
 
 Then install dependencies from your monorepo root:

--- a/apps/framework-docs-v2/content/shared/guides/performant-dashboards/add-moosestack-and-set-up-fiveonefour.mdx
+++ b/apps/framework-docs-v2/content/shared/guides/performant-dashboards/add-moosestack-and-set-up-fiveonefour.mdx
@@ -118,13 +118,13 @@ First, decide where `moosestack/` should live in your monorepo. Then `cd` to tha
 
 <ConditionalContent whenId="source-database" whenValue="sqlserver">
 ```shell
-moose init moosestack typescript-empty
+moose init --name moosestack --template typescript-empty
 ```
 </ConditionalContent>
 
 <ConditionalContent whenId="source-database" whenValue={["postgres", "none"]}>
 ```shell
-moose init moosestack typescript-empty --from-remote <YOUR_CLICKHOUSE_CONNECTION_STRING>
+moose init --name moosestack --template typescript-empty --from-remote <YOUR_CLICKHOUSE_CONNECTION_STRING>
 ```
 
 Enter your ClickHouse Cloud HTTPS connection string when prompted.

--- a/apps/framework-docs-v2/content/templates/index.mdx
+++ b/apps/framework-docs-v2/content/templates/index.mdx
@@ -9,7 +9,7 @@ import { TemplatesGridServer, CommandSnippet } from "@/components/mdx";
 
 # Templates & Apps
 
-Moose provides two ways to get started: **templates** and **demo apps**. Templates are simple skeleton applications that you can initialize with `moose init`, while demo apps are more advanced examples available on GitHub that showcase real-world use cases and integrations.
+Moose provides two ways to get started: **templates** and **demo apps**. Templates are simple skeleton applications that you can initialize with `moose init --name <name> --template <template>`, while demo apps are more advanced examples available on GitHub that showcase real-world use cases and integrations.
 
 <CommandSnippet />
 

--- a/apps/framework-docs-v2/src/components/mdx/command-snippet.tsx
+++ b/apps/framework-docs-v2/src/components/mdx/command-snippet.tsx
@@ -18,7 +18,7 @@ interface CommandSnippetProps {
 }
 
 export function CommandSnippet({
-  initCommand = "moose init PROJECT_NAME TEMPLATE_NAME",
+  initCommand = "moose init --name PROJECT_NAME --template TEMPLATE_NAME",
   listCommand = "moose template list",
   initLabel = "Init",
   listLabel = "List",

--- a/apps/framework-docs-v2/src/lib/templates.ts
+++ b/apps/framework-docs-v2/src/lib/templates.ts
@@ -202,7 +202,7 @@ export function getAllTemplates(): TemplateMetadata[] {
       const githubUrl = `https://github.com/514-labs/moosestack/tree/main/templates/${templateName}`;
 
       // Generate init command
-      const initCommand = `moose init PROJECT_NAME ${templateName}`;
+      const initCommand = `moose init --name PROJECT_NAME --template ${templateName}`;
 
       templates.push({
         name: templateName,

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -19,7 +19,7 @@ This is an empty Python-based Moose template that provides a minimal foundation 
 ### Installation
 
 1. Install Moose CLI: `pip install moose-cli`
-2. Create project: `moose init <project-name> python-empty`
+2. Create project: `moose init --name <project-name> --template python-empty`
 3. Install dependencies: `cd <project-name> && pip install -r requirements.txt`
 4. Run Moose: `moose dev`
 

--- a/templates/python-tests/README.md
+++ b/templates/python-tests/README.md
@@ -19,7 +19,7 @@ This is a Python-based Moose template that provides a foundation for building da
 ### Installation
 
 1. Install Moose CLI: `pip install moose-cli`
-2. Create project: `moose init <project-name> python`
+2. Create project: `moose init --name <project-name> --template python`
 3. Install dependencies: `cd <project-name> && pip install -r requirements.txt`
 4. Run Moose: `moose dev`
 

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -19,7 +19,7 @@ This is a Python-based Moose template that provides a foundation for building da
 ### Installation
 
 1. Install Moose CLI: `pip install moose-cli`
-2. Create project: `moose init <project-name> python`
+2. Create project: `moose init --name <project-name> --template python`
 3. Install dependencies: `cd <project-name> && pip install -r requirements.txt`
 4. Run Moose: `moose dev`
 

--- a/templates/typescript-agent/README.md
+++ b/templates/typescript-agent/README.md
@@ -230,7 +230,7 @@ Then initialize the template in a temp directory:
 MOOSE_CLI="${MOOSE_CLI:-$(pwd)/target/debug/moose-cli}"
 TMP_DIR="$(mktemp -d /tmp/typescript-agent-XXXXXX)"
 cd "$TMP_DIR"
-"$MOOSE_CLI" init my-agent typescript-agent
+"$MOOSE_CLI" init --name my-agent --template typescript-agent
 cd my-agent
 pnpm install
 ```

--- a/templates/typescript-mcp/README.md
+++ b/templates/typescript-mcp/README.md
@@ -35,7 +35,7 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,514
 Initiate your project:
 
 ```bash
-moose init <project-name> typescript-mcp
+moose init --name <project-name> --template typescript-mcp
 cd <project-name>
 ```
 


### PR DESCRIPTION
## Summary
Improves `moose init` so agents and scripts can use `--name` and `--template` (including `--template=value`) without Clap rejecting the flag form. Legacy positionals remain supported but are hidden from primary help; docs and examples use the flag syntax. Unknown-template errors now point to `moose template list` and `moose template list --json`.

## Linear
- [514-1408 — Improve moose init axp for template failures](https://linear.app/514/issue/514-1408/improve-moose-init-axp-for-template-failures)

## Testing
- `cargo test -p moose-cli --test cli_init`
- `cargo clippy -p moose-cli --all-targets -- -D warnings`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `moose init` argument parsing/validation (clap groups, conflicts, required args), which could break existing scripts or edge-case invocations despite keeping legacy positionals.
> 
> **Overview**
> Updates `moose init` to be **flag-first**, adding `--name` and `--template` (including `--template=...`) as the preferred interface while keeping the legacy positional name/template inputs as *hidden, backward-compatible* arguments.
> 
> Improves `init --help` to promote flag-based examples and adds new CLI tests covering flag usage, conflict cases (positional+flag), and unknown-template recovery messaging.
> 
> Enhances unknown-template errors to point users/agents to `moose template list` and `moose template list --json`, and updates E2E setup code, docs, and template READMEs to use the new flag-based `init` syntax throughout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4ef557a7e7cb260f3600a990d00e38aa32d55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->